### PR TITLE
Fix g2 scraper

### DIFF
--- a/g2-scraper/g2.py
+++ b/g2-scraper/g2.py
@@ -133,7 +133,7 @@ def parse_review_page(response: ScrapeApiResponse):
     """parse reviews data from G2 company pages"""
     selector = response.selector
 
-    # Corrected selector for total reviews
+    # selector for total reviews
     total_reviews_text = selector.xpath("//h3[contains(text(), 'DigitalOcean Reviews')]/text()").get()
     if total_reviews_text:
         total_reviews = int(total_reviews_text.split()[0])
@@ -145,7 +145,7 @@ def parse_review_page(response: ScrapeApiResponse):
         total_pages = 0
 
     data = []
-    # Corrected main review container selector from 'div' to 'article'
+    # main review container selector from 'div' to 'article'
     for review in selector.xpath("//article[.//div[@itemprop='reviewBody']]"):
         author_name = review.xpath(".//div[@itemprop='author']/meta[@itemprop='name']/@content").get()
         author_profile = review.xpath(".//div[contains(@class, 'avatar')]/parent::a/@href").get()
@@ -157,17 +157,17 @@ def parse_review_page(response: ScrapeApiResponse):
         author_position = author_details[0] if author_details and len(author_details) > 0 else None
         author_company_size = next((detail for detail in author_details if "emp." in detail), None)
 
-        # Corrected selector for review tags
+        # selector for review tags
         review_tags = review.xpath(
             ".//div[contains(@class, 'gap-3') and contains(@class, 'flex-wrap')]//label/text()"
         ).getall()
 
         review_date = review.xpath(".//meta[@itemprop='datePublished']/@content").get()
-        # Corrected selector for review rate using the reliable itemprop meta tag
+        # selector for review rate using the reliable itemprop meta tag
         review_rate = review.xpath(".//span[@itemprop='reviewRating']/meta[@itemprop='ratingValue']/@content").get()
         review_title = review.xpath(".//div[@itemprop='name']//text()").get()
 
-        # Corrected selectors for review likes and dislikes
+        # selectors for review likes and dislikes
         review_likes_parts = review.xpath(
             ".//section[div[contains(text(), 'What do you like best')]]/p//text()"
         ).getall()

--- a/g2-scraper/g2.py
+++ b/g2-scraper/g2.py
@@ -4,11 +4,14 @@ This is an example web scraper for g2.com.
 To run this scraper set env variable $SCRAPFLY_KEY with your scrapfly API key:
 $ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
 """
+
 import os
+import re
 import math
 from scrapfly import ScrapeConfig, ScrapflyClient, ScrapeApiResponse
 from typing import Dict, List, Literal
 from loguru import logger as log
+from urllib.parse import urljoin
 
 SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
 
@@ -21,41 +24,59 @@ BASE_CONFIG = {
 
 
 def parse_search_page(response: ScrapeApiResponse):
-    """parse company data from search pages"""
+    """Parse company data from search pages with updated selectors."""
     try:
         selector = response.selector
-    except:
-        pass
+    except Exception as e:
+        print(f"Failed to create selector: {e}")
+        return {"search_data": [], "total_pages": 0}
+
     data = []
-    total_results = selector.xpath("//div[@class='ml-half']/text()").get()
-    total_results = int(total_results[1:-1]) if total_results else None
-    _search_page_size = 20 # each search page contains 20 listings
-    total_pages = math.ceil(total_results / _search_page_size)
 
-    for result in selector.xpath("//div[contains(@class, 'paper mb-1')]"):
-        name = result.xpath(".//div[contains(@class, 'product-name')]/a/div/text()").get()
-        link = result.xpath(".//div[contains(@class, 'product-name')]/a/@href").get()
-        image = result.xpath(".//a[contains(@class, 'listing__img')]/img/@data-deferred-image-src").get()
-        rate = result.xpath(".//a[contains(@title, 'Reviews')]/div/span[2]/span[1]/text()").get()
-        reviews_number = result.xpath(".//a[contains(@title, 'Reviews')]/div/span[1]/text()").get()
-        description = result.xpath(".//span[contains(@class, 'paragraph')]/text()").get()
-        categories = []
-        for category in result.xpath(".//div[span[contains(text(),'Categories')]]/a/text()"):
-            categories.append(category.get())
-        data.append({
-            "name": name,
-            "link": link,
-            "image": image,
-            "rate": float(rate) if rate else None,
-            "reviewsNumber": int(reviews_number.replace("(", "").replace(")", "")) if reviews_number else None,
-            "description": description,
-            "categories": categories
-        })
+    # Extract total results count
+    total_results_text = selector.xpath("//div[contains(text(), 'Products')]/following-sibling::div/text()").get()
+    total_results = int(re.search(r"\((\d+)\)", total_results_text).group(1)) if total_results_text else 0
 
-    return {
-        "search_data": data,
-        "total_pages": total_pages
-    }
+    _search_page_size = 20
+    total_pages = math.ceil(total_results / _search_page_size) if total_results else 0
+
+    # Main selector for each product card
+    for result in selector.xpath("//section[.//a[contains(@href, '/products/')]]"):
+        name = result.xpath(".//div[contains(@class, 'elv-text-lg')]/text()").get()
+
+        # CORRECTED LINE: Use urljoin() from urllib.parse
+        relative_link = result.xpath(".//div[contains(@class, 'elv-text-lg')]/parent::a/@href").get()
+        link = urljoin(response.request.url, relative_link)
+
+        image = result.xpath(".//img[@itemprop='image']/@data-deferred-image-src").get()
+
+        raw_rate = result.xpath(".//label[contains(text(), '/5')]/text()").get()
+        rate = float(raw_rate.split("/")[0]) if raw_rate else None
+
+        raw_reviews = result.xpath(".//a[contains(@href, '#reviews')]//label[not(contains(text(), '/5'))]/text()").get()
+        reviews_number = int(raw_reviews.strip("()")) if raw_reviews else None
+
+        description_parts = result.xpath(".//div[div[contains(text(), 'Product Description')]]/p//text()").getall()
+        description = "".join(description_parts).strip() if description_parts else None
+
+        categories = result.xpath(".//aside//div[contains(@class, 'elv-whitespace-nowrap')]/text()").getall()
+
+        if not name:
+            continue
+
+        data.append(
+            {
+                "name": name.strip() if name else None,
+                "link": link,
+                "image": image,
+                "rate": rate,
+                "reviewsNumber": reviews_number,
+                "description": description if description else None,
+                "categories": [cat.strip() for cat in categories],
+            }
+        )
+
+    return {"search_data": data, "total_pages": total_pages}
 
 
 async def scrape_search(url: str, max_scrape_pages: int = None) -> List[Dict]:
@@ -65,7 +86,7 @@ async def scrape_search(url: str, max_scrape_pages: int = None) -> List[Dict]:
     data = parse_search_page(first_page)
     search_data = data["search_data"]
     total_pages = data["total_pages"]
-    
+
     # get the total number of pages to scrape
     if max_scrape_pages and max_scrape_pages < total_pages:
         total_pages = max_scrape_pages
@@ -78,72 +99,108 @@ async def scrape_search(url: str, max_scrape_pages: int = None) -> List[Dict]:
         try:
             data = parse_search_page(response)
             search_data.extend(data["search_data"])
-            # remove the successful requests from the URLs list            
+            # remove the successful requests from the URLs list
             remaining_urls.remove(response.context["url"])
         except Exception as e:  # catch any exception
             log.error(f"Error encountered: {e}")
             continue
 
-    # try again with the blocked requests if any using headless browsers and residential proxies   
+    # try again with the blocked requests if any using headless browsers and residential proxies
     if len(remaining_urls) != 0:
-        log.debug(f"{len(remaining_urls)} requests are blocked, trying again with render_js enabled and residential proxies")        
+        log.debug(
+            f"{len(remaining_urls)} requests are blocked, trying again with render_js enabled and residential proxies"
+        )
         try:
-            failed_requests = [ScrapeConfig(url, **BASE_CONFIG, render_js=True, proxy_pool="public_residential_pool") for url in remaining_urls]
+            failed_requests = [
+                ScrapeConfig(
+                    url,
+                    **BASE_CONFIG,
+                    render_js=True,
+                    proxy_pool="public_residential_pool",
+                )
+                for url in remaining_urls
+            ]
             async for response in SCRAPFLY.concurrent_scrape(failed_requests):
                 data = parse_search_page(response)
                 search_data.extend(data["search_data"])
         except Exception as e:  # catching any exception
-                log.error(f"Error encountered: {e}")
-                pass
+            log.error(f"Error encountered: {e}")
+            pass
     log.success(f"scraped {len(search_data)} company listings from G2 search pages with the URL {url}")
     return search_data
 
 
 def parse_review_page(response: ScrapeApiResponse):
     """parse reviews data from G2 company pages"""
-    try:
-        selector = response.selector
-    except:
-        pass
-    total_reviews = selector.xpath("//li/a[contains(text(),'reviews')]/text()").get()
-    total_reviews = int(total_reviews.split()[0]) if total_reviews else None
-    _review_page_size = 25 # each review page contains 25 reviews
-    total_pages = math.ceil(total_reviews / _review_page_size)    
+    selector = response.selector
+
+    # Corrected selector for total reviews
+    total_reviews_text = selector.xpath("//h3[contains(text(), 'DigitalOcean Reviews')]/text()").get()
+    if total_reviews_text:
+        total_reviews = int(total_reviews_text.split()[0])
+        # Updated: The page now shows 10 reviews, not 25
+        _review_page_size = 10
+        total_pages = math.ceil(total_reviews / _review_page_size)
+    else:
+        total_reviews = None
+        total_pages = 0
 
     data = []
-    for review in selector.xpath("//div[@itemprop='review']"):
-        author = review.xpath(".//span[@itemprop='author']/meta/@content").get()
-        author_profile = review.xpath(".//span[@itemprop='author']/meta[2]/@content").get()
-        author_position = review.xpath(".//div[@class='mt-4th']/text()").get()
-        author_company_size = review.xpath(".//div[span[contains(text(),'Business')]]/span/text()").getall()
-        review_tags = []
-        review_tags.extend(review.xpath(".//div[contains(@class, 'tags')]/div/div/text()").getall())
-        review_tags.extend(review.xpath(".//div[contains(@class, 'tags')]/div/text()").getall())
+    # Corrected main review container selector from 'div' to 'article'
+    for review in selector.xpath("//article[.//div[@itemprop='reviewBody']]"):
+        author_name = review.xpath(".//div[@itemprop='author']/meta[@itemprop='name']/@content").get()
+        author_profile = review.xpath(".//div[contains(@class, 'avatar')]/parent::a/@href").get()
+
+        # Author details have a new, less structured format
+        author_details = review.xpath(
+            ".//div[div[@itemprop='author']]//div[contains(@class, 'elv-text-subtle')]/text()"
+        ).getall()
+        author_position = author_details[0] if author_details and len(author_details) > 0 else None
+        author_company_size = next((detail for detail in author_details if "emp." in detail), None)
+
+        # Corrected selector for review tags
+        review_tags = review.xpath(
+            ".//div[contains(@class, 'gap-3') and contains(@class, 'flex-wrap')]//label/text()"
+        ).getall()
+
         review_date = review.xpath(".//meta[@itemprop='datePublished']/@content").get()
-        review_rate = review.xpath(".//div[contains(@class, 'stars')]").get()
-        review_title = review.xpath(".//div[@itemprop='name']/text()").get()
-        review_likes = "".join(review.xpath(".//div[@itemprop='reviewBody']/div/div/p/text()").getall())
-        review_dislikes = "".join(review.xpath(".//div[@itemprop='reviewBody']/div[2]/div/p/text()").getall())
-        data.append({
-            "author": {
-                "authorName": author,
-                "authorProfile": author_profile,
-                "authorPosition": author_position,
-                "authorCompanySize": author_company_size,
-            },
-            "review": {
-                "reviewTags": review_tags,
-                "reviewData": review_date,
-                "reviewRate": float(review_rate.split("stars-")[-1].split('">')[0]) / 2 if review_rate else None,
-                "reviewTitle": review_title.replace('"', '') if review_title else None,
-                "reviewLikes": review_likes,
-                "reviewDilikes": review_dislikes,
-            }})
-        
-    return {
-        "total_pages": total_pages,
-        "reviews_data": data
-    }
+        # Corrected selector for review rate using the reliable itemprop meta tag
+        review_rate = review.xpath(".//span[@itemprop='reviewRating']/meta[@itemprop='ratingValue']/@content").get()
+        review_title = review.xpath(".//div[@itemprop='name']//text()").get()
+
+        # Corrected selectors for review likes and dislikes
+        review_likes_parts = review.xpath(
+            ".//section[div[contains(text(), 'What do you like best')]]/p//text()"
+        ).getall()
+        review_likes = "".join(review_likes_parts).replace("Review collected by and hosted on G2.com.", "").strip()
+
+        review_dislikes_parts = review.xpath(
+            ".//section[div[contains(text(), 'What do you dislike')]]/p//text()"
+        ).getall()
+        review_dislikes = (
+            "".join(review_dislikes_parts).replace("Review collected by and hosted on G2.com.", "").strip()
+        )
+
+        data.append(
+            {
+                "author": {
+                    "authorName": author_name.strip() if author_name else None,
+                    "authorProfile": author_profile,
+                    "authorPosition": (author_position.strip() if author_position else None),
+                    "authorCompanySize": (author_company_size.strip() if author_company_size else None),
+                },
+                "review": {
+                    "reviewTags": [tag.strip() for tag in review_tags if tag.strip()],
+                    "reviewData": review_date,
+                    "reviewRate": float(review_rate) if review_rate else None,
+                    "reviewTitle": (review_title.replace('"', "").strip() if review_title else None),
+                    "reviewLikes": review_likes,
+                    "reviewDilikes": review_dislikes,  # Typo from original code, kept for consistency
+                },
+            }
+        )
+
+    return {"total_pages": total_pages, "reviews_data": data}
 
 
 async def scrape_reviews(url: str, max_review_pages: int = None) -> List[Dict]:
@@ -170,17 +227,27 @@ async def scrape_reviews(url: str, max_review_pages: int = None) -> List[Dict]:
         except Exception as e:  # catch any exception
             log.error(f"Error encountered: {e}")
             continue
-   
+
     if len(remaining_urls) != 0:
-        log.debug(f"{len(remaining_urls)} requests are blocked, trying again with render_js enabled and residential proxies")        
+        log.debug(
+            f"{len(remaining_urls)} requests are blocked, trying again with render_js enabled and residential proxies"
+        )
         try:
-            failed_requests = [ScrapeConfig(url, **BASE_CONFIG, render_js=True, proxy_pool="public_residential_pool") for url in remaining_urls]
+            failed_requests = [
+                ScrapeConfig(
+                    url,
+                    **BASE_CONFIG,
+                    render_js=True,
+                    proxy_pool="public_residential_pool",
+                )
+                for url in remaining_urls
+            ]
             async for response in SCRAPFLY.concurrent_scrape(failed_requests):
                 data = parse_search_page(response)
                 reviews_data.extend(data["reviews_data"])
         except Exception as e:  # catch any exception
-                log.error(f"Error encountered: {e}")
-                pass
+            log.error(f"Error encountered: {e}")
+            pass
     log.success(f"scraped {len(reviews_data)} company reviews from G2 review pages with the URL {url}")
     return reviews_data
 
@@ -194,28 +261,31 @@ def parse_alternatives(response: ScrapeApiResponse):
     data = []
     for alt in selector.xpath("//div[contains(@class, 'product-listing--competitor')]"):
         sponsored = alt.xpath(".//strong[text()='Sponsored']").get()
-        if sponsored: # ignore sponsored cards
+        if sponsored:  # ignore sponsored cards
             continue
         name = alt.xpath(".//div[@itemprop='name']/text()").get()
         link = alt.xpath(".//h3/a[contains(@class, 'link')]/@href").get()
         ranking = alt.xpath(".//div[@class='product-listing__number']/text()").get()
-        number_of_reviews = alt.xpath(".//div[div[contains(@class,'stars')]]/span/text()").get() # clean this
+        number_of_reviews = alt.xpath(".//div[div[contains(@class,'stars')]]/span/text()").get()  # clean this
         rate = alt.xpath(".//div[div[contains(@class,'stars')]]/span/span/text()").get()
         description = alt.xpath(".//div[@data-max-height-expand-type]/p/text()").get()
-        data.append({
-            "name": name,
-            "link": link,
-            "ranking": ranking,
-            "numberOfReviews": int(number_of_reviews[1:-1].replace(",", "")) if number_of_reviews else None,
-            "rate": float(rate.strip()) if rate else None,
-            "description": description
-        })
+        data.append(
+            {
+                "name": name,
+                "link": link,
+                "ranking": ranking,
+                "numberOfReviews": (int(number_of_reviews[1:-1].replace(",", "")) if number_of_reviews else None),
+                "rate": float(rate.strip()) if rate else None,
+                "description": description,
+            }
+        )
     return data
 
 
 async def scrape_alternatives(
-        product: str, alternatives: Literal["small-business", "mid-market", "enterprise"] = ""
-    ) -> Dict:
+    product: str,
+    alternatives: Literal["small-business", "mid-market", "enterprise"] = "",
+) -> Dict:
     """scrape product alternatives from G2 alternative pages"""
     # the default alternative is top 10, which takes to argument
     url = f"https://www.g2.com/products/{product}/competitors/alternatives/{alternatives}"
@@ -224,12 +294,19 @@ async def scrape_alternatives(
         response = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
         data = parse_alternatives(response)
     except Exception as e:  # Catching any exception
-            log.error(f"Error encountered: {e}, trying")
-            pass
+        log.error(f"Error encountered: {e}, trying")
+        pass
     if not data:
         log.debug("request is blocked, trying again with render_js enabled and residential proxies")
         try:
-            response = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG, render_js=True, proxy_pool="public_residential_pool"))
+            response = await SCRAPFLY.async_scrape(
+                ScrapeConfig(
+                    url,
+                    **BASE_CONFIG,
+                    render_js=True,
+                    proxy_pool="public_residential_pool",
+                )
+            )
             data = parse_alternatives(response)
         except:
             return

--- a/g2-scraper/g2.py
+++ b/g2-scraper/g2.py
@@ -195,7 +195,7 @@ def parse_review_page(response: ScrapeApiResponse):
                     "reviewRate": float(review_rate) if review_rate else None,
                     "reviewTitle": (review_title.replace('"', "").strip() if review_title else None),
                     "reviewLikes": review_likes,
-                    "reviewDilikes": review_dislikes,  # Typo from original code, kept for consistency
+                    "reviewDislikes": review_dislikes,
                 },
             }
         )

--- a/g2-scraper/g2.py
+++ b/g2-scraper/g2.py
@@ -44,7 +44,6 @@ def parse_search_page(response: ScrapeApiResponse):
     for result in selector.xpath("//section[.//a[contains(@href, '/products/')]]"):
         name = result.xpath(".//div[contains(@class, 'elv-text-lg')]/text()").get()
 
-        # CORRECTED LINE: Use urljoin() from urllib.parse
         relative_link = result.xpath(".//div[contains(@class, 'elv-text-lg')]/parent::a/@href").get()
         link = urljoin(response.request.url, relative_link)
 

--- a/g2-scraper/results/alternatives.json
+++ b/g2-scraper/results/alternatives.json
@@ -1,82 +1,82 @@
 [
-  {
-    "name": "Akamai Cloud",
-    "link": "https://www.g2.com/products/akamai-cloud/reviews",
-    "ranking": "#1",
-    "numberOfReviews": 317,
-    "rate": 4.5,
-    "description": null
-  },
-  {
-    "name": "Vultr",
-    "link": "https://www.g2.com/products/vultr/reviews",
-    "ranking": "#2",
-    "numberOfReviews": 276,
-    "rate": 4.3,
-    "description": null
-  },
-  {
-    "name": "Hostwinds",
-    "link": "https://www.g2.com/products/hostwinds/reviews",
-    "ranking": "#3",
-    "numberOfReviews": 438,
-    "rate": 4.9,
-    "description": null
-  },
-  {
-    "name": "Amazon Lightsail",
-    "link": "https://www.g2.com/products/amazon-lightsail/reviews",
-    "ranking": "#4",
-    "numberOfReviews": 58,
-    "rate": 4.4,
-    "description": null
-  },
-  {
-    "name": "Amazon EC2",
-    "link": "https://www.g2.com/products/amazon-ec2/reviews",
-    "ranking": "#5",
-    "numberOfReviews": 1325,
-    "rate": 4.6,
-    "description": null
-  },
-  {
-    "name": "AWS Lambda",
-    "link": "https://www.g2.com/products/aws-lambda/reviews",
-    "ranking": "#6",
-    "numberOfReviews": 1116,
-    "rate": 4.6,
-    "description": null
-  },
-  {
-    "name": "Amazon Relational Database Service (RDS)",
-    "link": "https://www.g2.com/products/amazon-relational-database-service-rds/reviews",
-    "ranking": "#7",
-    "numberOfReviews": 1052,
-    "rate": 4.5,
-    "description": null
-  },
-  {
-    "name": "Google Compute Engine",
-    "link": "https://www.g2.com/products/google-compute-engine/reviews",
-    "ranking": "#8",
-    "numberOfReviews": 940,
-    "rate": 4.5,
-    "description": null
-  },
-  {
-    "name": "Hostinger",
-    "link": "https://www.g2.com/products/hostinger/reviews",
-    "ranking": "#9",
-    "numberOfReviews": 727,
-    "rate": 4.4,
-    "description": null
-  },
-  {
-    "name": "Azure Virtual Machines",
-    "link": "https://www.g2.com/products/azure-virtual-machines/reviews",
-    "ranking": "#10",
-    "numberOfReviews": 471,
-    "rate": 4.4,
-    "description": null
-  }
+    {
+        "name": "DigitalOcean",
+        "link": "https://www.g2.com/products/digitalocean/reviews",
+        "ranking": "#1",
+        "numberOfReviews": 669,
+        "rate": 4.6,
+        "description": "DigitalOcean provides the best tools to control your virtual server in the cloud. Learn how we deliver the most intuitive interface and features so you can start building your web infrastructure today."
+    },
+    {
+        "name": "Hostwinds",
+        "link": "https://www.g2.com/products/hostwinds/reviews",
+        "ranking": "#2",
+        "numberOfReviews": 438,
+        "rate": 4.9,
+        "description": "Hostwinds offers website hosting for individuals and businesses of all sizes, with 24/7/365 support and nightly backups."
+    },
+    {
+        "name": "Amazon Lightsail",
+        "link": "https://www.g2.com/products/amazon-lightsail/reviews",
+        "ranking": "#3",
+        "numberOfReviews": 58,
+        "rate": 4.4,
+        "description": "Amazon Lightsail offers simple virtual private servers on AWS."
+    },
+    {
+        "name": "Amazon EC2",
+        "link": "https://www.g2.com/products/amazon-ec2/reviews",
+        "ranking": "#4",
+        "numberOfReviews": 1325,
+        "rate": 4.6,
+        "description": "AWS Elastic Compute Cloud (EC2) is a web service that provides resizable compute capacity in the cloud, making web-scale computing easier for developers."
+    },
+    {
+        "name": "Amazon Simple Storage Service (S3)",
+        "link": "https://www.g2.com/products/amazon-simple-storage-service-s3/reviews",
+        "ranking": "#5",
+        "numberOfReviews": 1221,
+        "rate": 4.6,
+        "description": "Amazon Simple Storage Service (S3) is storage for the Internet. A simple web services interface used to store and retrieve any amount of data, at any time, from anywhere on the web."
+    },
+    {
+        "name": "AWS Lambda",
+        "link": "https://www.g2.com/products/aws-lambda/reviews",
+        "ranking": "#6",
+        "numberOfReviews": 1116,
+        "rate": 4.6,
+        "description": "Run code without thinking about servers. Pay for only the compute time you consume."
+    },
+    {
+        "name": "Google Compute Engine",
+        "link": "https://www.g2.com/products/google-compute-engine/reviews",
+        "ranking": "#7",
+        "numberOfReviews": 940,
+        "rate": 4.5,
+        "description": "Compute Engine enables you to create and run large-scale workloads on virtual machines hosted on Google Cloud. Get running quickly with pre-built and ready-to-go configurations or create machines of your own with the optimal amount of vCPU and memory required for your workload."
+    },
+    {
+        "name": "Cloudflare Application Security and Performance",
+        "link": "https://www.g2.com/products/cloudflare-application-security-and-performance/reviews",
+        "ranking": "#8",
+        "numberOfReviews": 554,
+        "rate": 4.5,
+        "description": "Cloudflare Application Security and Performance solutions provide performance, reliability, and security for all of your web applications and APIs, wherever they are hosted and wherever your users are."
+    },
+    {
+        "name": "Cloudways",
+        "link": "https://www.g2.com/products/cloudways/reviews",
+        "ranking": "#9",
+        "numberOfReviews": 1045,
+        "rate": 4.7,
+        "description": "Cloudways provides its customers the convenience of developing, monitoring and managing spectacular web apps without fussing with the cloud infrastructure."
+    },
+    {
+        "name": "Vultr",
+        "link": "https://www.g2.com/products/vultr/reviews",
+        "ranking": "#10",
+        "numberOfReviews": 276,
+        "rate": 4.3,
+        "description": "Vultr offers a standardized highly reliable high performance cloud compute environment with 14 datacenters around the globe."
+    }
 ]

--- a/g2-scraper/results/alternatives.json
+++ b/g2-scraper/results/alternatives.json
@@ -1,82 +1,82 @@
 [
   {
-    "name": "Hostwinds",
-    "link": "https://www.g2.com/products/hostwinds/reviews",
+    "name": "Akamai Cloud",
+    "link": "https://www.g2.com/products/akamai-cloud/reviews",
     "ranking": "#1",
-    "numberOfReviews": 438,
-    "rate": 4.9,
-    "description": "Hostwinds offers website hosting for individuals and businesses of all sizes, with 24/7/365 support and nightly backups."
+    "numberOfReviews": 317,
+    "rate": 4.5,
+    "description": null
   },
   {
     "name": "Vultr",
     "link": "https://www.g2.com/products/vultr/reviews",
     "ranking": "#2",
-    "numberOfReviews": 154,
-    "rate": 4.2,
-    "description": "Vultr offers a standardized highly reliable high performance cloud compute environment with 14 datacenters around the globe."
+    "numberOfReviews": 276,
+    "rate": 4.3,
+    "description": null
   },
   {
-    "name": "Amazon EC2",
-    "link": "https://www.g2.com/products/amazon-ec2/reviews",
+    "name": "Hostwinds",
+    "link": "https://www.g2.com/products/hostwinds/reviews",
     "ranking": "#3",
-    "numberOfReviews": 1200,
-    "rate": 4.6,
-    "description": "AWS Elastic Compute Cloud (EC2) is a web service that provides resizable compute capacity in the cloud, making web-scale computing easier for developers."
-  },
-  {
-    "name": "AWS Lambda",
-    "link": "https://www.g2.com/products/aws-lambda/reviews",
-    "ranking": "#4",
-    "numberOfReviews": 1009,
-    "rate": 4.6,
-    "description": "Run code without thinking about servers. Pay for only the compute time you consume."
-  },
-  {
-    "name": "Amazon Relational Database Service (RDS)",
-    "link": "https://www.g2.com/products/amazon-relational-database-service-rds/reviews",
-    "ranking": "#5",
-    "numberOfReviews": 763,
-    "rate": 4.5,
-    "description": "Amazon Relational Database Service (RDS) is a web service that makes it easy to set up, operate, and scale a relational DB in the cloud: Amazon Aurora, PostgreSQL, MySQL, MariaDB, Oracle, and Microsoft SQL Server."
-  },
-  {
-    "name": "Google Compute Engine",
-    "link": "https://www.g2.com/products/google-compute-engine/reviews",
-    "ranking": "#6",
-    "numberOfReviews": 542,
-    "rate": 4.5,
-    "description": "Compute Engine enables you to create and run large-scale workloads on virtual machines hosted on Google Cloud. Get running quickly with pre-built and ready-to-go configurations or create machines of your own with the optimal amount of vCPU and memory required for your workload."
-  },
-  {
-    "name": "Hostinger",
-    "link": "https://www.g2.com/products/hostinger/reviews",
-    "ranking": "#7",
-    "numberOfReviews": 527,
-    "rate": 4.4,
-    "description": "Hostinger provides every customer with all the necessary tools to have a fully-functional website up and running as quickly as possible. Hostinger  provides an incredibly convenient drag & drop website builder and application installer."
-  },
-  {
-    "name": "Azure Virtual Machines",
-    "link": "https://www.g2.com/products/azure-virtual-machines/reviews",
-    "ranking": "#8",
-    "numberOfReviews": 402,
-    "rate": 4.4,
-    "description": "Azure Virtual Machines gives you the flexibility of virtualization for a wide range of computing solutions: development and testing, running applications, and extending your datacenter with support for Linux, Windows Server, SQL Server, Oracle, IBM, and SAP."
+    "numberOfReviews": 438,
+    "rate": 4.9,
+    "description": null
   },
   {
     "name": "Amazon Lightsail",
     "link": "https://www.g2.com/products/amazon-lightsail/reviews",
-    "ranking": "#9",
-    "numberOfReviews": 50,
-    "rate": 4.3,
-    "description": "Amazon Lightsail offers simple virtual private servers on AWS."
+    "ranking": "#4",
+    "numberOfReviews": 58,
+    "rate": 4.4,
+    "description": null
   },
   {
-    "name": "Amazon DynamoDB",
-    "link": "https://www.g2.com/products/amazon-web-services-aws-amazon-dynamodb/reviews",
-    "ranking": "#10",
-    "numberOfReviews": 596,
+    "name": "Amazon EC2",
+    "link": "https://www.g2.com/products/amazon-ec2/reviews",
+    "ranking": "#5",
+    "numberOfReviews": 1325,
+    "rate": 4.6,
+    "description": null
+  },
+  {
+    "name": "AWS Lambda",
+    "link": "https://www.g2.com/products/aws-lambda/reviews",
+    "ranking": "#6",
+    "numberOfReviews": 1116,
+    "rate": 4.6,
+    "description": null
+  },
+  {
+    "name": "Amazon Relational Database Service (RDS)",
+    "link": "https://www.g2.com/products/amazon-relational-database-service-rds/reviews",
+    "ranking": "#7",
+    "numberOfReviews": 1052,
+    "rate": 4.5,
+    "description": null
+  },
+  {
+    "name": "Google Compute Engine",
+    "link": "https://www.g2.com/products/google-compute-engine/reviews",
+    "ranking": "#8",
+    "numberOfReviews": 940,
+    "rate": 4.5,
+    "description": null
+  },
+  {
+    "name": "Hostinger",
+    "link": "https://www.g2.com/products/hostinger/reviews",
+    "ranking": "#9",
+    "numberOfReviews": 727,
     "rate": 4.4,
-    "description": "Nonrelational database for applications that need performance at any scale"
+    "description": null
+  },
+  {
+    "name": "Azure Virtual Machines",
+    "link": "https://www.g2.com/products/azure-virtual-machines/reviews",
+    "ranking": "#10",
+    "numberOfReviews": 471,
+    "rate": 4.4,
+    "description": null
   }
 ]

--- a/g2-scraper/results/reviews.json
+++ b/g2-scraper/results/reviews.json
@@ -1,630 +1,630 @@
 [
-    {
-        "author": {
-            "authorName": "Rajnish K.",
-            "authorProfile": "https://www.g2.com/users/e400b2ec-3deb-4edd-b849-e236301a13ce",
-            "authorPosition": "Salesforce Trainee Consultant",
-            "authorCompanySize": "Mid-Market (51-1000 emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: G2 invite"
-            ],
-            "reviewData": "2025-08-08",
-            "reviewRate": 4.5,
-            "reviewTitle": "Cloud Made Simple and Affordable, Just How I Like It",
-            "reviewLikes": "I really like how straightforward DigitalOcean is. Setting up a Droplet (their virtual server) takes just a few clicks, and the interface is clean enough that I never feel lost. The pricing is transparent-no hidden costs-and starts low enough to fit small projects or startups. Another plus is their huge library of community tutorials and guides, which makes solving issues a lot easier.",
-            "reviewDislikes": "Sometimes the support response time can be slow, especially during busy periods. I’ve also learned to keep extra backups, as I once had a managed database update cause some data loss. And while it’s perfect for simple to medium-scale projects, it lacks some of the advanced features you’d get from bigger cloud providers."
-        }
+  {
+    "author": {
+      "authorName": "Rajnish K.",
+      "authorProfile": "https://www.g2.com/users/e400b2ec-3deb-4edd-b849-e236301a13ce",
+      "authorPosition": "Salesforce Trainee Consultant",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
     },
-    {
-        "author": {
-            "authorName": "Alejandro L.",
-            "authorProfile": "https://www.g2.com/users/honess",
-            "authorPosition": "CEO",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Source: Organic"
-            ],
-            "reviewData": "2025-07-23",
-            "reviewRate": 4.5,
-            "reviewTitle": "La mejor plataforma de IaaS que he probado... ¡Minimalismo absoluto!",
-            "reviewLikes": "DigitalOcean es simplemente excepcional por su enfoque minimalista que no sacrifica funcionalidad. Lo que más me gusta:\n\nSimplicidad sin compromisos: La interfaz es increíblemente limpia e intuitiva. En minutos puedes tener un droplet funcionando, sin configuraciones complejas innecesarias.\n\nPrecio transparente: No hay sorpresas en la facturación. Sabes exactamente lo que pagas por lo que usas, sin costos ocultos ni estructuras de precios confusas como otros proveedores.\n\nDocumentación excepcional: Sus tutoriales y guías son claros, directos y realmente útiles. La comunidad y el contenido educativo son de primera calidad.\n\nRendimiento consistente: Los droplets tienen un rendimiento predecible y confiable. Las SSD y la red funcionan exactamente como esperas.\n\nDeveloper-friendly: Perfecto para desarrolladores que quieren enfocarse en construir, no en luchar con la infraestructura. Las APIs son simples y bien documentadas.",
-            "reviewDislikes": "Menos servicios enterprise: Comparado con AWS o Azure, tiene menos servicios especializados. Pero honestamente, esto también es parte de su encanto minimalista.\n\nSoporte limitado en planes básicos: El soporte técnico premium requiere planes más costosos, aunque la documentación compensa mucho esto."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Verified User in Marketing and Advertising",
-            "authorProfile": null,
-            "authorPosition": "Small-Business (50 or fewer emp.)",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Rating Updated (8/7/2025)",
-                "Current User",
-                "Validated Reviewer",
-                "Source: Organic"
-            ],
-            "reviewData": "2025-07-31",
-            "reviewRate": 5.0,
-            "reviewTitle": "Simple, Reliable, and Developer-Friendly Cloud Hosting",
-            "reviewLikes": "DigitalOcean stands out for its simplicity, reliability, and developer-friendly environment. The UI is clean and intuitive, making it easy to deploy and manage droplets even for those who aren’t full-time sysadmins.\n\nTheir documentation is top-tier—comprehensive, well-organized, and beginner-friendly, which really speeds up troubleshooting and learning. Pricing is transparent and affordable, especially for small businesses and startups looking to scale gradually. \n\nI also appreciate their growing ecosystem of products like Spaces, Managed Databases, and Kubernetes support.",
-            "reviewDislikes": "There’s not much to dislike, but if I had to point something out, it would be that some advanced features and monitoring tools are more limited compared to larger cloud providers like AWS or GCP. While that keeps things simpler, power users might miss certain enterprise-grade options or integrations. That said, for the vast majority of use cases, DigitalOcean more than delivers."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Verified User in Information Technology and Services",
-            "authorProfile": null,
-            "authorPosition": "Small-Business (50 or fewer emp.)",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: G2 invite"
-            ],
-            "reviewData": "2025-07-31",
-            "reviewRate": 4.0,
-            "reviewTitle": "Simple, Affordable, and Reliable Cloud Hosting",
-            "reviewLikes": "What I like best about DigitalOcean is its intuitive and clean interface, which makes managing servers and deployments incredibly straightforward - even for users who aren’t cloud experts. The pricing is also very transparent and affordable, allowing me to scale projects without worrying about unexpected costs. On top of that, the platform’s performance is consistently reliable, with fast server response times and minimal downtime, which is essential for my work.",
-            "reviewDislikes": "While I’m generally very satisfied with DigitalOcean, if I had to mention a downside, it would be that some advanced features and integrations found in larger cloud providers are missing or require more manual setup. Additionally, more detailed documentation or tutorials for certain use cases would be helpful for users looking to expand their projects."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Azeem C.",
-            "authorProfile": "https://www.g2.com/users/207c0228-9ccb-4a33-a321-1825ea6ea0aa",
-            "authorPosition": "Senior Software Engineer",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-05-07",
-            "reviewRate": 4.5,
-            "reviewTitle": "Very good selection of services. 99.99% Uptime.",
-            "reviewLikes": "DigitalOcean has very good selection of services. You can create VPS server of all sizes and quantities. For instance, you can create a vps host (with 1cpu and 10gb hard disk) for as little as $4 per month. It can go all the way up to $1630/mo with 60 CPUs. \n\nYou can create GPU droplets as well.\n\nOther think is about almost 100% uptime. Initially there some speed issues over the past. It could kick in once or twice in a month. But I think DigitalOcean has worked on this. I created an uptime monitoring service  (which also is from DigitalOcean). It says, last outage was around 175 days ago. That is very nice.\n\nIt's website is neatly structured. Great ease of use.\n\nCustomer support is also very good. Very responsive. I am using the free plan. In this plan, they reply you within 24 hours. Every time I opened  a ticket, they would promptly answer it.",
-            "reviewDislikes": "I dislike a couple of things about DigitalOcean. Centos 10 was released on December 12, 2024. But it is not available yet in DigitalOcean as of today (7th May). Other providers like Vultr has it already. The selection of linux distributions is also limited. Compared to Vultr, DigitalOcean does not have that much choice of linux distributions."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Ujjwal A.",
-            "authorProfile": "https://www.g2.com/users/301601e8-18fc-4b96-9343-0f274646d0da",
-            "authorPosition": "Devops Engineer",
-            "authorCompanySize": "Mid-Market (51-1000 emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: G2 invite"
-            ],
-            "reviewData": "2025-08-07",
-            "reviewRate": 5.0,
-            "reviewTitle": "Best and Developer Friendly Cloud Platform",
-            "reviewLikes": "1 - Very Easy to setup and manage droplets that is we can spin up servers or apps in just few minutes.\n2 - Simple and Clean UI\n3 - Transparent pricing we always know what we are spending\n4 - Great documentation and community support",
-            "reviewDislikes": "1 - It has limited advanced services when comapred to aws.\n2 - Load balancer and monitoring features are basic."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Lajith K.",
-            "authorProfile": "https://www.g2.com/users/811058dd-d83a-4d36-8e1e-f5da661c499d",
-            "authorPosition": "Software Engineer",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 5.0,
-            "reviewTitle": "Fast & secure & most reliable",
-            "reviewLikes": "Clean UI & UX: The control panel is intuitive and uncluttered, making it easy to spin up and manage virtual machines, databases, and other services even for beginners.\n\nTransparent pricing: Their pricing model is straightforward and predictable—especially attractive for startups and developers who need to keep tight control over costs.\n\nDeveloper community & documentation: DigitalOcean has built a strong library of tutorials and guides, which are often more accessible and practical than what you find from bigger cloud providers.\n\nDroplets (VMs): Launching a Droplet is fast, and performance tends to be solid for most general-purpose applications.\n\nManaged services: They’ve expanded into managed databases, Kubernetes, app platform (PaaS), etc., offering more flexibility while maintaining simplicity.",
-            "reviewDislikes": "Additional payment methods should be introduced to support currencies other than the US Dollar, such as Indian Rupees for customers in India."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Jeff L.",
-            "authorProfile": "https://www.g2.com/users/430b4bb4-4514-4d75-b9a9-d71643a1a26a",
-            "authorPosition": "Founder",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 4.0,
-            "reviewTitle": "Two Years with DigitalOcean: A Simple and Smooth Experience for My Projects",
-            "reviewLikes": "I've been using DigitalOcean for two years to support my own project. What stands out the most is how easy it is to use. The platform is beginner-friendly, the UI is clean, and setting up servers or other resources is straightforward without needing to dig through complex configurations. This simplicity helped me focus more on building my project rather than managing infrastructure.",
-            "reviewDislikes": "One downside I've noticed is the lack of a free tier for cloud databases. For beginners or small projects, having a zero-cost starting point would make it easier to experiment and grow without upfront costs. Compared to other providers that offer limited free database options, this can make DigitalOcean feel less accessible for early-stage users."
-        }
-    },
-    {
-        "author": {
-            "authorName": "David P.",
-            "authorProfile": "https://www.g2.com/users/27dfd888-c410-43b1-84ec-33bba5a98e37",
-            "authorPosition": "Owner",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 5.0,
-            "reviewTitle": "Very flexible, powerful API and website, decent prices!",
-            "reviewLikes": "As an occasional web developer and someone who wants to move forward with creating a bunch of powerful APPs in the future... Digital Ocean allows me to expand as my needs fit.  I also love the fact I can choose to run my websites/APP's on AMD processors.\n\nIf you need more space... drag the slider.  If you want another droplet, add one.  If you want a load balancer, add one.  It's very flexible and even as an intermediate web developer their systems are quite well done.\n\nPrices seem fair and we use the Toronto location for hosting.  We are now hosting 12 domains on a single simple low cost server.  We will be expanding and coding for years to come and at least we know that if we need more... Digital Ocean can handle it.",
-            "reviewDislikes": "Using G2 to submit a review.  After finishing the entire review, it FAILED to submit for no reason whatsoever...   I wasted 25 min of my time.\n\nI had very detailed answers in every category to be very thorough...  the question remains... should I redo everything and waste another 25 min only to have it fail again?   And now, most likely won't be chosen for the $25 gift card all because your site wouldn't submit my review and I don't feel like giving super detailed answers having to do this twice.  \n\nUgh...\n\n--------\nI am just going to summarize my answers since I already gave detailed ones...   please fix your website.\n--------\nMy answer for what I dislike about DO?\n\nSo far nothing.  It's been fine, but as I had posted on before, if I had to find a fault with DO...  (ugh)... I can't even remember what I wrote now.  How frustrating this has become.   I'm on a deadline, thought this wouldn't take that long... and now that I have to redo it... I'm all frustrated... can't think..."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Luca P.",
-            "authorProfile": "https://www.g2.com/users/lucapiccinotti",
-            "authorPosition": "✅ CTO - Growth Marketer full stack #MarTech | ⚡️ SaaS Advisor",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "G2 Icon",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: G2 Gives Campaign"
-            ],
-            "reviewData": "2025-07-04",
-            "reviewRate": 5.0,
-            "reviewTitle": "Reliable cloud infrastructure for developers and SMBs",
-            "reviewLikes": "DigitalOcean delivers a robust suite of cloud infrastructure products tailored for developers, startups, and SMBs.\n\nThe platform stands out for its intuitive user interface and predictable pricing model, which simplifies resource management and cost forecasting. Key features include Droplets (scalable Linux-based virtual machines), a fully managed Kubernetes service with a free control plane, and an App Platform for rapid deployment of web applications and APIs using PaaS principles. \n\nIt supports managed databases (PostgreSQL, MySQL, MongoDB, Kafka), object storage (Spaces), and block storage. Recent additions like GPU compute options (via the Paperspace acquisition) and GenAI Platform for building and deploying AI agents expand its capabilities for machine learning and generative AI workloads.\n\nThe API ecosystem is comprehensive, enabling automation and integration across a range of programming languages. One-click app deployment (e.g., WordPress, Docker) and clear documentation further streamline the developer experience.",
-            "reviewDislikes": "While the overall experience is streamlined, I find that advanced configuration options can be limited in some managed services, particularly within the App Platform. Customizing deployment environments sometimes requires restarting instances from scratch, which may result in lost changes if not managed carefully. Additionally, migration to other public clouds is not always straightforward, and the process can be confusing or restrictive in certain scenarios."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Deepjyoti R.",
-            "authorProfile": "https://www.g2.com/users/950f009b-cfc1-409f-87d2-27f93975ffda",
-            "authorPosition": "Cyber Security Analyst",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Rating Updated (8/3/2025)",
-                "Validated Reviewer",
-                "Source: Organic"
-            ],
-            "reviewData": "2025-08-01",
-            "reviewRate": 5.0,
-            "reviewTitle": "Best cloud provider for beginners",
-            "reviewLikes": "Digital Ocean is easy to use, with a clean interface and simple pricing. Setting up servers takes minutes. A strong community make it friendly, reliable, and great for beginners.",
-            "reviewDislikes": "Sudden account lockouts, limited OS choices and unexpected data deletion."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Vee D.",
-            "authorProfile": "https://www.g2.com/users/6bc9b282-76bf-47bf-959d-8ef874dce3cd",
-            "authorPosition": "Founder",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-29",
-            "reviewRate": 4.5,
-            "reviewTitle": "Long time customer, still going strong",
-            "reviewLikes": "Love the fact that they are one of the most transparent providers. I've been with them since 2016, regularly. Contemplated moving to AWS but I cannot deal with the complexity for now.\n\nSome products can make it expensive but the ease of use and implementation makes me want to stay.\n\nMoreover, their blog is always updated - which requires less support and customer service emails!",
-            "reviewDislikes": "Wish their functions section was a little bit easier to debug. Had to go back to my own personal VPS functions because DO Functions wasn't easy to debug."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Verified User in Consulting",
-            "authorProfile": null,
-            "authorPosition": "Small-Business (50 or fewer emp.)",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-02-12",
-            "reviewRate": 5.0,
-            "reviewTitle": "Very easy-to-use interface and instant response droplets",
-            "reviewLikes": "I like how easy it is to create and destroy droplets. I also like how reponsive the servers are – every change or request is instant.  This makes it effortless to implement complex applications including complex web apps. The uptime is just so good. \n\nI feel the best part is the pricing. I run a small business and DigitalOcean's packages are quite affordable.\n\nCustomer support is always available and responds within a reasonable time.",
-            "reviewDislikes": "Every experience I've had with DigitalOcen has been wonderful. I can't think of anything I dislike."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Verified User in Internet",
-            "authorProfile": null,
-            "authorPosition": "Small-Business (50 or fewer emp.)",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-29",
-            "reviewRate": 4.0,
-            "reviewTitle": "Stable and easy to use cloud solution",
-            "reviewLikes": "Ease of use, basically instant set up of new droplets or other products, straightforward approach on accessing your resources. Essentially it's set and forget, which is the best.",
-            "reviewDislikes": "Pricing, lack of granularity on upgrading/changing configuration of products. There is a lot of options for droplets, but as a one-man hobbyist I just need a small enough server with non-standard RAM size, and I am locked on a config that's not ideal for me. Same for the database, it is a pain to set up some advanced use cases, or it's impossible at all (like implementing a specified PostgreSQL extension)."
-        }
-    },
-    {
-        "author": {
-            "authorName": "J. Antonio A.",
-            "authorProfile": "https://www.g2.com/users/d87dba53-7035-4e91-b4df-7d7a0c4300bc",
-            "authorPosition": "Product Manager",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-02-12",
-            "reviewRate": 4.5,
-            "reviewTitle": "Awesome service, performance and cost somehow very technical but totally worthy",
-            "reviewLikes": "I like everything is super clear about the costs and features you'll get. There's also a lot of tutorials in blogs in youtube so it was then easy to use, implement and then integrate with my stuff. Getting some coupons for start was the key to me to migrate my services here, it felt like no risk and their Customer Support help me with a couple of questions. Security and Stability were another factors to consider, because of the nature of my frequent use of the service.",
-            "reviewDislikes": "Even DigitalOcen offers different easy-to-config options, it can be perceived as a hard choice for tech people with few time or the regular people who just want to set a website or service."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Gerardo  B.",
-            "authorProfile": "https://www.g2.com/users/e544c460-bc69-46ab-969c-13674bfc673f",
-            "authorPosition": "Co-founder. COO y Administración de los servidores",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2024-11-04",
-            "reviewRate": 5.0,
-            "reviewTitle": "Simplicidad de un producto que funciona",
-            "reviewLikes": "Primero es que cumple con su funcionalidad con una baja o casi nula curva de aprendizaje en desplegar nuevas implementaciones. Nos abastece de sus servicios en los cuales confiamos y ponemos nuestro trabajo día a día, minuto a minuto desde desde después de la pandemia. Gracias a Digital Ocean nosotros estamos online con nuestra propuesta y llegamos a nuestros usuarios de todo Latam y parte de Europa. Realmente nos sentimos muy cómodos aquí y no nos interesa cambiarnos de proveedor en el mediano plazo (tampoco en el largo plazo). \nAntes de ser clientes de Digital Ocean, ya consultábamos toda la buena documentación de la comunidad, eso es algo que nos fue y es de mucha ayuda, principalmente en los momentos de inicio de los desarrollos y al adoptar nuevas tecnologías. \nEl soporte de cliente, lo hemos utilizado muy pocas veces, casi nunca, y siempre hemos tenido la mejor atención solucionando y aclarando los distintos inconvenientes.",
-            "reviewDislikes": "Puntualmente utilizamos droplets y nuestro desarrollo es bastante puntual, así que sentimos que hoy y en el mediano plazo cumple con nuestras espectativas. Me gustaría que tenga más servicios como lo tiene AWS, pero hoy en día no los estaríamos aprovechando. En el día de mañana tal vez necesitemos algunas herramientas para escalar o aumentar la productividad pero la tecnología hoy en día avanza muy rápido y es posible que también estemos cubiertos con las nuevas features."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Jonathan P.",
-            "authorProfile": "https://www.g2.com/users/13b4b965-4e8d-4454-8555-65a95bf6b6aa",
-            "authorPosition": "Company Director, CTO",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Rating Updated (5/5/2025)",
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2024-11-04",
-            "reviewRate": 4.5,
-            "reviewTitle": "Feels like you are really working with other developers",
-            "reviewLikes": "The number one reason I like DigitalOcean is that you feel like you are working with other developers. Yes they have commercial marketing, but it's quite, not 'in your face' like other providers.\nJust as much a number one reason is cost, where else can you get a cloud presence for $6/month that is professionally maintained, easy to use and in my case, after almost 7 years, never let me down.",
-            "reviewDislikes": "Honestly, it's difficult to think of anything negative. Yes I've had the odd issue, but between their excellent documentation and their customer tech support it's never been an issue to the extent that I've experienced with other providers.\nThere's a few extra's that I would like to see like domain registration, all in all a good place to be for a developer"
-        }
-    },
-    {
-        "author": {
-            "authorName": "P B.",
-            "authorProfile": "https://www.g2.com/users/0fa0065a-847f-4353-b5b6-bf3a5d282d26",
-            "authorPosition": "CTO",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-02-19",
-            "reviewRate": 5.0,
-            "reviewTitle": "What AWS should have been",
-            "reviewLikes": "Digital Ocean (DO) is amazing for one fact - its super simple to use.  AWS, while powerful, gives me a headache trying to figure out what things mean or how to use them.  DO has been amazing in that regard - its easy to spin up servers or new services, and hardly requires any babysitting. It runs 90% of our company, and has for years.",
-            "reviewDislikes": "There isn't much to complain about here.  I guess a few of the services could be a bit cheaper."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Linus .",
-            "authorProfile": "https://www.g2.com/users/ea72d925-c14e-426d-b473-09da23b6d215",
-            "authorPosition": "Game Designer / Game Lead Director",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2024-11-04",
-            "reviewRate": 5.0,
-            "reviewTitle": "Excellent serivce for a fair affordable price",
-            "reviewLikes": "We use Digital Ocean to host Perforce Helix Core version control for unreal engine 5. DigitalOcean provides a very affordable service for our small team with good plans to choose from. \nWe use it for our whole development of games, therefor it's great to choose only what we really need and have the option to easily expand our plan when needed.\nThe implementation was easy and we had no struggles.",
-            "reviewDislikes": "Sadly (as far as we know) you can only see how much space you are already using in percentage and not written like: 20GB/25GB. That would be a great addition if you can't keep track how much space you provide to a droplet."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Dillon D.",
-            "authorProfile": "https://www.g2.com/users/ff9feaaa-ce36-4dd2-aa55-311ab73e119b",
-            "authorPosition": "Owner",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 5.0,
-            "reviewTitle": "Easy, fast, and flexible",
-            "reviewLikes": "Web UI is very intuitive and easy to use. Resources are readily available and performance meets expectations.",
-            "reviewDislikes": "Not the cheapest option for large servers but still good value."
-        }
-    },
-    {
-        "author": {
-            "authorName": "HEJOIR S.",
-            "authorProfile": "https://www.g2.com/users/2ee44b4f-9d5a-4e4c-ab94-ffecc4649bb0",
-            "authorPosition": "developer",
-            "authorCompanySize": "Mid-Market (51-1000 emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-29",
-            "reviewRate": 5.0,
-            "reviewTitle": "Great for small businesses with tech skills",
-            "reviewLikes": "DigitalOcean is a flexible and scalable platform that works perfectly for small and medium-sized businesses. It offers an intuitive interface, fast server deployment, and affordable pricing, which makes it ideal for startups or growing companies. The technical documentation is extensive and very helpful for developers.",
-            "reviewDislikes": "The main downside is the lack of customer support in Spanish. This can be a challenge for non-English-speaking users, especially during critical issues. It would be great to see more localized support for Latin America and Spanish-speaking users."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Kenneth K.",
-            "authorProfile": "https://www.g2.com/users/2e79f60c-175c-4bec-9c7f-3a90ed0e27e2",
-            "authorPosition": "CEO",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-02-18",
-            "reviewRate": 5.0,
-            "reviewTitle": "Best affordable Cloud Provider",
-            "reviewLikes": "I'm working on a startup together with a friend. We haven't gone live yet, but I feel compelled to give an honest review of DigitalOcean after having used their droplets for almost 4 months now.\n\nWell, just like most startups, we have a tight budget yet need massive resources to run a video sharing MERN app.\nWe first tried AWS, but that was way out of out budget. After a lot of research, we came across DigitalOcean, tried their droplets for three months using their free trial and haven't looked back.\n\nWhat I love most is how easy it is to manage our kubernetes cluster without worrying about how much we'll pay at the end of the month. All we  needed to do is select how many droplets we needed based on number of vCPUs, RAM, and disk storage, and we're guaranteed to pay only for those droplets . The only other cost is space storage, persistent storage, and load balancer, all of which are also so easy to estimate and cheap.\n\nTheir customer service is also really good, and they'll respond even during weekends. But you have to be very clear on what you need help on so they can assist you with the fewest number of messages since they do not respond immediately. But they also offer premium customer service options if you need immediate responses. \n\nAnother option is BobCares, which they do promote on their site also. It's a third-party customer service for kubernetes which I've used before and didn't like it at all. First, they're pretty expensive - about $99 per hour - and you're not guaranteed they'll solve your issue. Second, you have to give them access to your kubernetes cluster, which could be a potential source of a security breach for your cluster. \n\nFor someone who didn't know how to spin up a kubernetes cluster from scratch for a MERN app, I'd say choosing DigitalOcean was my best decision ever. I have control over everything and have an amazing group of specialists waiting to help any time I get stuck.\n\nTheir online publications are also super helpful and very well documented. I can't talk much about their DigitalOcean managed kubernetes (DOKS), but if you're looking to spin up a kubernetes cluster from scratch inside droplets, you'll need their CSI driver, which is just as easy as copying and pasting it from their Github.",
-            "reviewDislikes": "The only negative experience I've had is in setting up firewall for my droplets using their firewall dashboard. I noticed that anytime I could add firewall rules, my site got really slow. I'm not sure why and didn't bother asking them so I can't blame it all on them. I went for the alternative of setting up firewall using iptables, which works fine now. I honestly can't think of any other negative experience.\n\nSince I'm using Droplets rather than their managed kubernetes service (DOKS), most of the issues I come across are things I can solve since I have control over the entire kubernetes set up. That's why it's kind of difficult to address any negatives; I can't fault them."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Vasilis",
-            "authorProfile": "https://www.g2.com/users/94d371fd-a84c-48af-b1ef-8ba0d8c6f0a1",
-            "authorPosition": "Chief Technical Officer",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 4.5,
-            "reviewTitle": "Great and simple to use cloud provider",
-            "reviewLikes": "It strikes the best balance of provided services and low complexity for SMBs. We don't have dedicated SREs, we don't wanna spend countless hours setting up IAMs, dozens of configs just to do the simplest of things, or trying to figure out what services is the best.\n\nIf you're looking for simple to use and straightfoward servers, DBs, containers, DNS management, S3 buckets, etc, the Digital Ocean is a great solution.",
-            "reviewDislikes": "We would like juuuust a tad more permission management, specifically giving people permissions on a project-based level, so that we can isolate between prod and dev.\n\nBut as I already mentioned, we appreciate the simplicity and straight forwardness of DO, so I'd rather use what they have right now."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Vince  C.",
-            "authorProfile": "https://www.g2.com/users/1cf14acd-7f7f-44cf-b46e-50327694d690",
-            "authorPosition": "Owner",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-29",
-            "reviewRate": 4.5,
-            "reviewTitle": "Solid reliable cloud services with great value",
-            "reviewLikes": "I've been with DigitalOcean for almost 10 years and extremely happy with their services, which don't overwhelm you with options and are a great value. Customer support when needed is excellent and they have lots of self-help support in the form of how-to documents and examples.",
-            "reviewDislikes": "So far I have no complaints, they meet my needs perfectly. If I was with a larger Enterprise or government Institution they might be a harder sell as they don't have the same credibility as a Microsoft or Amazon, but for what most people need digital ocean is great."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Filipe V.",
-            "authorProfile": "https://www.g2.com/users/e68afb74-b175-4380-9ca9-f17a64ad82b3",
-            "authorPosition": "Full Stack Engineer",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 5.0,
-            "reviewTitle": "Fantastic and stable product",
-            "reviewLikes": "I really like they are predictable regarding the pricing and offers stable products that have zero downtime. I am a client over more than 10 years and only had positive interactions with their support team and product. Zero headaches and awesome performance.",
-            "reviewDislikes": "In the past they only offered droplets which was kinda limiting, but now they offer a wide array of services so I don't think there's anything that I dislike about it."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Stephen Douglas S.",
-            "authorProfile": "https://www.g2.com/users/bluewizard",
-            "authorPosition": "Founder",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Rating Updated (2/11/2025)",
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2024-05-09",
-            "reviewRate": 4.5,
-            "reviewTitle": "High value for the price, and their customer service is good.  They added PaperSpace (GPUs for AI)",
-            "reviewLikes": "The value for the price, and their customer service.  The control panel / UI is easy to navigate.  I have Digital Ocea to manage some Docker packages, including my web hosting service.  I more recently started to explore the deployment of some AI platforms, but I'd rather purchase my hardware to develop in-house, and then deploy to the Cloud when it is production ready.",
-            "reviewDislikes": "Their offerings don't compare to something like AWS, but for small and medium-sized businesses they have a nice platform that keeps improving."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Verified User in Facilities Services",
-            "authorProfile": null,
-            "authorPosition": "Small-Business (50 or fewer emp.)",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Rating Updated (5/25/2025)",
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite",
-                "AI Translated"
-            ],
-            "reviewData": "2025-04-29",
-            "reviewRate": 3.5,
-            "reviewTitle": "My point of view on Digital Ocean as a product",
-            "reviewLikes": "What I like best about Digital Ocean is that the process and UI are easy to understand for new users. They are giving simple options to make the changes and make them effective.",
-            "reviewDislikes": "Several times we have faced the problem with deployment regarding cache issues in the newly deployed build. It gets deployed, but new changes are not reflecting. In that case, we have to go and restart the app with a clear build cache. It's a headache."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Ryan  D.",
-            "authorProfile": "https://www.g2.com/users/bdec8dd0-ad23-4a6e-b165-aec65a81e9a5",
-            "authorPosition": "Sole Trader",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-04-28",
-            "reviewRate": 5.0,
-            "reviewTitle": "Cheap, easy to use",
-            "reviewLikes": "It just works, setup was easy and I've had no issues with the platform since then. Recovery tools just work when you need them and adding additional volumes is just a few clicks with really clear pricing.",
-            "reviewDislikes": "Have not had any downsides yet beyond but being cheapest in the market but that's balanced out by the updates. I don't have experience with their support services or other products so have limited knowledge of their downsides"
-        }
-    },
-    {
-        "author": {
-            "authorName": "Yahya L.",
-            "authorProfile": "https://www.g2.com/users/bad78889-6929-458b-8873-fe7d9670648c",
-            "authorPosition": "Owner of the Company",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Incentivized",
-                "Source: Seller invite"
-            ],
-            "reviewData": "2025-02-14",
-            "reviewRate": 4.5,
-            "reviewTitle": "when i started using DO i never changed them",
-            "reviewLikes": "DO is fast, clean, was first in kind once they started, cheap, they have great doccumentation, they have toturials, easy to use, fast and serious customer support and great products.",
-            "reviewDislikes": "i had never got problems with them except this last two months my droplet that runs my website stops working as expected and just hand and services get down, thats maybe because they have added many many other services and products and updates, and my droplet is up from 2014/2015 maybe."
-        }
-    },
-    {
-        "author": {
-            "authorName": "Filip S.",
-            "authorProfile": "https://www.g2.com/users/475d1c0c-c5e9-4053-93e7-931b6e80816a",
-            "authorPosition": "student, and attempting to became java developer",
-            "authorCompanySize": "Small-Business (50 or fewer emp.)"
-        },
-        "review": {
-            "reviewTags": [
-                "Current User",
-                "Validated Reviewer",
-                "Source: Organic"
-            ],
-            "reviewData": "2025-02-12",
-            "reviewRate": 4.5,
-            "reviewTitle": "Over 4 months of using services of Digital Ocean.",
-            "reviewLikes": "Support was very quick and informative, providing helpful assistance.\n\nFrom the perspective of ease of use, this is the first service of this type that I’m using, so it’s hard to judge as I have no comparison. However, the overall process wasn’t difficult, and I managed to achieve what I was looking for.",
-            "reviewDislikes": "If I had to point out something, it would be the price—and one situation I resolved with support, where I believe the price differed from what I signed up for. However, since I had the option to downgrade my plan, I'm still satisfied."
-        }
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 invite"
+      ],
+      "reviewData": "2025-08-08",
+      "reviewRate": 4.5,
+      "reviewTitle": "Cloud Made Simple and Affordable, Just How I Like It",
+      "reviewLikes": "I really like how straightforward DigitalOcean is. Setting up a Droplet (their virtual server) takes just a few clicks, and the interface is clean enough that I never feel lost. The pricing is transparent-no hidden costs-and starts low enough to fit small projects or startups. Another plus is their huge library of community tutorials and guides, which makes solving issues a lot easier.",
+      "reviewDislikes": "Sometimes the support response time can be slow, especially during busy periods. I’ve also learned to keep extra backups, as I once had a managed database update cause some data loss. And while it’s perfect for simple to medium-scale projects, it lacks some of the advanced features you’d get from bigger cloud providers."
     }
+  },
+  {
+    "author": {
+      "authorName": "Alejandro L.",
+      "authorProfile": "https://www.g2.com/users/honess",
+      "authorPosition": "CEO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-07-23",
+      "reviewRate": 4.5,
+      "reviewTitle": "La mejor plataforma de IaaS que he probado... ¡Minimalismo absoluto!",
+      "reviewLikes": "DigitalOcean es simplemente excepcional por su enfoque minimalista que no sacrifica funcionalidad. Lo que más me gusta:\n\nSimplicidad sin compromisos: La interfaz es increíblemente limpia e intuitiva. En minutos puedes tener un droplet funcionando, sin configuraciones complejas innecesarias.\n\nPrecio transparente: No hay sorpresas en la facturación. Sabes exactamente lo que pagas por lo que usas, sin costos ocultos ni estructuras de precios confusas como otros proveedores.\n\nDocumentación excepcional: Sus tutoriales y guías son claros, directos y realmente útiles. La comunidad y el contenido educativo son de primera calidad.\n\nRendimiento consistente: Los droplets tienen un rendimiento predecible y confiable. Las SSD y la red funcionan exactamente como esperas.\n\nDeveloper-friendly: Perfecto para desarrolladores que quieren enfocarse en construir, no en luchar con la infraestructura. Las APIs son simples y bien documentadas.",
+      "reviewDislikes": "Menos servicios enterprise: Comparado con AWS o Azure, tiene menos servicios especializados. Pero honestamente, esto también es parte de su encanto minimalista.\n\nSoporte limitado en planes básicos: El soporte técnico premium requiere planes más costosos, aunque la documentación compensa mucho esto."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Marketing and Advertising",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (8/7/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-07-31",
+      "reviewRate": 5.0,
+      "reviewTitle": "Simple, Reliable, and Developer-Friendly Cloud Hosting",
+      "reviewLikes": "DigitalOcean stands out for its simplicity, reliability, and developer-friendly environment. The UI is clean and intuitive, making it easy to deploy and manage droplets even for those who aren’t full-time sysadmins.\n\nTheir documentation is top-tier—comprehensive, well-organized, and beginner-friendly, which really speeds up troubleshooting and learning. Pricing is transparent and affordable, especially for small businesses and startups looking to scale gradually. \n\nI also appreciate their growing ecosystem of products like Spaces, Managed Databases, and Kubernetes support.",
+      "reviewDislikes": "There’s not much to dislike, but if I had to point something out, it would be that some advanced features and monitoring tools are more limited compared to larger cloud providers like AWS or GCP. While that keeps things simpler, power users might miss certain enterprise-grade options or integrations. That said, for the vast majority of use cases, DigitalOcean more than delivers."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Information Technology and Services",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 invite"
+      ],
+      "reviewData": "2025-07-31",
+      "reviewRate": 4.0,
+      "reviewTitle": "Simple, Affordable, and Reliable Cloud Hosting",
+      "reviewLikes": "What I like best about DigitalOcean is its intuitive and clean interface, which makes managing servers and deployments incredibly straightforward - even for users who aren’t cloud experts. The pricing is also very transparent and affordable, allowing me to scale projects without worrying about unexpected costs. On top of that, the platform’s performance is consistently reliable, with fast server response times and minimal downtime, which is essential for my work.",
+      "reviewDislikes": "While I’m generally very satisfied with DigitalOcean, if I had to mention a downside, it would be that some advanced features and integrations found in larger cloud providers are missing or require more manual setup. Additionally, more detailed documentation or tutorials for certain use cases would be helpful for users looking to expand their projects."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Azeem C.",
+      "authorProfile": "https://www.g2.com/users/207c0228-9ccb-4a33-a321-1825ea6ea0aa",
+      "authorPosition": "Senior Software Engineer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-05-07",
+      "reviewRate": 4.5,
+      "reviewTitle": "Very good selection of services. 99.99% Uptime.",
+      "reviewLikes": "DigitalOcean has very good selection of services. You can create VPS server of all sizes and quantities. For instance, you can create a vps host (with 1cpu and 10gb hard disk) for as little as $4 per month. It can go all the way up to $1630/mo with 60 CPUs. \n\nYou can create GPU droplets as well.\n\nOther think is about almost 100% uptime. Initially there some speed issues over the past. It could kick in once or twice in a month. But I think DigitalOcean has worked on this. I created an uptime monitoring service  (which also is from DigitalOcean). It says, last outage was around 175 days ago. That is very nice.\n\nIt's website is neatly structured. Great ease of use.\n\nCustomer support is also very good. Very responsive. I am using the free plan. In this plan, they reply you within 24 hours. Every time I opened  a ticket, they would promptly answer it.",
+      "reviewDislikes": "I dislike a couple of things about DigitalOcean. Centos 10 was released on December 12, 2024. But it is not available yet in DigitalOcean as of today (7th May). Other providers like Vultr has it already. The selection of linux distributions is also limited. Compared to Vultr, DigitalOcean does not have that much choice of linux distributions."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Ujjwal A.",
+      "authorProfile": "https://www.g2.com/users/301601e8-18fc-4b96-9343-0f274646d0da",
+      "authorPosition": "Devops Engineer",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 invite"
+      ],
+      "reviewData": "2025-08-07",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best and Developer Friendly Cloud Platform",
+      "reviewLikes": "1 - Very Easy to setup and manage droplets that is we can spin up servers or apps in just few minutes.\n2 - Simple and Clean UI\n3 - Transparent pricing we always know what we are spending\n4 - Great documentation and community support",
+      "reviewDislikes": "1 - It has limited advanced services when comapred to aws.\n2 - Load balancer and monitoring features are basic."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Lajith K.",
+      "authorProfile": "https://www.g2.com/users/811058dd-d83a-4d36-8e1e-f5da661c499d",
+      "authorPosition": "Software Engineer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Fast & secure & most reliable",
+      "reviewLikes": "Clean UI & UX: The control panel is intuitive and uncluttered, making it easy to spin up and manage virtual machines, databases, and other services even for beginners.\n\nTransparent pricing: Their pricing model is straightforward and predictable—especially attractive for startups and developers who need to keep tight control over costs.\n\nDeveloper community & documentation: DigitalOcean has built a strong library of tutorials and guides, which are often more accessible and practical than what you find from bigger cloud providers.\n\nDroplets (VMs): Launching a Droplet is fast, and performance tends to be solid for most general-purpose applications.\n\nManaged services: They’ve expanded into managed databases, Kubernetes, app platform (PaaS), etc., offering more flexibility while maintaining simplicity.",
+      "reviewDislikes": "Additional payment methods should be introduced to support currencies other than the US Dollar, such as Indian Rupees for customers in India."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Jeff L.",
+      "authorProfile": "https://www.g2.com/users/430b4bb4-4514-4d75-b9a9-d71643a1a26a",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 4.0,
+      "reviewTitle": "Two Years with DigitalOcean: A Simple and Smooth Experience for My Projects",
+      "reviewLikes": "I've been using DigitalOcean for two years to support my own project. What stands out the most is how easy it is to use. The platform is beginner-friendly, the UI is clean, and setting up servers or other resources is straightforward without needing to dig through complex configurations. This simplicity helped me focus more on building my project rather than managing infrastructure.",
+      "reviewDislikes": "One downside I've noticed is the lack of a free tier for cloud databases. For beginners or small projects, having a zero-cost starting point would make it easier to experiment and grow without upfront costs. Compared to other providers that offer limited free database options, this can make DigitalOcean feel less accessible for early-stage users."
+    }
+  },
+  {
+    "author": {
+      "authorName": "David P.",
+      "authorProfile": "https://www.g2.com/users/27dfd888-c410-43b1-84ec-33bba5a98e37",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Very flexible, powerful API and website, decent prices!",
+      "reviewLikes": "As an occasional web developer and someone who wants to move forward with creating a bunch of powerful APPs in the future... Digital Ocean allows me to expand as my needs fit.  I also love the fact I can choose to run my websites/APP's on AMD processors.\n\nIf you need more space... drag the slider.  If you want another droplet, add one.  If you want a load balancer, add one.  It's very flexible and even as an intermediate web developer their systems are quite well done.\n\nPrices seem fair and we use the Toronto location for hosting.  We are now hosting 12 domains on a single simple low cost server.  We will be expanding and coding for years to come and at least we know that if we need more... Digital Ocean can handle it.",
+      "reviewDislikes": "Using G2 to submit a review.  After finishing the entire review, it FAILED to submit for no reason whatsoever...   I wasted 25 min of my time.\n\nI had very detailed answers in every category to be very thorough...  the question remains... should I redo everything and waste another 25 min only to have it fail again?   And now, most likely won't be chosen for the $25 gift card all because your site wouldn't submit my review and I don't feel like giving super detailed answers having to do this twice.  \n\nUgh...\n\n--------\nI am just going to summarize my answers since I already gave detailed ones...   please fix your website.\n--------\nMy answer for what I dislike about DO?\n\nSo far nothing.  It's been fine, but as I had posted on before, if I had to find a fault with DO...  (ugh)... I can't even remember what I wrote now.  How frustrating this has become.   I'm on a deadline, thought this wouldn't take that long... and now that I have to redo it... I'm all frustrated... can't think..."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Luca P.",
+      "authorProfile": "https://www.g2.com/users/lucapiccinotti",
+      "authorPosition": "✅ CTO - Growth Marketer full stack #MarTech | ⚡️ SaaS Advisor",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "G2 Icon",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 Gives Campaign"
+      ],
+      "reviewData": "2025-07-04",
+      "reviewRate": 5.0,
+      "reviewTitle": "Reliable cloud infrastructure for developers and SMBs",
+      "reviewLikes": "DigitalOcean delivers a robust suite of cloud infrastructure products tailored for developers, startups, and SMBs.\n\nThe platform stands out for its intuitive user interface and predictable pricing model, which simplifies resource management and cost forecasting. Key features include Droplets (scalable Linux-based virtual machines), a fully managed Kubernetes service with a free control plane, and an App Platform for rapid deployment of web applications and APIs using PaaS principles. \n\nIt supports managed databases (PostgreSQL, MySQL, MongoDB, Kafka), object storage (Spaces), and block storage. Recent additions like GPU compute options (via the Paperspace acquisition) and GenAI Platform for building and deploying AI agents expand its capabilities for machine learning and generative AI workloads.\n\nThe API ecosystem is comprehensive, enabling automation and integration across a range of programming languages. One-click app deployment (e.g., WordPress, Docker) and clear documentation further streamline the developer experience.",
+      "reviewDislikes": "While the overall experience is streamlined, I find that advanced configuration options can be limited in some managed services, particularly within the App Platform. Customizing deployment environments sometimes requires restarting instances from scratch, which may result in lost changes if not managed carefully. Additionally, migration to other public clouds is not always straightforward, and the process can be confusing or restrictive in certain scenarios."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Deepjyoti R.",
+      "authorProfile": "https://www.g2.com/users/950f009b-cfc1-409f-87d2-27f93975ffda",
+      "authorPosition": "Cyber Security Analyst",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (8/3/2025)",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-08-01",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best cloud provider for beginners",
+      "reviewLikes": "Digital Ocean is easy to use, with a clean interface and simple pricing. Setting up servers takes minutes. A strong community make it friendly, reliable, and great for beginners.",
+      "reviewDislikes": "Sudden account lockouts, limited OS choices and unexpected data deletion."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vee D.",
+      "authorProfile": "https://www.g2.com/users/6bc9b282-76bf-47bf-959d-8ef874dce3cd",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.5,
+      "reviewTitle": "Long time customer, still going strong",
+      "reviewLikes": "Love the fact that they are one of the most transparent providers. I've been with them since 2016, regularly. Contemplated moving to AWS but I cannot deal with the complexity for now.\n\nSome products can make it expensive but the ease of use and implementation makes me want to stay.\n\nMoreover, their blog is always updated - which requires less support and customer service emails!",
+      "reviewDislikes": "Wish their functions section was a little bit easier to debug. Had to go back to my own personal VPS functions because DO Functions wasn't easy to debug."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Consulting",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-12",
+      "reviewRate": 5.0,
+      "reviewTitle": "Very easy-to-use interface and instant response droplets",
+      "reviewLikes": "I like how easy it is to create and destroy droplets. I also like how reponsive the servers are – every change or request is instant.  This makes it effortless to implement complex applications including complex web apps. The uptime is just so good. \n\nI feel the best part is the pricing. I run a small business and DigitalOcean's packages are quite affordable.\n\nCustomer support is always available and responds within a reasonable time.",
+      "reviewDislikes": "Every experience I've had with DigitalOcen has been wonderful. I can't think of anything I dislike."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Internet",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.0,
+      "reviewTitle": "Stable and easy to use cloud solution",
+      "reviewLikes": "Ease of use, basically instant set up of new droplets or other products, straightforward approach on accessing your resources. Essentially it's set and forget, which is the best.",
+      "reviewDislikes": "Pricing, lack of granularity on upgrading/changing configuration of products. There is a lot of options for droplets, but as a one-man hobbyist I just need a small enough server with non-standard RAM size, and I am locked on a config that's not ideal for me. Same for the database, it is a pain to set up some advanced use cases, or it's impossible at all (like implementing a specified PostgreSQL extension)."
+    }
+  },
+  {
+    "author": {
+      "authorName": "J. Antonio A.",
+      "authorProfile": "https://www.g2.com/users/d87dba53-7035-4e91-b4df-7d7a0c4300bc",
+      "authorPosition": "Product Manager",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-12",
+      "reviewRate": 4.5,
+      "reviewTitle": "Awesome service, performance and cost somehow very technical but totally worthy",
+      "reviewLikes": "I like everything is super clear about the costs and features you'll get. There's also a lot of tutorials in blogs in youtube so it was then easy to use, implement and then integrate with my stuff. Getting some coupons for start was the key to me to migrate my services here, it felt like no risk and their Customer Support help me with a couple of questions. Security and Stability were another factors to consider, because of the nature of my frequent use of the service.",
+      "reviewDislikes": "Even DigitalOcen offers different easy-to-config options, it can be perceived as a hard choice for tech people with few time or the regular people who just want to set a website or service."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Gerardo  B.",
+      "authorProfile": "https://www.g2.com/users/e544c460-bc69-46ab-969c-13674bfc673f",
+      "authorPosition": "Co-founder. COO y Administración de los servidores",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
+      "reviewRate": 5.0,
+      "reviewTitle": "Simplicidad de un producto que funciona",
+      "reviewLikes": "Primero es que cumple con su funcionalidad con una baja o casi nula curva de aprendizaje en desplegar nuevas implementaciones. Nos abastece de sus servicios en los cuales confiamos y ponemos nuestro trabajo día a día, minuto a minuto desde desde después de la pandemia. Gracias a Digital Ocean nosotros estamos online con nuestra propuesta y llegamos a nuestros usuarios de todo Latam y parte de Europa. Realmente nos sentimos muy cómodos aquí y no nos interesa cambiarnos de proveedor en el mediano plazo (tampoco en el largo plazo). \nAntes de ser clientes de Digital Ocean, ya consultábamos toda la buena documentación de la comunidad, eso es algo que nos fue y es de mucha ayuda, principalmente en los momentos de inicio de los desarrollos y al adoptar nuevas tecnologías. \nEl soporte de cliente, lo hemos utilizado muy pocas veces, casi nunca, y siempre hemos tenido la mejor atención solucionando y aclarando los distintos inconvenientes.",
+      "reviewDislikes": "Puntualmente utilizamos droplets y nuestro desarrollo es bastante puntual, así que sentimos que hoy y en el mediano plazo cumple con nuestras espectativas. Me gustaría que tenga más servicios como lo tiene AWS, pero hoy en día no los estaríamos aprovechando. En el día de mañana tal vez necesitemos algunas herramientas para escalar o aumentar la productividad pero la tecnología hoy en día avanza muy rápido y es posible que también estemos cubiertos con las nuevas features."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Jonathan P.",
+      "authorProfile": "https://www.g2.com/users/13b4b965-4e8d-4454-8555-65a95bf6b6aa",
+      "authorPosition": "Company Director, CTO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (5/5/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
+      "reviewRate": 4.5,
+      "reviewTitle": "Feels like you are really working with other developers",
+      "reviewLikes": "The number one reason I like DigitalOcean is that you feel like you are working with other developers. Yes they have commercial marketing, but it's quite, not 'in your face' like other providers.\nJust as much a number one reason is cost, where else can you get a cloud presence for $6/month that is professionally maintained, easy to use and in my case, after almost 7 years, never let me down.",
+      "reviewDislikes": "Honestly, it's difficult to think of anything negative. Yes I've had the odd issue, but between their excellent documentation and their customer tech support it's never been an issue to the extent that I've experienced with other providers.\nThere's a few extra's that I would like to see like domain registration, all in all a good place to be for a developer"
+    }
+  },
+  {
+    "author": {
+      "authorName": "P B.",
+      "authorProfile": "https://www.g2.com/users/0fa0065a-847f-4353-b5b6-bf3a5d282d26",
+      "authorPosition": "CTO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-19",
+      "reviewRate": 5.0,
+      "reviewTitle": "What AWS should have been",
+      "reviewLikes": "Digital Ocean (DO) is amazing for one fact - its super simple to use.  AWS, while powerful, gives me a headache trying to figure out what things mean or how to use them.  DO has been amazing in that regard - its easy to spin up servers or new services, and hardly requires any babysitting. It runs 90% of our company, and has for years.",
+      "reviewDislikes": "There isn't much to complain about here.  I guess a few of the services could be a bit cheaper."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Linus .",
+      "authorProfile": "https://www.g2.com/users/ea72d925-c14e-426d-b473-09da23b6d215",
+      "authorPosition": "Game Designer / Game Lead Director",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
+      "reviewRate": 5.0,
+      "reviewTitle": "Excellent serivce for a fair affordable price",
+      "reviewLikes": "We use Digital Ocean to host Perforce Helix Core version control for unreal engine 5. DigitalOcean provides a very affordable service for our small team with good plans to choose from. \nWe use it for our whole development of games, therefor it's great to choose only what we really need and have the option to easily expand our plan when needed.\nThe implementation was easy and we had no struggles.",
+      "reviewDislikes": "Sadly (as far as we know) you can only see how much space you are already using in percentage and not written like: 20GB/25GB. That would be a great addition if you can't keep track how much space you provide to a droplet."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Dillon D.",
+      "authorProfile": "https://www.g2.com/users/ff9feaaa-ce36-4dd2-aa55-311ab73e119b",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Easy, fast, and flexible",
+      "reviewLikes": "Web UI is very intuitive and easy to use. Resources are readily available and performance meets expectations.",
+      "reviewDislikes": "Not the cheapest option for large servers but still good value."
+    }
+  },
+  {
+    "author": {
+      "authorName": "HEJOIR S.",
+      "authorProfile": "https://www.g2.com/users/2ee44b4f-9d5a-4e4c-ab94-ffecc4649bb0",
+      "authorPosition": "developer",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 5.0,
+      "reviewTitle": "Great for small businesses with tech skills",
+      "reviewLikes": "DigitalOcean is a flexible and scalable platform that works perfectly for small and medium-sized businesses. It offers an intuitive interface, fast server deployment, and affordable pricing, which makes it ideal for startups or growing companies. The technical documentation is extensive and very helpful for developers.",
+      "reviewDislikes": "The main downside is the lack of customer support in Spanish. This can be a challenge for non-English-speaking users, especially during critical issues. It would be great to see more localized support for Latin America and Spanish-speaking users."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Kenneth K.",
+      "authorProfile": "https://www.g2.com/users/2e79f60c-175c-4bec-9c7f-3a90ed0e27e2",
+      "authorPosition": "CEO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-18",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best affordable Cloud Provider",
+      "reviewLikes": "I'm working on a startup together with a friend. We haven't gone live yet, but I feel compelled to give an honest review of DigitalOcean after having used their droplets for almost 4 months now.\n\nWell, just like most startups, we have a tight budget yet need massive resources to run a video sharing MERN app.\nWe first tried AWS, but that was way out of out budget. After a lot of research, we came across DigitalOcean, tried their droplets for three months using their free trial and haven't looked back.\n\nWhat I love most is how easy it is to manage our kubernetes cluster without worrying about how much we'll pay at the end of the month. All we  needed to do is select how many droplets we needed based on number of vCPUs, RAM, and disk storage, and we're guaranteed to pay only for those droplets . The only other cost is space storage, persistent storage, and load balancer, all of which are also so easy to estimate and cheap.\n\nTheir customer service is also really good, and they'll respond even during weekends. But you have to be very clear on what you need help on so they can assist you with the fewest number of messages since they do not respond immediately. But they also offer premium customer service options if you need immediate responses. \n\nAnother option is BobCares, which they do promote on their site also. It's a third-party customer service for kubernetes which I've used before and didn't like it at all. First, they're pretty expensive - about $99 per hour - and you're not guaranteed they'll solve your issue. Second, you have to give them access to your kubernetes cluster, which could be a potential source of a security breach for your cluster. \n\nFor someone who didn't know how to spin up a kubernetes cluster from scratch for a MERN app, I'd say choosing DigitalOcean was my best decision ever. I have control over everything and have an amazing group of specialists waiting to help any time I get stuck.\n\nTheir online publications are also super helpful and very well documented. I can't talk much about their DigitalOcean managed kubernetes (DOKS), but if you're looking to spin up a kubernetes cluster from scratch inside droplets, you'll need their CSI driver, which is just as easy as copying and pasting it from their Github.",
+      "reviewDislikes": "The only negative experience I've had is in setting up firewall for my droplets using their firewall dashboard. I noticed that anytime I could add firewall rules, my site got really slow. I'm not sure why and didn't bother asking them so I can't blame it all on them. I went for the alternative of setting up firewall using iptables, which works fine now. I honestly can't think of any other negative experience.\n\nSince I'm using Droplets rather than their managed kubernetes service (DOKS), most of the issues I come across are things I can solve since I have control over the entire kubernetes set up. That's why it's kind of difficult to address any negatives; I can't fault them."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vasilis",
+      "authorProfile": "https://www.g2.com/users/94d371fd-a84c-48af-b1ef-8ba0d8c6f0a1",
+      "authorPosition": "Chief Technical Officer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 4.5,
+      "reviewTitle": "Great and simple to use cloud provider",
+      "reviewLikes": "It strikes the best balance of provided services and low complexity for SMBs. We don't have dedicated SREs, we don't wanna spend countless hours setting up IAMs, dozens of configs just to do the simplest of things, or trying to figure out what services is the best.\n\nIf you're looking for simple to use and straightfoward servers, DBs, containers, DNS management, S3 buckets, etc, the Digital Ocean is a great solution.",
+      "reviewDislikes": "We would like juuuust a tad more permission management, specifically giving people permissions on a project-based level, so that we can isolate between prod and dev.\n\nBut as I already mentioned, we appreciate the simplicity and straight forwardness of DO, so I'd rather use what they have right now."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vince  C.",
+      "authorProfile": "https://www.g2.com/users/1cf14acd-7f7f-44cf-b46e-50327694d690",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.5,
+      "reviewTitle": "Solid reliable cloud services with great value",
+      "reviewLikes": "I've been with DigitalOcean for almost 10 years and extremely happy with their services, which don't overwhelm you with options and are a great value. Customer support when needed is excellent and they have lots of self-help support in the form of how-to documents and examples.",
+      "reviewDislikes": "So far I have no complaints, they meet my needs perfectly. If I was with a larger Enterprise or government Institution they might be a harder sell as they don't have the same credibility as a Microsoft or Amazon, but for what most people need digital ocean is great."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Filipe V.",
+      "authorProfile": "https://www.g2.com/users/e68afb74-b175-4380-9ca9-f17a64ad82b3",
+      "authorPosition": "Full Stack Engineer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Fantastic and stable product",
+      "reviewLikes": "I really like they are predictable regarding the pricing and offers stable products that have zero downtime. I am a client over more than 10 years and only had positive interactions with their support team and product. Zero headaches and awesome performance.",
+      "reviewDislikes": "In the past they only offered droplets which was kinda limiting, but now they offer a wide array of services so I don't think there's anything that I dislike about it."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Stephen Douglas S.",
+      "authorProfile": "https://www.g2.com/users/bluewizard",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (2/11/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-05-09",
+      "reviewRate": 4.5,
+      "reviewTitle": "High value for the price, and their customer service is good.  They added PaperSpace (GPUs for AI)",
+      "reviewLikes": "The value for the price, and their customer service.  The control panel / UI is easy to navigate.  I have Digital Ocea to manage some Docker packages, including my web hosting service.  I more recently started to explore the deployment of some AI platforms, but I'd rather purchase my hardware to develop in-house, and then deploy to the Cloud when it is production ready.",
+      "reviewDislikes": "Their offerings don't compare to something like AWS, but for small and medium-sized businesses they have a nice platform that keeps improving."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Facilities Services",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (5/25/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite",
+        "AI Translated"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 3.5,
+      "reviewTitle": "My point of view on Digital Ocean as a product",
+      "reviewLikes": "What I like best about Digital Ocean is that the process and UI are easy to understand for new users. They are giving simple options to make the changes and make them effective.",
+      "reviewDislikes": "Several times we have faced the problem with deployment regarding cache issues in the newly deployed build. It gets deployed, but new changes are not reflecting. In that case, we have to go and restart the app with a clear build cache. It's a headache."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Ryan  D.",
+      "authorProfile": "https://www.g2.com/users/bdec8dd0-ad23-4a6e-b165-aec65a81e9a5",
+      "authorPosition": "Sole Trader",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Cheap, easy to use",
+      "reviewLikes": "It just works, setup was easy and I've had no issues with the platform since then. Recovery tools just work when you need them and adding additional volumes is just a few clicks with really clear pricing.",
+      "reviewDislikes": "Have not had any downsides yet beyond but being cheapest in the market but that's balanced out by the updates. I don't have experience with their support services or other products so have limited knowledge of their downsides"
+    }
+  },
+  {
+    "author": {
+      "authorName": "Yahya L.",
+      "authorProfile": "https://www.g2.com/users/bad78889-6929-458b-8873-fe7d9670648c",
+      "authorPosition": "Owner of the Company",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-14",
+      "reviewRate": 4.5,
+      "reviewTitle": "when i started using DO i never changed them",
+      "reviewLikes": "DO is fast, clean, was first in kind once they started, cheap, they have great doccumentation, they have toturials, easy to use, fast and serious customer support and great products.",
+      "reviewDislikes": "i had never got problems with them except this last two months my droplet that runs my website stops working as expected and just hand and services get down, thats maybe because they have added many many other services and products and updates, and my droplet is up from 2014/2015 maybe."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Filip S.",
+      "authorProfile": "https://www.g2.com/users/475d1c0c-c5e9-4053-93e7-931b6e80816a",
+      "authorPosition": "student, and attempting to became java developer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-02-12",
+      "reviewRate": 4.5,
+      "reviewTitle": "Over 4 months of using services of Digital Ocean.",
+      "reviewLikes": "Support was very quick and informative, providing helpful assistance.\n\nFrom the perspective of ease of use, this is the first service of this type that I’m using, so it’s hard to judge as I have no comparison. However, the overall process wasn’t difficult, and I managed to achieve what I was looking for.",
+      "reviewDislikes": "If I had to point out something, it would be the price—and one situation I resolved with support, where I believe the price differed from what I signed up for. However, since I had the option to downgrade my plan, I'm still satisfied."
+    }
+  }
 ]

--- a/g2-scraper/results/reviews.json
+++ b/g2-scraper/results/reviews.json
@@ -1,630 +1,630 @@
 [
-  {
-    "author": {
-      "authorName": "Rajnish K.",
-      "authorProfile": "https://www.g2.com/users/e400b2ec-3deb-4edd-b849-e236301a13ce",
-      "authorPosition": "Salesforce Trainee Consultant",
-      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    {
+        "author": {
+            "authorName": "Rajnish K.",
+            "authorProfile": "https://www.g2.com/users/e400b2ec-3deb-4edd-b849-e236301a13ce",
+            "authorPosition": "Salesforce Trainee Consultant",
+            "authorCompanySize": "Mid-Market (51-1000 emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: G2 invite"
+            ],
+            "reviewData": "2025-08-08",
+            "reviewRate": 4.5,
+            "reviewTitle": "Cloud Made Simple and Affordable, Just How I Like It",
+            "reviewLikes": "I really like how straightforward DigitalOcean is. Setting up a Droplet (their virtual server) takes just a few clicks, and the interface is clean enough that I never feel lost. The pricing is transparent-no hidden costs-and starts low enough to fit small projects or startups. Another plus is their huge library of community tutorials and guides, which makes solving issues a lot easier.",
+            "reviewDislikes": "Sometimes the support response time can be slow, especially during busy periods. I’ve also learned to keep extra backups, as I once had a managed database update cause some data loss. And while it’s perfect for simple to medium-scale projects, it lacks some of the advanced features you’d get from bigger cloud providers."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: G2 invite"
-      ],
-      "reviewData": "2025-08-08",
-      "reviewRate": 4.5,
-      "reviewTitle": "Cloud Made Simple and Affordable, Just How I Like It",
-      "reviewLikes": "I really like how straightforward DigitalOcean is. Setting up a Droplet (their virtual server) takes just a few clicks, and the interface is clean enough that I never feel lost. The pricing is transparent-no hidden costs-and starts low enough to fit small projects or startups. Another plus is their huge library of community tutorials and guides, which makes solving issues a lot easier.",
-      "reviewDilikes": "Sometimes the support response time can be slow, especially during busy periods. I’ve also learned to keep extra backups, as I once had a managed database update cause some data loss. And while it’s perfect for simple to medium-scale projects, it lacks some of the advanced features you’d get from bigger cloud providers."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Alejandro L.",
-      "authorProfile": "https://www.g2.com/users/honess",
-      "authorPosition": "CEO",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Alejandro L.",
+            "authorProfile": "https://www.g2.com/users/honess",
+            "authorPosition": "CEO",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Source: Organic"
+            ],
+            "reviewData": "2025-07-23",
+            "reviewRate": 4.5,
+            "reviewTitle": "La mejor plataforma de IaaS que he probado... ¡Minimalismo absoluto!",
+            "reviewLikes": "DigitalOcean es simplemente excepcional por su enfoque minimalista que no sacrifica funcionalidad. Lo que más me gusta:\n\nSimplicidad sin compromisos: La interfaz es increíblemente limpia e intuitiva. En minutos puedes tener un droplet funcionando, sin configuraciones complejas innecesarias.\n\nPrecio transparente: No hay sorpresas en la facturación. Sabes exactamente lo que pagas por lo que usas, sin costos ocultos ni estructuras de precios confusas como otros proveedores.\n\nDocumentación excepcional: Sus tutoriales y guías son claros, directos y realmente útiles. La comunidad y el contenido educativo son de primera calidad.\n\nRendimiento consistente: Los droplets tienen un rendimiento predecible y confiable. Las SSD y la red funcionan exactamente como esperas.\n\nDeveloper-friendly: Perfecto para desarrolladores que quieren enfocarse en construir, no en luchar con la infraestructura. Las APIs son simples y bien documentadas.",
+            "reviewDislikes": "Menos servicios enterprise: Comparado con AWS o Azure, tiene menos servicios especializados. Pero honestamente, esto también es parte de su encanto minimalista.\n\nSoporte limitado en planes básicos: El soporte técnico premium requiere planes más costosos, aunque la documentación compensa mucho esto."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Source: Organic"
-      ],
-      "reviewData": "2025-07-23",
-      "reviewRate": 4.5,
-      "reviewTitle": "La mejor plataforma de IaaS que he probado... ¡Minimalismo absoluto!",
-      "reviewLikes": "DigitalOcean es simplemente excepcional por su enfoque minimalista que no sacrifica funcionalidad. Lo que más me gusta:\n\nSimplicidad sin compromisos: La interfaz es increíblemente limpia e intuitiva. En minutos puedes tener un droplet funcionando, sin configuraciones complejas innecesarias.\n\nPrecio transparente: No hay sorpresas en la facturación. Sabes exactamente lo que pagas por lo que usas, sin costos ocultos ni estructuras de precios confusas como otros proveedores.\n\nDocumentación excepcional: Sus tutoriales y guías son claros, directos y realmente útiles. La comunidad y el contenido educativo son de primera calidad.\n\nRendimiento consistente: Los droplets tienen un rendimiento predecible y confiable. Las SSD y la red funcionan exactamente como esperas.\n\nDeveloper-friendly: Perfecto para desarrolladores que quieren enfocarse en construir, no en luchar con la infraestructura. Las APIs son simples y bien documentadas.",
-      "reviewDilikes": "Menos servicios enterprise: Comparado con AWS o Azure, tiene menos servicios especializados. Pero honestamente, esto también es parte de su encanto minimalista.\n\nSoporte limitado en planes básicos: El soporte técnico premium requiere planes más costosos, aunque la documentación compensa mucho esto."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Verified User in Marketing and Advertising",
-      "authorProfile": null,
-      "authorPosition": "Small-Business (50 or fewer emp.)",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Verified User in Marketing and Advertising",
+            "authorProfile": null,
+            "authorPosition": "Small-Business (50 or fewer emp.)",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Rating Updated (8/7/2025)",
+                "Current User",
+                "Validated Reviewer",
+                "Source: Organic"
+            ],
+            "reviewData": "2025-07-31",
+            "reviewRate": 5.0,
+            "reviewTitle": "Simple, Reliable, and Developer-Friendly Cloud Hosting",
+            "reviewLikes": "DigitalOcean stands out for its simplicity, reliability, and developer-friendly environment. The UI is clean and intuitive, making it easy to deploy and manage droplets even for those who aren’t full-time sysadmins.\n\nTheir documentation is top-tier—comprehensive, well-organized, and beginner-friendly, which really speeds up troubleshooting and learning. Pricing is transparent and affordable, especially for small businesses and startups looking to scale gradually. \n\nI also appreciate their growing ecosystem of products like Spaces, Managed Databases, and Kubernetes support.",
+            "reviewDislikes": "There’s not much to dislike, but if I had to point something out, it would be that some advanced features and monitoring tools are more limited compared to larger cloud providers like AWS or GCP. While that keeps things simpler, power users might miss certain enterprise-grade options or integrations. That said, for the vast majority of use cases, DigitalOcean more than delivers."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Rating Updated (8/7/2025)",
-        "Current User",
-        "Validated Reviewer",
-        "Source: Organic"
-      ],
-      "reviewData": "2025-07-31",
-      "reviewRate": 5.0,
-      "reviewTitle": "Simple, Reliable, and Developer-Friendly Cloud Hosting",
-      "reviewLikes": "DigitalOcean stands out for its simplicity, reliability, and developer-friendly environment. The UI is clean and intuitive, making it easy to deploy and manage droplets even for those who aren’t full-time sysadmins.\n\nTheir documentation is top-tier—comprehensive, well-organized, and beginner-friendly, which really speeds up troubleshooting and learning. Pricing is transparent and affordable, especially for small businesses and startups looking to scale gradually. \n\nI also appreciate their growing ecosystem of products like Spaces, Managed Databases, and Kubernetes support.",
-      "reviewDilikes": "There’s not much to dislike, but if I had to point something out, it would be that some advanced features and monitoring tools are more limited compared to larger cloud providers like AWS or GCP. While that keeps things simpler, power users might miss certain enterprise-grade options or integrations. That said, for the vast majority of use cases, DigitalOcean more than delivers."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Verified User in Information Technology and Services",
-      "authorProfile": null,
-      "authorPosition": "Small-Business (50 or fewer emp.)",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Verified User in Information Technology and Services",
+            "authorProfile": null,
+            "authorPosition": "Small-Business (50 or fewer emp.)",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: G2 invite"
+            ],
+            "reviewData": "2025-07-31",
+            "reviewRate": 4.0,
+            "reviewTitle": "Simple, Affordable, and Reliable Cloud Hosting",
+            "reviewLikes": "What I like best about DigitalOcean is its intuitive and clean interface, which makes managing servers and deployments incredibly straightforward - even for users who aren’t cloud experts. The pricing is also very transparent and affordable, allowing me to scale projects without worrying about unexpected costs. On top of that, the platform’s performance is consistently reliable, with fast server response times and minimal downtime, which is essential for my work.",
+            "reviewDislikes": "While I’m generally very satisfied with DigitalOcean, if I had to mention a downside, it would be that some advanced features and integrations found in larger cloud providers are missing or require more manual setup. Additionally, more detailed documentation or tutorials for certain use cases would be helpful for users looking to expand their projects."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: G2 invite"
-      ],
-      "reviewData": "2025-07-31",
-      "reviewRate": 4.0,
-      "reviewTitle": "Simple, Affordable, and Reliable Cloud Hosting",
-      "reviewLikes": "What I like best about DigitalOcean is its intuitive and clean interface, which makes managing servers and deployments incredibly straightforward - even for users who aren’t cloud experts. The pricing is also very transparent and affordable, allowing me to scale projects without worrying about unexpected costs. On top of that, the platform’s performance is consistently reliable, with fast server response times and minimal downtime, which is essential for my work.",
-      "reviewDilikes": "While I’m generally very satisfied with DigitalOcean, if I had to mention a downside, it would be that some advanced features and integrations found in larger cloud providers are missing or require more manual setup. Additionally, more detailed documentation or tutorials for certain use cases would be helpful for users looking to expand their projects."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Azeem C.",
-      "authorProfile": "https://www.g2.com/users/207c0228-9ccb-4a33-a321-1825ea6ea0aa",
-      "authorPosition": "Senior Software Engineer",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Azeem C.",
+            "authorProfile": "https://www.g2.com/users/207c0228-9ccb-4a33-a321-1825ea6ea0aa",
+            "authorPosition": "Senior Software Engineer",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-05-07",
+            "reviewRate": 4.5,
+            "reviewTitle": "Very good selection of services. 99.99% Uptime.",
+            "reviewLikes": "DigitalOcean has very good selection of services. You can create VPS server of all sizes and quantities. For instance, you can create a vps host (with 1cpu and 10gb hard disk) for as little as $4 per month. It can go all the way up to $1630/mo with 60 CPUs. \n\nYou can create GPU droplets as well.\n\nOther think is about almost 100% uptime. Initially there some speed issues over the past. It could kick in once or twice in a month. But I think DigitalOcean has worked on this. I created an uptime monitoring service  (which also is from DigitalOcean). It says, last outage was around 175 days ago. That is very nice.\n\nIt's website is neatly structured. Great ease of use.\n\nCustomer support is also very good. Very responsive. I am using the free plan. In this plan, they reply you within 24 hours. Every time I opened  a ticket, they would promptly answer it.",
+            "reviewDislikes": "I dislike a couple of things about DigitalOcean. Centos 10 was released on December 12, 2024. But it is not available yet in DigitalOcean as of today (7th May). Other providers like Vultr has it already. The selection of linux distributions is also limited. Compared to Vultr, DigitalOcean does not have that much choice of linux distributions."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-05-07",
-      "reviewRate": 4.5,
-      "reviewTitle": "Very good selection of services. 99.99% Uptime.",
-      "reviewLikes": "DigitalOcean has very good selection of services. You can create VPS server of all sizes and quantities. For instance, you can create a vps host (with 1cpu and 10gb hard disk) for as little as $4 per month. It can go all the way up to $1630/mo with 60 CPUs. \n\nYou can create GPU droplets as well.\n\nOther think is about almost 100% uptime. Initially there some speed issues over the past. It could kick in once or twice in a month. But I think DigitalOcean has worked on this. I created an uptime monitoring service  (which also is from DigitalOcean). It says, last outage was around 175 days ago. That is very nice.\n\nIt's website is neatly structured. Great ease of use.\n\nCustomer support is also very good. Very responsive. I am using the free plan. In this plan, they reply you within 24 hours. Every time I opened  a ticket, they would promptly answer it.",
-      "reviewDilikes": "I dislike a couple of things about DigitalOcean. Centos 10 was released on December 12, 2024. But it is not available yet in DigitalOcean as of today (7th May). Other providers like Vultr has it already. The selection of linux distributions is also limited. Compared to Vultr, DigitalOcean does not have that much choice of linux distributions."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Ujjwal A.",
-      "authorProfile": "https://www.g2.com/users/301601e8-18fc-4b96-9343-0f274646d0da",
-      "authorPosition": "Devops Engineer",
-      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    {
+        "author": {
+            "authorName": "Ujjwal A.",
+            "authorProfile": "https://www.g2.com/users/301601e8-18fc-4b96-9343-0f274646d0da",
+            "authorPosition": "Devops Engineer",
+            "authorCompanySize": "Mid-Market (51-1000 emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: G2 invite"
+            ],
+            "reviewData": "2025-08-07",
+            "reviewRate": 5.0,
+            "reviewTitle": "Best and Developer Friendly Cloud Platform",
+            "reviewLikes": "1 - Very Easy to setup and manage droplets that is we can spin up servers or apps in just few minutes.\n2 - Simple and Clean UI\n3 - Transparent pricing we always know what we are spending\n4 - Great documentation and community support",
+            "reviewDislikes": "1 - It has limited advanced services when comapred to aws.\n2 - Load balancer and monitoring features are basic."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: G2 invite"
-      ],
-      "reviewData": "2025-08-07",
-      "reviewRate": 5.0,
-      "reviewTitle": "Best and Developer Friendly Cloud Platform",
-      "reviewLikes": "1 - Very Easy to setup and manage droplets that is we can spin up servers or apps in just few minutes.\n2 - Simple and Clean UI\n3 - Transparent pricing we always know what we are spending\n4 - Great documentation and community support",
-      "reviewDilikes": "1 - It has limited advanced services when comapred to aws.\n2 - Load balancer and monitoring features are basic."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Lajith K.",
-      "authorProfile": "https://www.g2.com/users/811058dd-d83a-4d36-8e1e-f5da661c499d",
-      "authorPosition": "Software Engineer",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Lajith K.",
+            "authorProfile": "https://www.g2.com/users/811058dd-d83a-4d36-8e1e-f5da661c499d",
+            "authorPosition": "Software Engineer",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 5.0,
+            "reviewTitle": "Fast & secure & most reliable",
+            "reviewLikes": "Clean UI & UX: The control panel is intuitive and uncluttered, making it easy to spin up and manage virtual machines, databases, and other services even for beginners.\n\nTransparent pricing: Their pricing model is straightforward and predictable—especially attractive for startups and developers who need to keep tight control over costs.\n\nDeveloper community & documentation: DigitalOcean has built a strong library of tutorials and guides, which are often more accessible and practical than what you find from bigger cloud providers.\n\nDroplets (VMs): Launching a Droplet is fast, and performance tends to be solid for most general-purpose applications.\n\nManaged services: They’ve expanded into managed databases, Kubernetes, app platform (PaaS), etc., offering more flexibility while maintaining simplicity.",
+            "reviewDislikes": "Additional payment methods should be introduced to support currencies other than the US Dollar, such as Indian Rupees for customers in India."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Fast & secure & most reliable",
-      "reviewLikes": "Clean UI & UX: The control panel is intuitive and uncluttered, making it easy to spin up and manage virtual machines, databases, and other services even for beginners.\n\nTransparent pricing: Their pricing model is straightforward and predictable—especially attractive for startups and developers who need to keep tight control over costs.\n\nDeveloper community & documentation: DigitalOcean has built a strong library of tutorials and guides, which are often more accessible and practical than what you find from bigger cloud providers.\n\nDroplets (VMs): Launching a Droplet is fast, and performance tends to be solid for most general-purpose applications.\n\nManaged services: They’ve expanded into managed databases, Kubernetes, app platform (PaaS), etc., offering more flexibility while maintaining simplicity.",
-      "reviewDilikes": "Additional payment methods should be introduced to support currencies other than the US Dollar, such as Indian Rupees for customers in India."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Jeff L.",
-      "authorProfile": "https://www.g2.com/users/430b4bb4-4514-4d75-b9a9-d71643a1a26a",
-      "authorPosition": "Founder",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Jeff L.",
+            "authorProfile": "https://www.g2.com/users/430b4bb4-4514-4d75-b9a9-d71643a1a26a",
+            "authorPosition": "Founder",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 4.0,
+            "reviewTitle": "Two Years with DigitalOcean: A Simple and Smooth Experience for My Projects",
+            "reviewLikes": "I've been using DigitalOcean for two years to support my own project. What stands out the most is how easy it is to use. The platform is beginner-friendly, the UI is clean, and setting up servers or other resources is straightforward without needing to dig through complex configurations. This simplicity helped me focus more on building my project rather than managing infrastructure.",
+            "reviewDislikes": "One downside I've noticed is the lack of a free tier for cloud databases. For beginners or small projects, having a zero-cost starting point would make it easier to experiment and grow without upfront costs. Compared to other providers that offer limited free database options, this can make DigitalOcean feel less accessible for early-stage users."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 4.0,
-      "reviewTitle": "Two Years with DigitalOcean: A Simple and Smooth Experience for My Projects",
-      "reviewLikes": "I've been using DigitalOcean for two years to support my own project. What stands out the most is how easy it is to use. The platform is beginner-friendly, the UI is clean, and setting up servers or other resources is straightforward without needing to dig through complex configurations. This simplicity helped me focus more on building my project rather than managing infrastructure.",
-      "reviewDilikes": "One downside I've noticed is the lack of a free tier for cloud databases. For beginners or small projects, having a zero-cost starting point would make it easier to experiment and grow without upfront costs. Compared to other providers that offer limited free database options, this can make DigitalOcean feel less accessible for early-stage users."
-    }
-  },
-  {
-    "author": {
-      "authorName": "David P.",
-      "authorProfile": "https://www.g2.com/users/27dfd888-c410-43b1-84ec-33bba5a98e37",
-      "authorPosition": "Owner",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "David P.",
+            "authorProfile": "https://www.g2.com/users/27dfd888-c410-43b1-84ec-33bba5a98e37",
+            "authorPosition": "Owner",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 5.0,
+            "reviewTitle": "Very flexible, powerful API and website, decent prices!",
+            "reviewLikes": "As an occasional web developer and someone who wants to move forward with creating a bunch of powerful APPs in the future... Digital Ocean allows me to expand as my needs fit.  I also love the fact I can choose to run my websites/APP's on AMD processors.\n\nIf you need more space... drag the slider.  If you want another droplet, add one.  If you want a load balancer, add one.  It's very flexible and even as an intermediate web developer their systems are quite well done.\n\nPrices seem fair and we use the Toronto location for hosting.  We are now hosting 12 domains on a single simple low cost server.  We will be expanding and coding for years to come and at least we know that if we need more... Digital Ocean can handle it.",
+            "reviewDislikes": "Using G2 to submit a review.  After finishing the entire review, it FAILED to submit for no reason whatsoever...   I wasted 25 min of my time.\n\nI had very detailed answers in every category to be very thorough...  the question remains... should I redo everything and waste another 25 min only to have it fail again?   And now, most likely won't be chosen for the $25 gift card all because your site wouldn't submit my review and I don't feel like giving super detailed answers having to do this twice.  \n\nUgh...\n\n--------\nI am just going to summarize my answers since I already gave detailed ones...   please fix your website.\n--------\nMy answer for what I dislike about DO?\n\nSo far nothing.  It's been fine, but as I had posted on before, if I had to find a fault with DO...  (ugh)... I can't even remember what I wrote now.  How frustrating this has become.   I'm on a deadline, thought this wouldn't take that long... and now that I have to redo it... I'm all frustrated... can't think..."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Very flexible, powerful API and website, decent prices!",
-      "reviewLikes": "As an occasional web developer and someone who wants to move forward with creating a bunch of powerful APPs in the future... Digital Ocean allows me to expand as my needs fit.  I also love the fact I can choose to run my websites/APP's on AMD processors.\n\nIf you need more space... drag the slider.  If you want another droplet, add one.  If you want a load balancer, add one.  It's very flexible and even as an intermediate web developer their systems are quite well done.\n\nPrices seem fair and we use the Toronto location for hosting.  We are now hosting 12 domains on a single simple low cost server.  We will be expanding and coding for years to come and at least we know that if we need more... Digital Ocean can handle it.",
-      "reviewDilikes": "Using G2 to submit a review.  After finishing the entire review, it FAILED to submit for no reason whatsoever...   I wasted 25 min of my time.\n\nI had very detailed answers in every category to be very thorough...  the question remains... should I redo everything and waste another 25 min only to have it fail again?   And now, most likely won't be chosen for the $25 gift card all because your site wouldn't submit my review and I don't feel like giving super detailed answers having to do this twice.  \n\nUgh...\n\n--------\nI am just going to summarize my answers since I already gave detailed ones...   please fix your website.\n--------\nMy answer for what I dislike about DO?\n\nSo far nothing.  It's been fine, but as I had posted on before, if I had to find a fault with DO...  (ugh)... I can't even remember what I wrote now.  How frustrating this has become.   I'm on a deadline, thought this wouldn't take that long... and now that I have to redo it... I'm all frustrated... can't think..."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Luca P.",
-      "authorProfile": "https://www.g2.com/users/lucapiccinotti",
-      "authorPosition": "✅ CTO - Growth Marketer full stack #MarTech | ⚡️ SaaS Advisor",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Luca P.",
+            "authorProfile": "https://www.g2.com/users/lucapiccinotti",
+            "authorPosition": "✅ CTO - Growth Marketer full stack #MarTech | ⚡️ SaaS Advisor",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "G2 Icon",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: G2 Gives Campaign"
+            ],
+            "reviewData": "2025-07-04",
+            "reviewRate": 5.0,
+            "reviewTitle": "Reliable cloud infrastructure for developers and SMBs",
+            "reviewLikes": "DigitalOcean delivers a robust suite of cloud infrastructure products tailored for developers, startups, and SMBs.\n\nThe platform stands out for its intuitive user interface and predictable pricing model, which simplifies resource management and cost forecasting. Key features include Droplets (scalable Linux-based virtual machines), a fully managed Kubernetes service with a free control plane, and an App Platform for rapid deployment of web applications and APIs using PaaS principles. \n\nIt supports managed databases (PostgreSQL, MySQL, MongoDB, Kafka), object storage (Spaces), and block storage. Recent additions like GPU compute options (via the Paperspace acquisition) and GenAI Platform for building and deploying AI agents expand its capabilities for machine learning and generative AI workloads.\n\nThe API ecosystem is comprehensive, enabling automation and integration across a range of programming languages. One-click app deployment (e.g., WordPress, Docker) and clear documentation further streamline the developer experience.",
+            "reviewDislikes": "While the overall experience is streamlined, I find that advanced configuration options can be limited in some managed services, particularly within the App Platform. Customizing deployment environments sometimes requires restarting instances from scratch, which may result in lost changes if not managed carefully. Additionally, migration to other public clouds is not always straightforward, and the process can be confusing or restrictive in certain scenarios."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "G2 Icon",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: G2 Gives Campaign"
-      ],
-      "reviewData": "2025-07-04",
-      "reviewRate": 5.0,
-      "reviewTitle": "Reliable cloud infrastructure for developers and SMBs",
-      "reviewLikes": "DigitalOcean delivers a robust suite of cloud infrastructure products tailored for developers, startups, and SMBs.\n\nThe platform stands out for its intuitive user interface and predictable pricing model, which simplifies resource management and cost forecasting. Key features include Droplets (scalable Linux-based virtual machines), a fully managed Kubernetes service with a free control plane, and an App Platform for rapid deployment of web applications and APIs using PaaS principles. \n\nIt supports managed databases (PostgreSQL, MySQL, MongoDB, Kafka), object storage (Spaces), and block storage. Recent additions like GPU compute options (via the Paperspace acquisition) and GenAI Platform for building and deploying AI agents expand its capabilities for machine learning and generative AI workloads.\n\nThe API ecosystem is comprehensive, enabling automation and integration across a range of programming languages. One-click app deployment (e.g., WordPress, Docker) and clear documentation further streamline the developer experience.",
-      "reviewDilikes": "While the overall experience is streamlined, I find that advanced configuration options can be limited in some managed services, particularly within the App Platform. Customizing deployment environments sometimes requires restarting instances from scratch, which may result in lost changes if not managed carefully. Additionally, migration to other public clouds is not always straightforward, and the process can be confusing or restrictive in certain scenarios."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Deepjyoti R.",
-      "authorProfile": "https://www.g2.com/users/950f009b-cfc1-409f-87d2-27f93975ffda",
-      "authorPosition": "Cyber Security Analyst",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Deepjyoti R.",
+            "authorProfile": "https://www.g2.com/users/950f009b-cfc1-409f-87d2-27f93975ffda",
+            "authorPosition": "Cyber Security Analyst",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Rating Updated (8/3/2025)",
+                "Validated Reviewer",
+                "Source: Organic"
+            ],
+            "reviewData": "2025-08-01",
+            "reviewRate": 5.0,
+            "reviewTitle": "Best cloud provider for beginners",
+            "reviewLikes": "Digital Ocean is easy to use, with a clean interface and simple pricing. Setting up servers takes minutes. A strong community make it friendly, reliable, and great for beginners.",
+            "reviewDislikes": "Sudden account lockouts, limited OS choices and unexpected data deletion."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Rating Updated (8/3/2025)",
-        "Validated Reviewer",
-        "Source: Organic"
-      ],
-      "reviewData": "2025-08-01",
-      "reviewRate": 5.0,
-      "reviewTitle": "Best cloud provider for beginners",
-      "reviewLikes": "Digital Ocean is easy to use, with a clean interface and simple pricing. Setting up servers takes minutes. A strong community make it friendly, reliable, and great for beginners.",
-      "reviewDilikes": "Sudden account lockouts, limited OS choices and unexpected data deletion."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Vee D.",
-      "authorProfile": "https://www.g2.com/users/6bc9b282-76bf-47bf-959d-8ef874dce3cd",
-      "authorPosition": "Founder",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Vee D.",
+            "authorProfile": "https://www.g2.com/users/6bc9b282-76bf-47bf-959d-8ef874dce3cd",
+            "authorPosition": "Founder",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-29",
+            "reviewRate": 4.5,
+            "reviewTitle": "Long time customer, still going strong",
+            "reviewLikes": "Love the fact that they are one of the most transparent providers. I've been with them since 2016, regularly. Contemplated moving to AWS but I cannot deal with the complexity for now.\n\nSome products can make it expensive but the ease of use and implementation makes me want to stay.\n\nMoreover, their blog is always updated - which requires less support and customer service emails!",
+            "reviewDislikes": "Wish their functions section was a little bit easier to debug. Had to go back to my own personal VPS functions because DO Functions wasn't easy to debug."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-29",
-      "reviewRate": 4.5,
-      "reviewTitle": "Long time customer, still going strong",
-      "reviewLikes": "Love the fact that they are one of the most transparent providers. I've been with them since 2016, regularly. Contemplated moving to AWS but I cannot deal with the complexity for now.\n\nSome products can make it expensive but the ease of use and implementation makes me want to stay.\n\nMoreover, their blog is always updated - which requires less support and customer service emails!",
-      "reviewDilikes": "Wish their functions section was a little bit easier to debug. Had to go back to my own personal VPS functions because DO Functions wasn't easy to debug."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Verified User in Consulting",
-      "authorProfile": null,
-      "authorPosition": "Small-Business (50 or fewer emp.)",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Verified User in Consulting",
+            "authorProfile": null,
+            "authorPosition": "Small-Business (50 or fewer emp.)",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-02-12",
+            "reviewRate": 5.0,
+            "reviewTitle": "Very easy-to-use interface and instant response droplets",
+            "reviewLikes": "I like how easy it is to create and destroy droplets. I also like how reponsive the servers are – every change or request is instant.  This makes it effortless to implement complex applications including complex web apps. The uptime is just so good. \n\nI feel the best part is the pricing. I run a small business and DigitalOcean's packages are quite affordable.\n\nCustomer support is always available and responds within a reasonable time.",
+            "reviewDislikes": "Every experience I've had with DigitalOcen has been wonderful. I can't think of anything I dislike."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-02-12",
-      "reviewRate": 5.0,
-      "reviewTitle": "Very easy-to-use interface and instant response droplets",
-      "reviewLikes": "I like how easy it is to create and destroy droplets. I also like how reponsive the servers are – every change or request is instant.  This makes it effortless to implement complex applications including complex web apps. The uptime is just so good. \n\nI feel the best part is the pricing. I run a small business and DigitalOcean's packages are quite affordable.\n\nCustomer support is always available and responds within a reasonable time.",
-      "reviewDilikes": "Every experience I've had with DigitalOcen has been wonderful. I can't think of anything I dislike."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Verified User in Internet",
-      "authorProfile": null,
-      "authorPosition": "Small-Business (50 or fewer emp.)",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Verified User in Internet",
+            "authorProfile": null,
+            "authorPosition": "Small-Business (50 or fewer emp.)",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-29",
+            "reviewRate": 4.0,
+            "reviewTitle": "Stable and easy to use cloud solution",
+            "reviewLikes": "Ease of use, basically instant set up of new droplets or other products, straightforward approach on accessing your resources. Essentially it's set and forget, which is the best.",
+            "reviewDislikes": "Pricing, lack of granularity on upgrading/changing configuration of products. There is a lot of options for droplets, but as a one-man hobbyist I just need a small enough server with non-standard RAM size, and I am locked on a config that's not ideal for me. Same for the database, it is a pain to set up some advanced use cases, or it's impossible at all (like implementing a specified PostgreSQL extension)."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-29",
-      "reviewRate": 4.0,
-      "reviewTitle": "Stable and easy to use cloud solution",
-      "reviewLikes": "Ease of use, basically instant set up of new droplets or other products, straightforward approach on accessing your resources. Essentially it's set and forget, which is the best.",
-      "reviewDilikes": "Pricing, lack of granularity on upgrading/changing configuration of products. There is a lot of options for droplets, but as a one-man hobbyist I just need a small enough server with non-standard RAM size, and I am locked on a config that's not ideal for me. Same for the database, it is a pain to set up some advanced use cases, or it's impossible at all (like implementing a specified PostgreSQL extension)."
-    }
-  },
-  {
-    "author": {
-      "authorName": "J. Antonio A.",
-      "authorProfile": "https://www.g2.com/users/d87dba53-7035-4e91-b4df-7d7a0c4300bc",
-      "authorPosition": "Product Manager",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "J. Antonio A.",
+            "authorProfile": "https://www.g2.com/users/d87dba53-7035-4e91-b4df-7d7a0c4300bc",
+            "authorPosition": "Product Manager",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-02-12",
+            "reviewRate": 4.5,
+            "reviewTitle": "Awesome service, performance and cost somehow very technical but totally worthy",
+            "reviewLikes": "I like everything is super clear about the costs and features you'll get. There's also a lot of tutorials in blogs in youtube so it was then easy to use, implement and then integrate with my stuff. Getting some coupons for start was the key to me to migrate my services here, it felt like no risk and their Customer Support help me with a couple of questions. Security and Stability were another factors to consider, because of the nature of my frequent use of the service.",
+            "reviewDislikes": "Even DigitalOcen offers different easy-to-config options, it can be perceived as a hard choice for tech people with few time or the regular people who just want to set a website or service."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-02-12",
-      "reviewRate": 4.5,
-      "reviewTitle": "Awesome service, performance and cost somehow very technical but totally worthy",
-      "reviewLikes": "I like everything is super clear about the costs and features you'll get. There's also a lot of tutorials in blogs in youtube so it was then easy to use, implement and then integrate with my stuff. Getting some coupons for start was the key to me to migrate my services here, it felt like no risk and their Customer Support help me with a couple of questions. Security and Stability were another factors to consider, because of the nature of my frequent use of the service.",
-      "reviewDilikes": "Even DigitalOcen offers different easy-to-config options, it can be perceived as a hard choice for tech people with few time or the regular people who just want to set a website or service."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Gerardo  B.",
-      "authorProfile": "https://www.g2.com/users/e544c460-bc69-46ab-969c-13674bfc673f",
-      "authorPosition": "Co-founder. COO y Administración de los servidores",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Gerardo  B.",
+            "authorProfile": "https://www.g2.com/users/e544c460-bc69-46ab-969c-13674bfc673f",
+            "authorPosition": "Co-founder. COO y Administración de los servidores",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2024-11-04",
+            "reviewRate": 5.0,
+            "reviewTitle": "Simplicidad de un producto que funciona",
+            "reviewLikes": "Primero es que cumple con su funcionalidad con una baja o casi nula curva de aprendizaje en desplegar nuevas implementaciones. Nos abastece de sus servicios en los cuales confiamos y ponemos nuestro trabajo día a día, minuto a minuto desde desde después de la pandemia. Gracias a Digital Ocean nosotros estamos online con nuestra propuesta y llegamos a nuestros usuarios de todo Latam y parte de Europa. Realmente nos sentimos muy cómodos aquí y no nos interesa cambiarnos de proveedor en el mediano plazo (tampoco en el largo plazo). \nAntes de ser clientes de Digital Ocean, ya consultábamos toda la buena documentación de la comunidad, eso es algo que nos fue y es de mucha ayuda, principalmente en los momentos de inicio de los desarrollos y al adoptar nuevas tecnologías. \nEl soporte de cliente, lo hemos utilizado muy pocas veces, casi nunca, y siempre hemos tenido la mejor atención solucionando y aclarando los distintos inconvenientes.",
+            "reviewDislikes": "Puntualmente utilizamos droplets y nuestro desarrollo es bastante puntual, así que sentimos que hoy y en el mediano plazo cumple con nuestras espectativas. Me gustaría que tenga más servicios como lo tiene AWS, pero hoy en día no los estaríamos aprovechando. En el día de mañana tal vez necesitemos algunas herramientas para escalar o aumentar la productividad pero la tecnología hoy en día avanza muy rápido y es posible que también estemos cubiertos con las nuevas features."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2024-11-04",
-      "reviewRate": 5.0,
-      "reviewTitle": "Simplicidad de un producto que funciona",
-      "reviewLikes": "Primero es que cumple con su funcionalidad con una baja o casi nula curva de aprendizaje en desplegar nuevas implementaciones. Nos abastece de sus servicios en los cuales confiamos y ponemos nuestro trabajo día a día, minuto a minuto desde desde después de la pandemia. Gracias a Digital Ocean nosotros estamos online con nuestra propuesta y llegamos a nuestros usuarios de todo Latam y parte de Europa. Realmente nos sentimos muy cómodos aquí y no nos interesa cambiarnos de proveedor en el mediano plazo (tampoco en el largo plazo). \nAntes de ser clientes de Digital Ocean, ya consultábamos toda la buena documentación de la comunidad, eso es algo que nos fue y es de mucha ayuda, principalmente en los momentos de inicio de los desarrollos y al adoptar nuevas tecnologías. \nEl soporte de cliente, lo hemos utilizado muy pocas veces, casi nunca, y siempre hemos tenido la mejor atención solucionando y aclarando los distintos inconvenientes.",
-      "reviewDilikes": "Puntualmente utilizamos droplets y nuestro desarrollo es bastante puntual, así que sentimos que hoy y en el mediano plazo cumple con nuestras espectativas. Me gustaría que tenga más servicios como lo tiene AWS, pero hoy en día no los estaríamos aprovechando. En el día de mañana tal vez necesitemos algunas herramientas para escalar o aumentar la productividad pero la tecnología hoy en día avanza muy rápido y es posible que también estemos cubiertos con las nuevas features."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Jonathan P.",
-      "authorProfile": "https://www.g2.com/users/13b4b965-4e8d-4454-8555-65a95bf6b6aa",
-      "authorPosition": "Company Director, CTO",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Jonathan P.",
+            "authorProfile": "https://www.g2.com/users/13b4b965-4e8d-4454-8555-65a95bf6b6aa",
+            "authorPosition": "Company Director, CTO",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Rating Updated (5/5/2025)",
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2024-11-04",
+            "reviewRate": 4.5,
+            "reviewTitle": "Feels like you are really working with other developers",
+            "reviewLikes": "The number one reason I like DigitalOcean is that you feel like you are working with other developers. Yes they have commercial marketing, but it's quite, not 'in your face' like other providers.\nJust as much a number one reason is cost, where else can you get a cloud presence for $6/month that is professionally maintained, easy to use and in my case, after almost 7 years, never let me down.",
+            "reviewDislikes": "Honestly, it's difficult to think of anything negative. Yes I've had the odd issue, but between their excellent documentation and their customer tech support it's never been an issue to the extent that I've experienced with other providers.\nThere's a few extra's that I would like to see like domain registration, all in all a good place to be for a developer"
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Rating Updated (5/5/2025)",
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2024-11-04",
-      "reviewRate": 4.5,
-      "reviewTitle": "Feels like you are really working with other developers",
-      "reviewLikes": "The number one reason I like DigitalOcean is that you feel like you are working with other developers. Yes they have commercial marketing, but it's quite, not 'in your face' like other providers.\nJust as much a number one reason is cost, where else can you get a cloud presence for $6/month that is professionally maintained, easy to use and in my case, after almost 7 years, never let me down.",
-      "reviewDilikes": "Honestly, it's difficult to think of anything negative. Yes I've had the odd issue, but between their excellent documentation and their customer tech support it's never been an issue to the extent that I've experienced with other providers.\nThere's a few extra's that I would like to see like domain registration, all in all a good place to be for a developer"
-    }
-  },
-  {
-    "author": {
-      "authorName": "P B.",
-      "authorProfile": "https://www.g2.com/users/0fa0065a-847f-4353-b5b6-bf3a5d282d26",
-      "authorPosition": "CTO",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "P B.",
+            "authorProfile": "https://www.g2.com/users/0fa0065a-847f-4353-b5b6-bf3a5d282d26",
+            "authorPosition": "CTO",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-02-19",
+            "reviewRate": 5.0,
+            "reviewTitle": "What AWS should have been",
+            "reviewLikes": "Digital Ocean (DO) is amazing for one fact - its super simple to use.  AWS, while powerful, gives me a headache trying to figure out what things mean or how to use them.  DO has been amazing in that regard - its easy to spin up servers or new services, and hardly requires any babysitting. It runs 90% of our company, and has for years.",
+            "reviewDislikes": "There isn't much to complain about here.  I guess a few of the services could be a bit cheaper."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-02-19",
-      "reviewRate": 5.0,
-      "reviewTitle": "What AWS should have been",
-      "reviewLikes": "Digital Ocean (DO) is amazing for one fact - its super simple to use.  AWS, while powerful, gives me a headache trying to figure out what things mean or how to use them.  DO has been amazing in that regard - its easy to spin up servers or new services, and hardly requires any babysitting. It runs 90% of our company, and has for years.",
-      "reviewDilikes": "There isn't much to complain about here.  I guess a few of the services could be a bit cheaper."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Linus .",
-      "authorProfile": "https://www.g2.com/users/ea72d925-c14e-426d-b473-09da23b6d215",
-      "authorPosition": "Game Designer / Game Lead Director",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Linus .",
+            "authorProfile": "https://www.g2.com/users/ea72d925-c14e-426d-b473-09da23b6d215",
+            "authorPosition": "Game Designer / Game Lead Director",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2024-11-04",
+            "reviewRate": 5.0,
+            "reviewTitle": "Excellent serivce for a fair affordable price",
+            "reviewLikes": "We use Digital Ocean to host Perforce Helix Core version control for unreal engine 5. DigitalOcean provides a very affordable service for our small team with good plans to choose from. \nWe use it for our whole development of games, therefor it's great to choose only what we really need and have the option to easily expand our plan when needed.\nThe implementation was easy and we had no struggles.",
+            "reviewDislikes": "Sadly (as far as we know) you can only see how much space you are already using in percentage and not written like: 20GB/25GB. That would be a great addition if you can't keep track how much space you provide to a droplet."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2024-11-04",
-      "reviewRate": 5.0,
-      "reviewTitle": "Excellent serivce for a fair affordable price",
-      "reviewLikes": "We use Digital Ocean to host Perforce Helix Core version control for unreal engine 5. DigitalOcean provides a very affordable service for our small team with good plans to choose from. \nWe use it for our whole development of games, therefor it's great to choose only what we really need and have the option to easily expand our plan when needed.\nThe implementation was easy and we had no struggles.",
-      "reviewDilikes": "Sadly (as far as we know) you can only see how much space you are already using in percentage and not written like: 20GB/25GB. That would be a great addition if you can't keep track how much space you provide to a droplet."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Dillon D.",
-      "authorProfile": "https://www.g2.com/users/ff9feaaa-ce36-4dd2-aa55-311ab73e119b",
-      "authorPosition": "Owner",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Dillon D.",
+            "authorProfile": "https://www.g2.com/users/ff9feaaa-ce36-4dd2-aa55-311ab73e119b",
+            "authorPosition": "Owner",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 5.0,
+            "reviewTitle": "Easy, fast, and flexible",
+            "reviewLikes": "Web UI is very intuitive and easy to use. Resources are readily available and performance meets expectations.",
+            "reviewDislikes": "Not the cheapest option for large servers but still good value."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Easy, fast, and flexible",
-      "reviewLikes": "Web UI is very intuitive and easy to use. Resources are readily available and performance meets expectations.",
-      "reviewDilikes": "Not the cheapest option for large servers but still good value."
-    }
-  },
-  {
-    "author": {
-      "authorName": "HEJOIR S.",
-      "authorProfile": "https://www.g2.com/users/2ee44b4f-9d5a-4e4c-ab94-ffecc4649bb0",
-      "authorPosition": "developer",
-      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    {
+        "author": {
+            "authorName": "HEJOIR S.",
+            "authorProfile": "https://www.g2.com/users/2ee44b4f-9d5a-4e4c-ab94-ffecc4649bb0",
+            "authorPosition": "developer",
+            "authorCompanySize": "Mid-Market (51-1000 emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-29",
+            "reviewRate": 5.0,
+            "reviewTitle": "Great for small businesses with tech skills",
+            "reviewLikes": "DigitalOcean is a flexible and scalable platform that works perfectly for small and medium-sized businesses. It offers an intuitive interface, fast server deployment, and affordable pricing, which makes it ideal for startups or growing companies. The technical documentation is extensive and very helpful for developers.",
+            "reviewDislikes": "The main downside is the lack of customer support in Spanish. This can be a challenge for non-English-speaking users, especially during critical issues. It would be great to see more localized support for Latin America and Spanish-speaking users."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-29",
-      "reviewRate": 5.0,
-      "reviewTitle": "Great for small businesses with tech skills",
-      "reviewLikes": "DigitalOcean is a flexible and scalable platform that works perfectly for small and medium-sized businesses. It offers an intuitive interface, fast server deployment, and affordable pricing, which makes it ideal for startups or growing companies. The technical documentation is extensive and very helpful for developers.",
-      "reviewDilikes": "The main downside is the lack of customer support in Spanish. This can be a challenge for non-English-speaking users, especially during critical issues. It would be great to see more localized support for Latin America and Spanish-speaking users."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Kenneth K.",
-      "authorProfile": "https://www.g2.com/users/2e79f60c-175c-4bec-9c7f-3a90ed0e27e2",
-      "authorPosition": "CEO",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Kenneth K.",
+            "authorProfile": "https://www.g2.com/users/2e79f60c-175c-4bec-9c7f-3a90ed0e27e2",
+            "authorPosition": "CEO",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-02-18",
+            "reviewRate": 5.0,
+            "reviewTitle": "Best affordable Cloud Provider",
+            "reviewLikes": "I'm working on a startup together with a friend. We haven't gone live yet, but I feel compelled to give an honest review of DigitalOcean after having used their droplets for almost 4 months now.\n\nWell, just like most startups, we have a tight budget yet need massive resources to run a video sharing MERN app.\nWe first tried AWS, but that was way out of out budget. After a lot of research, we came across DigitalOcean, tried their droplets for three months using their free trial and haven't looked back.\n\nWhat I love most is how easy it is to manage our kubernetes cluster without worrying about how much we'll pay at the end of the month. All we  needed to do is select how many droplets we needed based on number of vCPUs, RAM, and disk storage, and we're guaranteed to pay only for those droplets . The only other cost is space storage, persistent storage, and load balancer, all of which are also so easy to estimate and cheap.\n\nTheir customer service is also really good, and they'll respond even during weekends. But you have to be very clear on what you need help on so they can assist you with the fewest number of messages since they do not respond immediately. But they also offer premium customer service options if you need immediate responses. \n\nAnother option is BobCares, which they do promote on their site also. It's a third-party customer service for kubernetes which I've used before and didn't like it at all. First, they're pretty expensive - about $99 per hour - and you're not guaranteed they'll solve your issue. Second, you have to give them access to your kubernetes cluster, which could be a potential source of a security breach for your cluster. \n\nFor someone who didn't know how to spin up a kubernetes cluster from scratch for a MERN app, I'd say choosing DigitalOcean was my best decision ever. I have control over everything and have an amazing group of specialists waiting to help any time I get stuck.\n\nTheir online publications are also super helpful and very well documented. I can't talk much about their DigitalOcean managed kubernetes (DOKS), but if you're looking to spin up a kubernetes cluster from scratch inside droplets, you'll need their CSI driver, which is just as easy as copying and pasting it from their Github.",
+            "reviewDislikes": "The only negative experience I've had is in setting up firewall for my droplets using their firewall dashboard. I noticed that anytime I could add firewall rules, my site got really slow. I'm not sure why and didn't bother asking them so I can't blame it all on them. I went for the alternative of setting up firewall using iptables, which works fine now. I honestly can't think of any other negative experience.\n\nSince I'm using Droplets rather than their managed kubernetes service (DOKS), most of the issues I come across are things I can solve since I have control over the entire kubernetes set up. That's why it's kind of difficult to address any negatives; I can't fault them."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-02-18",
-      "reviewRate": 5.0,
-      "reviewTitle": "Best affordable Cloud Provider",
-      "reviewLikes": "I'm working on a startup together with a friend. We haven't gone live yet, but I feel compelled to give an honest review of DigitalOcean after having used their droplets for almost 4 months now.\n\nWell, just like most startups, we have a tight budget yet need massive resources to run a video sharing MERN app.\nWe first tried AWS, but that was way out of out budget. After a lot of research, we came across DigitalOcean, tried their droplets for three months using their free trial and haven't looked back.\n\nWhat I love most is how easy it is to manage our kubernetes cluster without worrying about how much we'll pay at the end of the month. All we  needed to do is select how many droplets we needed based on number of vCPUs, RAM, and disk storage, and we're guaranteed to pay only for those droplets . The only other cost is space storage, persistent storage, and load balancer, all of which are also so easy to estimate and cheap.\n\nTheir customer service is also really good, and they'll respond even during weekends. But you have to be very clear on what you need help on so they can assist you with the fewest number of messages since they do not respond immediately. But they also offer premium customer service options if you need immediate responses. \n\nAnother option is BobCares, which they do promote on their site also. It's a third-party customer service for kubernetes which I've used before and didn't like it at all. First, they're pretty expensive - about $99 per hour - and you're not guaranteed they'll solve your issue. Second, you have to give them access to your kubernetes cluster, which could be a potential source of a security breach for your cluster. \n\nFor someone who didn't know how to spin up a kubernetes cluster from scratch for a MERN app, I'd say choosing DigitalOcean was my best decision ever. I have control over everything and have an amazing group of specialists waiting to help any time I get stuck.\n\nTheir online publications are also super helpful and very well documented. I can't talk much about their DigitalOcean managed kubernetes (DOKS), but if you're looking to spin up a kubernetes cluster from scratch inside droplets, you'll need their CSI driver, which is just as easy as copying and pasting it from their Github.",
-      "reviewDilikes": "The only negative experience I've had is in setting up firewall for my droplets using their firewall dashboard. I noticed that anytime I could add firewall rules, my site got really slow. I'm not sure why and didn't bother asking them so I can't blame it all on them. I went for the alternative of setting up firewall using iptables, which works fine now. I honestly can't think of any other negative experience.\n\nSince I'm using Droplets rather than their managed kubernetes service (DOKS), most of the issues I come across are things I can solve since I have control over the entire kubernetes set up. That's why it's kind of difficult to address any negatives; I can't fault them."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Vasilis",
-      "authorProfile": "https://www.g2.com/users/94d371fd-a84c-48af-b1ef-8ba0d8c6f0a1",
-      "authorPosition": "Chief Technical Officer",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Vasilis",
+            "authorProfile": "https://www.g2.com/users/94d371fd-a84c-48af-b1ef-8ba0d8c6f0a1",
+            "authorPosition": "Chief Technical Officer",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 4.5,
+            "reviewTitle": "Great and simple to use cloud provider",
+            "reviewLikes": "It strikes the best balance of provided services and low complexity for SMBs. We don't have dedicated SREs, we don't wanna spend countless hours setting up IAMs, dozens of configs just to do the simplest of things, or trying to figure out what services is the best.\n\nIf you're looking for simple to use and straightfoward servers, DBs, containers, DNS management, S3 buckets, etc, the Digital Ocean is a great solution.",
+            "reviewDislikes": "We would like juuuust a tad more permission management, specifically giving people permissions on a project-based level, so that we can isolate between prod and dev.\n\nBut as I already mentioned, we appreciate the simplicity and straight forwardness of DO, so I'd rather use what they have right now."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 4.5,
-      "reviewTitle": "Great and simple to use cloud provider",
-      "reviewLikes": "It strikes the best balance of provided services and low complexity for SMBs. We don't have dedicated SREs, we don't wanna spend countless hours setting up IAMs, dozens of configs just to do the simplest of things, or trying to figure out what services is the best.\n\nIf you're looking for simple to use and straightfoward servers, DBs, containers, DNS management, S3 buckets, etc, the Digital Ocean is a great solution.",
-      "reviewDilikes": "We would like juuuust a tad more permission management, specifically giving people permissions on a project-based level, so that we can isolate between prod and dev.\n\nBut as I already mentioned, we appreciate the simplicity and straight forwardness of DO, so I'd rather use what they have right now."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Vince  C.",
-      "authorProfile": "https://www.g2.com/users/1cf14acd-7f7f-44cf-b46e-50327694d690",
-      "authorPosition": "Owner",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Vince  C.",
+            "authorProfile": "https://www.g2.com/users/1cf14acd-7f7f-44cf-b46e-50327694d690",
+            "authorPosition": "Owner",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-29",
+            "reviewRate": 4.5,
+            "reviewTitle": "Solid reliable cloud services with great value",
+            "reviewLikes": "I've been with DigitalOcean for almost 10 years and extremely happy with their services, which don't overwhelm you with options and are a great value. Customer support when needed is excellent and they have lots of self-help support in the form of how-to documents and examples.",
+            "reviewDislikes": "So far I have no complaints, they meet my needs perfectly. If I was with a larger Enterprise or government Institution they might be a harder sell as they don't have the same credibility as a Microsoft or Amazon, but for what most people need digital ocean is great."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-29",
-      "reviewRate": 4.5,
-      "reviewTitle": "Solid reliable cloud services with great value",
-      "reviewLikes": "I've been with DigitalOcean for almost 10 years and extremely happy with their services, which don't overwhelm you with options and are a great value. Customer support when needed is excellent and they have lots of self-help support in the form of how-to documents and examples.",
-      "reviewDilikes": "So far I have no complaints, they meet my needs perfectly. If I was with a larger Enterprise or government Institution they might be a harder sell as they don't have the same credibility as a Microsoft or Amazon, but for what most people need digital ocean is great."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Filipe V.",
-      "authorProfile": "https://www.g2.com/users/e68afb74-b175-4380-9ca9-f17a64ad82b3",
-      "authorPosition": "Full Stack Engineer",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Filipe V.",
+            "authorProfile": "https://www.g2.com/users/e68afb74-b175-4380-9ca9-f17a64ad82b3",
+            "authorPosition": "Full Stack Engineer",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 5.0,
+            "reviewTitle": "Fantastic and stable product",
+            "reviewLikes": "I really like they are predictable regarding the pricing and offers stable products that have zero downtime. I am a client over more than 10 years and only had positive interactions with their support team and product. Zero headaches and awesome performance.",
+            "reviewDislikes": "In the past they only offered droplets which was kinda limiting, but now they offer a wide array of services so I don't think there's anything that I dislike about it."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Fantastic and stable product",
-      "reviewLikes": "I really like they are predictable regarding the pricing and offers stable products that have zero downtime. I am a client over more than 10 years and only had positive interactions with their support team and product. Zero headaches and awesome performance.",
-      "reviewDilikes": "In the past they only offered droplets which was kinda limiting, but now they offer a wide array of services so I don't think there's anything that I dislike about it."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Stephen Douglas S.",
-      "authorProfile": "https://www.g2.com/users/bluewizard",
-      "authorPosition": "Founder",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Stephen Douglas S.",
+            "authorProfile": "https://www.g2.com/users/bluewizard",
+            "authorPosition": "Founder",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Rating Updated (2/11/2025)",
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2024-05-09",
+            "reviewRate": 4.5,
+            "reviewTitle": "High value for the price, and their customer service is good.  They added PaperSpace (GPUs for AI)",
+            "reviewLikes": "The value for the price, and their customer service.  The control panel / UI is easy to navigate.  I have Digital Ocea to manage some Docker packages, including my web hosting service.  I more recently started to explore the deployment of some AI platforms, but I'd rather purchase my hardware to develop in-house, and then deploy to the Cloud when it is production ready.",
+            "reviewDislikes": "Their offerings don't compare to something like AWS, but for small and medium-sized businesses they have a nice platform that keeps improving."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Rating Updated (2/11/2025)",
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2024-05-09",
-      "reviewRate": 4.5,
-      "reviewTitle": "High value for the price, and their customer service is good.  They added PaperSpace (GPUs for AI)",
-      "reviewLikes": "The value for the price, and their customer service.  The control panel / UI is easy to navigate.  I have Digital Ocea to manage some Docker packages, including my web hosting service.  I more recently started to explore the deployment of some AI platforms, but I'd rather purchase my hardware to develop in-house, and then deploy to the Cloud when it is production ready.",
-      "reviewDilikes": "Their offerings don't compare to something like AWS, but for small and medium-sized businesses they have a nice platform that keeps improving."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Verified User in Facilities Services",
-      "authorProfile": null,
-      "authorPosition": "Small-Business (50 or fewer emp.)",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Verified User in Facilities Services",
+            "authorProfile": null,
+            "authorPosition": "Small-Business (50 or fewer emp.)",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Rating Updated (5/25/2025)",
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite",
+                "AI Translated"
+            ],
+            "reviewData": "2025-04-29",
+            "reviewRate": 3.5,
+            "reviewTitle": "My point of view on Digital Ocean as a product",
+            "reviewLikes": "What I like best about Digital Ocean is that the process and UI are easy to understand for new users. They are giving simple options to make the changes and make them effective.",
+            "reviewDislikes": "Several times we have faced the problem with deployment regarding cache issues in the newly deployed build. It gets deployed, but new changes are not reflecting. In that case, we have to go and restart the app with a clear build cache. It's a headache."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Rating Updated (5/25/2025)",
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite",
-        "AI Translated"
-      ],
-      "reviewData": "2025-04-29",
-      "reviewRate": 3.5,
-      "reviewTitle": "My point of view on Digital Ocean as a product",
-      "reviewLikes": "What I like best about Digital Ocean is that the process and UI are easy to understand for new users. They are giving simple options to make the changes and make them effective.",
-      "reviewDilikes": "Several times we have faced the problem with deployment regarding cache issues in the newly deployed build. It gets deployed, but new changes are not reflecting. In that case, we have to go and restart the app with a clear build cache. It's a headache."
-    }
-  },
-  {
-    "author": {
-      "authorName": "Ryan  D.",
-      "authorProfile": "https://www.g2.com/users/bdec8dd0-ad23-4a6e-b165-aec65a81e9a5",
-      "authorPosition": "Sole Trader",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Ryan  D.",
+            "authorProfile": "https://www.g2.com/users/bdec8dd0-ad23-4a6e-b165-aec65a81e9a5",
+            "authorPosition": "Sole Trader",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-04-28",
+            "reviewRate": 5.0,
+            "reviewTitle": "Cheap, easy to use",
+            "reviewLikes": "It just works, setup was easy and I've had no issues with the platform since then. Recovery tools just work when you need them and adding additional volumes is just a few clicks with really clear pricing.",
+            "reviewDislikes": "Have not had any downsides yet beyond but being cheapest in the market but that's balanced out by the updates. I don't have experience with their support services or other products so have limited knowledge of their downsides"
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-04-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Cheap, easy to use",
-      "reviewLikes": "It just works, setup was easy and I've had no issues with the platform since then. Recovery tools just work when you need them and adding additional volumes is just a few clicks with really clear pricing.",
-      "reviewDilikes": "Have not had any downsides yet beyond but being cheapest in the market but that's balanced out by the updates. I don't have experience with their support services or other products so have limited knowledge of their downsides"
-    }
-  },
-  {
-    "author": {
-      "authorName": "Yahya L.",
-      "authorProfile": "https://www.g2.com/users/bad78889-6929-458b-8873-fe7d9670648c",
-      "authorPosition": "Owner of the Company",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    {
+        "author": {
+            "authorName": "Yahya L.",
+            "authorProfile": "https://www.g2.com/users/bad78889-6929-458b-8873-fe7d9670648c",
+            "authorPosition": "Owner of the Company",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Incentivized",
+                "Source: Seller invite"
+            ],
+            "reviewData": "2025-02-14",
+            "reviewRate": 4.5,
+            "reviewTitle": "when i started using DO i never changed them",
+            "reviewLikes": "DO is fast, clean, was first in kind once they started, cheap, they have great doccumentation, they have toturials, easy to use, fast and serious customer support and great products.",
+            "reviewDislikes": "i had never got problems with them except this last two months my droplet that runs my website stops working as expected and just hand and services get down, thats maybe because they have added many many other services and products and updates, and my droplet is up from 2014/2015 maybe."
+        }
     },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Incentivized",
-        "Source: Seller invite"
-      ],
-      "reviewData": "2025-02-14",
-      "reviewRate": 4.5,
-      "reviewTitle": "when i started using DO i never changed them",
-      "reviewLikes": "DO is fast, clean, was first in kind once they started, cheap, they have great doccumentation, they have toturials, easy to use, fast and serious customer support and great products.",
-      "reviewDilikes": "i had never got problems with them except this last two months my droplet that runs my website stops working as expected and just hand and services get down, thats maybe because they have added many many other services and products and updates, and my droplet is up from 2014/2015 maybe."
+    {
+        "author": {
+            "authorName": "Filip S.",
+            "authorProfile": "https://www.g2.com/users/475d1c0c-c5e9-4053-93e7-931b6e80816a",
+            "authorPosition": "student, and attempting to became java developer",
+            "authorCompanySize": "Small-Business (50 or fewer emp.)"
+        },
+        "review": {
+            "reviewTags": [
+                "Current User",
+                "Validated Reviewer",
+                "Source: Organic"
+            ],
+            "reviewData": "2025-02-12",
+            "reviewRate": 4.5,
+            "reviewTitle": "Over 4 months of using services of Digital Ocean.",
+            "reviewLikes": "Support was very quick and informative, providing helpful assistance.\n\nFrom the perspective of ease of use, this is the first service of this type that I’m using, so it’s hard to judge as I have no comparison. However, the overall process wasn’t difficult, and I managed to achieve what I was looking for.",
+            "reviewDislikes": "If I had to point out something, it would be the price—and one situation I resolved with support, where I believe the price differed from what I signed up for. However, since I had the option to downgrade my plan, I'm still satisfied."
+        }
     }
-  },
-  {
-    "author": {
-      "authorName": "Filip S.",
-      "authorProfile": "https://www.g2.com/users/475d1c0c-c5e9-4053-93e7-931b6e80816a",
-      "authorPosition": "student, and attempting to became java developer",
-      "authorCompanySize": "Small-Business (50 or fewer emp.)"
-    },
-    "review": {
-      "reviewTags": [
-        "Current User",
-        "Validated Reviewer",
-        "Source: Organic"
-      ],
-      "reviewData": "2025-02-12",
-      "reviewRate": 4.5,
-      "reviewTitle": "Over 4 months of using services of Digital Ocean.",
-      "reviewLikes": "Support was very quick and informative, providing helpful assistance.\n\nFrom the perspective of ease of use, this is the first service of this type that I’m using, so it’s hard to judge as I have no comparison. However, the overall process wasn’t difficult, and I managed to achieve what I was looking for.",
-      "reviewDilikes": "If I had to point out something, it would be the price—and one situation I resolved with support, where I believe the price differed from what I signed up for. However, since I had the option to downgrade my plan, I'm still satisfied."
-    }
-  }
 ]

--- a/g2-scraper/results/reviews.json
+++ b/g2-scraper/results/reviews.json
@@ -1,588 +1,630 @@
 [
   {
     "author": {
-      "authorName": "Marlon P.",
-      "authorProfile": "https://www.g2.com/users/d523e9ac-7e5b-453f-85f8-9ab05b27a556",
-      "authorPosition": "Desenvolvedor de front-end",
-      "authorCompanySize": []
+      "authorName": "Rajnish K.",
+      "authorProfile": "https://www.g2.com/users/e400b2ec-3deb-4edd-b849-e236301a13ce",
+      "authorPosition": "Salesforce Trainee Consultant",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
     },
     "review": {
       "reviewTags": [
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
+        "Incentivized",
+        "Source: G2 invite"
       ],
-      "reviewData": "2023-11-14",
+      "reviewData": "2025-08-08",
       "reviewRate": 4.5,
-      "reviewTitle": "Good for beginners",
-      "reviewLikes": "It was very simple to start playing around and be able to test the projects I'm learning about for a cool price. I use it at work and it's easy to create new machines. Initial configuration is simple with the app Free tier is so short.  is now than the company need money but, for me 90 days it was very fast to user the credits. \n\nThere is an app configuration file that I find very annoying to configure. It would be cool if there was a way to test that locally. I've had a lot of problems that doing several deployments in production to see my app's configuration is ok. leave personal projects public. And in the company, when I have to use it, I find it very simple to use the terminal via the platform ",
-      "reviewDilikes": "Free tier is so short.  is now than the company need money but, for me 90 days it was very fast to user the credits. \n\nThere is an app configuration file that I find very annoying to configure. It would be cool if there was a way to test that locally. I've had a lot of problems that doing several deployments in production to see my app's configuration is ok. "
+      "reviewTitle": "Cloud Made Simple and Affordable, Just How I Like It",
+      "reviewLikes": "I really like how straightforward DigitalOcean is. Setting up a Droplet (their virtual server) takes just a few clicks, and the interface is clean enough that I never feel lost. The pricing is transparent-no hidden costs-and starts low enough to fit small projects or startups. Another plus is their huge library of community tutorials and guides, which makes solving issues a lot easier.",
+      "reviewDilikes": "Sometimes the support response time can be slow, especially during busy periods. I’ve also learned to keep extra backups, as I once had a managed database update cause some data loss. And while it’s perfect for simple to medium-scale projects, it lacks some of the advanced features you’d get from bigger cloud providers."
     }
   },
   {
     "author": {
-      "authorName": "Alberto G.",
-      "authorProfile": "https://www.g2.com/users/1e8b4d38-bc84-470d-a5a8-1be22fc4c95b",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorName": "Alejandro L.",
+      "authorProfile": "https://www.g2.com/users/honess",
+      "authorPosition": "CEO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
+        "Source: Organic"
       ],
-      "reviewData": "2023-11-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "Digital Ocean review",
-      "reviewLikes": "I like the agility, speed, and technology of DigitalOcean. I find the pricing of DigitalOcean's plans to be expensive. DigitalOcean is solving several problems for me. One of the key benefits is the simplification of cloud infrastructure management. It provides a user-friendly platform that makes it easier for me to deploy and manage servers and applications without the need for advanced technical expertise. Additionally, DigitalOcean's scalable infrastructure and fast provisioning times help me quickly adapt to changing resource demands, which is crucial for my projects. The availability of a wide range of pre-configured one-click applications and developer-friendly features also saves me time and effort. Overall, DigitalOcean's solutions have streamlined my workflow and reduced the complexities associated with cloud hosting, making it a more cost-effective and efficient choice for my needs. ",
-      "reviewDilikes": "I find the pricing of DigitalOcean's plans to be expensive. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Jailyn P.",
-      "authorProfile": "https://www.g2.com/users/ef6efaf5-57ad-4c59-95c4-0311a0c1833f",
-      "authorPosition": "A",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-14",
+      "reviewData": "2025-07-23",
       "reviewRate": 4.5,
-      "reviewTitle": "Reliable Hosting Service",
-      "reviewLikes": "DigitalOcean is one of the best cloud providers out there. I like the fact that it provides an easy to use platform with a variety of features and services that can be used to create a powerful and reliable cloud infrastructure. It also offers an intuitive user interface that makes it easy to set up and manage cloud servers quickly and efficiently. Additionally, the pricing is very competitive with other providers and the customer support is excellent. The company also offers an extensive library of tutorials and documentation to help users get the most out of the platform. DigitalOcean also provides a wide range of services, including dedicated servers, managed databases, object storage, and more. Furthermore, the company offers a variety of tools and features such as monitoring, logging, backups, and auditing, which make it easier to keep your cloud infrastructure secure and reliable. All in all, DigitalOcean is a great choice for anyone who wants to create and maintain a reliable cloud infrastructure with the help of a powerful and easy to use platform. DigitalOcean is a great cloud hosting service, but there are a few drawbacks. One of the biggest issues with DigitalOcean is its limited customer support. While they do offer 24/7 support for most issues, the response time can be slow, and there are only a few ways to contact them. Web hosting ",
-      "reviewDilikes": "DigitalOcean is a great cloud hosting service, but there are a few drawbacks. One of the biggest issues with DigitalOcean is its limited customer support. While they do offer 24/7 support for most issues, the response time can be slow, and there are only a few ways to contact them. "
+      "reviewTitle": "La mejor plataforma de IaaS que he probado... ¡Minimalismo absoluto!",
+      "reviewLikes": "DigitalOcean es simplemente excepcional por su enfoque minimalista que no sacrifica funcionalidad. Lo que más me gusta:\n\nSimplicidad sin compromisos: La interfaz es increíblemente limpia e intuitiva. En minutos puedes tener un droplet funcionando, sin configuraciones complejas innecesarias.\n\nPrecio transparente: No hay sorpresas en la facturación. Sabes exactamente lo que pagas por lo que usas, sin costos ocultos ni estructuras de precios confusas como otros proveedores.\n\nDocumentación excepcional: Sus tutoriales y guías son claros, directos y realmente útiles. La comunidad y el contenido educativo son de primera calidad.\n\nRendimiento consistente: Los droplets tienen un rendimiento predecible y confiable. Las SSD y la red funcionan exactamente como esperas.\n\nDeveloper-friendly: Perfecto para desarrolladores que quieren enfocarse en construir, no en luchar con la infraestructura. Las APIs son simples y bien documentadas.",
+      "reviewDilikes": "Menos servicios enterprise: Comparado con AWS o Azure, tiene menos servicios especializados. Pero honestamente, esto también es parte de su encanto minimalista.\n\nSoporte limitado en planes básicos: El soporte técnico premium requiere planes más costosos, aunque la documentación compensa mucho esto."
     }
   },
   {
     "author": {
-      "authorName": "Danny A.",
-      "authorProfile": "https://www.g2.com/users/bb327c9d-ee4c-46c5-a41b-ecd7c77bf01d",
-      "authorPosition": "LibreChat.ai",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "DDoS, Encrypted At Rest, Affordable, easy to setup",
-      "reviewLikes": "The aspects of DigitalOcean that stand out include its cost-effectiveness, transparent and straightforward billing, and competitive pricing. The user interface is very clear and intuitive, making it incredibly simple to create a cloud instance in seconds. Additionally, the speed performance of DigitalOcean is excellent, with an impressive record for load speed, which is a critical factor for web hosting. The platform also offers robust and reliable cloud servers with the convenience of one-click application installations, and the flexibility to easily scale the infrastructure with growing business needs is a significant advantage. One limitation is the reliance on CloudFlare, which restricts request times to a maximum of 100 seconds, leading to potential timeouts that cannot be altered. Additionally, the initial pricing for certain features, such as load balancers, being too high, though there has been a recent reduction in this cost. Despite these disadvantages, DigitalOcean's strengths in performance, pricing, and user experience seem to outweigh the drawbacks. Easy deployment ",
-      "reviewDilikes": "One limitation is the reliance on CloudFlare, which restricts request times to a maximum of 100 seconds, leading to potential timeouts that cannot be altered. Additionally, the initial pricing for certain features, such as load balancers, being too high, though there has been a recent reduction in this cost. Despite these disadvantages, DigitalOcean's strengths in performance, pricing, and user experience seem to outweigh the drawbacks. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Matt D.",
-      "authorProfile": "https://www.g2.com/users/mjd",
-      "authorPosition": "Computer Software",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Organic Review from User Profile"
-      ],
-      "reviewData": "2023-08-15",
-      "reviewRate": 4.0,
-      "reviewTitle": "Just what you'd expect from a cloud provider!",
-      "reviewLikes": "DigitalOcean is an easy option at an affordable price, compared to most of it's competitors, Digital Ocean offers some really low prices and no surprise costs which make it really easy to trust. Their specifications are fair and it's easy to launch a Droplet or other server type anywhere in their range of regions.\n\nThe company offer a variety of different server types as well as other services which means you have a lot of versatility with the platform to run multiple different parts of your business on one cloud system. There are also free options for products such as Functions, which while limited are still generous and useful for specific use cases. The platform offered by DigitalOcean lacks the depth that certain other Platforms such as AWS contains. DigitalOcean lock port 25 on Droplets making it impossible to use for email without an external SMTP relay. DigitalOcean also do not offer an SMTP relay of their own, making it necessary to look elsewhere for such a tool if you plan to use the server for email hosting - as someone managing a web server this is disappointing, but not a dealbreaker. As a web development business we host our clients' websites to close the room for confusion that this entails for someone unexperienced in the industry. No small business owner out there selling their product needs a second 9 to 5 to manage their website. We were finding that any host we tried to use to host our client's sites was costing a lot of money and we needed to change this, so we opted to setup our own servers using DigitalOcean to make a cost-effective way to manage our clients' websites. DigitalOcean costs us a fraction of the cost to get all of our client's sites online as well as our own, meaning we don't have to charge as much, and we have full control of what's going on! ",
-      "reviewDilikes": "The platform offered by DigitalOcean lacks the depth that certain other Platforms such as AWS contains. DigitalOcean lock port 25 on Droplets making it impossible to use for email without an external SMTP relay. DigitalOcean also do not offer an SMTP relay of their own, making it necessary to look elsewhere for such a tool if you plan to use the server for email hosting - as someone managing a web server this is disappointing, but not a dealbreaker. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Jason M.",
-      "authorProfile": "https://www.g2.com/users/48be773c-88ba-4784-a9c2-645854d1cffc",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-14",
-      "reviewRate": 5.0,
-      "reviewTitle": "Reliable easy to use cloud provider",
-      "reviewLikes": "Digital ocean is reliable, my droplets and apps just work. The basics are all there, networking and basic monitoring are just present. It lets us focus on our products and services and not being cloud architects. In some cases the major cloud providers offer services that abstract away complexity and these services make unskilled corporate types feel more secure in choosing them. Our company isn't one of those but I have worked for some. Hosting services like web, api, email and other internal services. ",
-      "reviewDilikes": "In some cases the major cloud providers offer services that abstract away complexity and these services make unskilled corporate types feel more secure in choosing them. Our company isn't one of those but I have worked for some. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "David B.",
-      "authorProfile": "https://www.g2.com/users/c14b873e-1991-43fb-9a0a-76e955c154ae",
-      "authorPosition": null,
-      "authorCompanySize": []
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-08-11",
-      "reviewRate": 5.0,
-      "reviewTitle": "Very reliable and friendly support",
-      "reviewLikes": "The digitalocean.com is my favourite hosting company after 16 years of using different hosting providers.  Their droplets actually perform better over other same sized providers and save me tons of usd over other providers.  Their support team respond to inquiries very fast and supportive. Nothing special.  Recently they have implemented a system to block users to create additional resources when there is an account due. This is not good as we are paying end of the month and the digitalocean.com bill on the 1st of each month. Cost efficient reliable cloud hosting service that has limitless possibilities to to scale.  We host over 400 websites and applications with them and some LMS have 50000 students. ",
-      "reviewDilikes": "Nothing special.  Recently they have implemented a system to block users to create additional resources when there is an account due. This is not good as we are paying end of the month and the digitalocean.com bill on the 1st of each month. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Ribiro M.",
-      "authorProfile": "https://www.g2.com/users/9206b3d8-f477-4e1c-91af-060e129fdd23",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-08-14",
-      "reviewRate": 5.0,
-      "reviewTitle": "I have had a seamless experience over the past 4 years.",
-      "reviewLikes": "Digital Ocean is relatively affordable and considering I was just getting started in my career when I first used it, I could easily afford their services, which are more in value than what paid for. In addition, I enjoy the community part, which has always provided me with solutions whenever I am stranded. Well, I can't quite identify a downside of the digital ocean as I have always chosen it any day any time over any other available solutions. Digital Ocean has continually incorporated automation, which is good considering my work's nature. This automation has made it easier to use and, at the same time, made it more fun. ",
-      "reviewDilikes": "Well, I can't quite identify a downside of the digital ocean as I have always chosen it any day any time over any other available solutions. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Martin s.",
-      "authorProfile": "https://www.g2.com/users/bda4f13a-9cc6-49dc-9cab-49e7756f122b",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "A very good overall experience",
-      "reviewLikes": "The entire interface is relatively easy to understand. Droplets are a very fast and elegant way to deploy a project. I have also had good experiences with assistance. I would like them to improve docs a little I don't have that much experience with dev ops stuff, so having a simple way to be able to deploy a project is the benefit from DO for me ",
-      "reviewDilikes": "I would like them to improve docs a little "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Paolo G.",
-      "authorProfile": "https://www.g2.com/users/ff5559c1-da9d-454a-ad28-c060ab64e13d",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-08-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "Using Digital Ocean as our primary VPS supplier since 2015 and we never had an issue.",
-      "reviewLikes": "What we like the most is that everything works as expected and we haven't had any issue in 8 years. Maybe a couple of minor issues, but nothing that the support didn't resolve or helped us resolve in short time. We don't have any diskile about DigitalOcean. Maybe the only thing that we would like to see are discount on bigger usage, maybe something proportional that would make them competitive with dedicated servers. We needed a reliable supplier with an easy to use interface, with predictables prices, and when we tried Digital, 8 years ago, we were hooked by the products. It's been a long journey but very pleasant. ",
-      "reviewDilikes": "We don't have any diskile about DigitalOcean. Maybe the only thing that we would like to see are discount on bigger usage, maybe something proportional that would make them competitive with dedicated servers. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "JEFREY D.",
-      "authorProfile": "https://www.g2.com/users/cd0499ac-7678-4e6a-806c-b6f537ca5797",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-05-15",
-      "reviewRate": 5.0,
-      "reviewTitle": "My DigiOcean Journey",
-      "reviewLikes": "Ease of Use: DigitalOcean provides a user-friendly interface and intuitive tools, making it easy for developers to deploy, manage, and scale their applications and infrastructure.Developer-Focused Features: DigitalOcean offers a range of developer-friendly features, such as pre-configured droplets (virtual machines), one-click application deployments, and extensive documentation, enabling developers to quickly get started with their projects.Scalability: DigitalOcean allows users to easily scale their infrastructure as their needs grow. They provide flexible options to resize droplets, add more resources, or leverage load balancers to handle increased traffic.Cost-Effective: DigitalOcean offers competitive pricing and transparent billing. They provide various pricing plans to suit different project requirements, and their pricing structure is straightforward, allowing users to estimate and control their costs effectively.Community and Support: DigitalOcean has a vibrant community of developers and a vast collection of tutorials, articles, and Q&A resources. Additionally, they provide reliable support services to assist users with any technical issues or inquiries they may have. Limited Service Offerings: DigitalOcean focuses primarily on providing cloud infrastructure services, such as virtual machines (droplets), storage, and networking. While they offer additional services like managed databases and load balancers, their service portfolio may be less extensive compared to some larger cloud providers.Geographical Availability: DigitalOcean has data centers in specific regions, which may limit the options for deploying infrastructure in certain geographic locations. Support Response Times: While DigitalOcean provides support services, Sometimes there are longer response times for support tickets during peak periods. Making droplets and market place ready bundled applications easily accessible and deployable. ",
-      "reviewDilikes": "Limited Service Offerings: DigitalOcean focuses primarily on providing cloud infrastructure services, such as virtual machines (droplets), storage, and networking. While they offer additional services like managed databases and load balancers, their service portfolio may be less extensive compared to some larger cloud providers.Geographical Availability: DigitalOcean has data centers in specific regions, which may limit the options for deploying infrastructure in certain geographic locations. Support Response Times: While DigitalOcean provides support services, Sometimes there are longer response times for support tickets during peak periods. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Hassan B.",
-      "authorProfile": "https://www.g2.com/users/517f474e-41c4-4df3-80aa-4dd013e3e374",
-      "authorPosition": "Senior Software Engineer",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-10",
-      "reviewRate": 5.0,
-      "reviewTitle": "Software Engineer",
-      "reviewLikes": "Digitalocean is a very developer friendly IAAS and well documented. I always use it and recommend it to my clients. The thing I hope for in Digitalocean is to have a presence in the Middle East region as Amazon did. Block storage (space) is the main service I use for my apps, it fulfill my needs and has full usage API. ",
-      "reviewDilikes": "The thing I hope for in Digitalocean is to have a presence in the Middle East region as Amazon did. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Dan B.",
-      "authorProfile": "https://www.g2.com/users/7559b8fa-3a9f-46a1-9274-b696ce9570e2",
-      "authorPosition": "Founder",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Review source: Thank You page"
-      ],
-      "reviewData": "2023-07-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Been using DigitalOcean for over 10 years...",
-      "reviewLikes": "I have been using DigitalOcean for around a decade now for various sized servers, both for my own solutions as well as client solutions. In all this time I almost never had any interactions with their customer service - this in itself warrants for a review! \n\nHowever, for the last two weeks I was attempting something mailserver-related more complicated, and one particular support team member was amazing, and it is what is making me write this review... \n\nS*j*n (omitting actual full name for privacy purposes) is a legendary customer service representative and server administration expert. Thank you! To be fair, not all team members at the support team were great, there were some canned responses on occasion, but for me it's the result that counts. From a tech point of view there have never been any issues. Save time. Have a functioning server. ",
-      "reviewDilikes": "To be fair, not all team members at the support team were great, there were some canned responses on occasion, but for me it's the result that counts. From a tech point of view there have never been any issues. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Aaron A.",
-      "authorProfile": "https://www.g2.com/users/416b60ac-053d-48b4-8f89-30429294f406",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-08-10",
-      "reviewRate": 5.0,
-      "reviewTitle": "great experience and I'm in control",
-      "reviewLikes": "The droplets let you control the OS completely. No annoying site builder for those of us that don't want it. DigitalOcean is the best solution for real nerds that want to configure everything themselves. In all my time using DigitalOcean, I have not encountered anything that I dislike so far. They keep me notified about any maintenance that is scheduled- which also has not affected me. DigitalOcean offers a very economic product tier that I was not able to find elsewhere. Other websites charge much higher prices because they add so much that I don't need right now. ",
-      "reviewDilikes": "In all my time using DigitalOcean, I have not encountered anything that I dislike so far. They keep me notified about any maintenance that is scheduled- which also has not affected me. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Jay K.",
-      "authorProfile": "https://www.g2.com/users/b3ee3ecb-c124-4a22-b8cf-f58b7168f159",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Organic"
-      ],
-      "reviewData": "2023-08-04",
-      "reviewRate": 4.0,
-      "reviewTitle": "Best instant VPS infrastructure provider with awesome tech support!",
-      "reviewLikes": "Their vast line of products meet almost all requirements any business can have for their digital virtual or cloud infrasturcture. From a simple testing server to critical servers, they have it all at affordable cost The intital learning curve could be an issue for new users but being a quick learner, I adopted to the DO wrold very quickly because of adaquate support marial available instantly. We host all our websites on DO. We are also a part of DO Hatch program for startups. We have been able to test and host all our digital products with help of DO infrastructure. ",
-      "reviewDilikes": "The intital learning curve could be an issue for new users but being a quick learner, I adopted to the DO wrold very quickly because of adaquate support marial available instantly. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Manuel Ignacio R.",
-      "authorProfile": "https://www.g2.com/users/1c010af5-a2be-4b8e-8c16-90d446a644c2",
-      "authorPosition": "Senior Software Engineer",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "great platform, simple to use!",
-      "reviewLikes": "Product offering is a whole is very complete and holistic for independent development, personal projects and more. I like their abstractions for computing resources, storage, backups, etc Haven't run into any issues for the past 3 years that I've been using them Hosting websites, backups, CRM management ",
-      "reviewDilikes": "Haven't run into any issues for the past 3 years that I've been using them "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Michael H.",
-      "authorProfile": "https://www.g2.com/users/jwx",
-      "authorPosition": "Founder, Developer",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: G2 invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-04-11",
-      "reviewRate": 4.5,
-      "reviewTitle": "Affordable, Simple (yet powerful) VPS Hosting",
-      "reviewLikes": "I LOVE their one-click application install via their marketplace. They also have an insanely huge collection of applications that can be deployed in minutes. Unlike other Cloud Platforms, which also have a large marketplace; involving many enterprise applications, DigitalOean focus more on the latest technology software that a normal user would experiment with or use in production. This is common with many cloud providers, but I really wish they would let you scale down a droplet (which is basically a virtual machine deployed). If you notice your website or application takes nowhere near the amount of power you created, instead of doing a complete replica, a scale-down option would be amazing. I wouldn't even mind paying for the feature if reasonable. When I want a very quick environment to test a new application I am working on, I can launch a 'droplet' which is a VM (virtual machine) in minutes without needing to use my own computer as an environment. You can quickly point a domain to its DNS, enable monitor (for free) and pick just the right environment that you need. Once I am done, I can either let it run (which is really affordable) or destroy the droplet. I'm not a fan of using my own computer has a sandbox, and DigitalOcean fixes this issue for me. I don't only use it for development, but I also use it for staining and production. ",
-      "reviewDilikes": "This is common with many cloud providers, but I really wish they would let you scale down a droplet (which is basically a virtual machine deployed). If you notice your website or application takes nowhere near the amount of power you created, instead of doing a complete replica, a scale-down option would be amazing. I wouldn't even mind paying for the feature if reasonable. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Diogo P.",
-      "authorProfile": "https://www.g2.com/users/762b45e4-1dbe-4689-b863-8fff34d627bf",
-      "authorPosition": "Desenvolvedor sênior",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-11-09",
-      "reviewRate": 5.0,
-      "reviewTitle": "Very easy very cheap",
-      "reviewLikes": "A service that grows in the variety of services but maintains simplicity in the way it is used Some tools still need improvement, I believe they could greatly improve the use of db hosting my server, automatic container deployment ",
-      "reviewDilikes": "Some tools still need improvement, I believe they could greatly improve the use of db "
-    }
-  },
-  {
-    "author": {
-      "authorName": null,
+      "authorName": "Verified User in Marketing and Advertising",
       "authorProfile": null,
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
+        "Rating Updated (8/7/2025)",
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
+        "Source: Organic"
       ],
-      "reviewData": "2023-11-09",
+      "reviewData": "2025-07-31",
       "reviewRate": 5.0,
-      "reviewTitle": "It's Awesome for development  but needs more regions for production",
-      "reviewLikes": "Pricing is predictable, Easy setup, Great UI Regions like Latam need to be addresable it would be great to have predictable pricing on insfratructure to serve latam and think on putting an app to production with DO, the developer experience is great I have yet to learn more on other servicer more than Droplets but is great. In the development cycle is great to predic how much it will cost all the insfracture. ",
-      "reviewDilikes": "Regions like Latam need to be addresable it would be great to have predictable pricing on insfratructure to serve latam and think on putting an app to production with DO, the developer experience is great I have yet to learn more on other servicer more than Droplets but is great. "
+      "reviewTitle": "Simple, Reliable, and Developer-Friendly Cloud Hosting",
+      "reviewLikes": "DigitalOcean stands out for its simplicity, reliability, and developer-friendly environment. The UI is clean and intuitive, making it easy to deploy and manage droplets even for those who aren’t full-time sysadmins.\n\nTheir documentation is top-tier—comprehensive, well-organized, and beginner-friendly, which really speeds up troubleshooting and learning. Pricing is transparent and affordable, especially for small businesses and startups looking to scale gradually. \n\nI also appreciate their growing ecosystem of products like Spaces, Managed Databases, and Kubernetes support.",
+      "reviewDilikes": "There’s not much to dislike, but if I had to point something out, it would be that some advanced features and monitoring tools are more limited compared to larger cloud providers like AWS or GCP. While that keeps things simpler, power users might miss certain enterprise-grade options or integrations. That said, for the vast majority of use cases, DigitalOcean more than delivers."
     }
   },
   {
     "author": {
-      "authorName": null,
+      "authorName": "Verified User in Information Technology and Services",
       "authorProfile": null,
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: G2 invite",
-        "Incentivized Review"
+        "Incentivized",
+        "Source: G2 invite"
       ],
-      "reviewData": "2023-05-29",
-      "reviewRate": 5.0,
-      "reviewTitle": "Best Cloud Service Provider",
-      "reviewLikes": "Digital Ocean is the best cloud service provider. They provide various services like Storage, Database, Computing (Droplets). The best thing I like about digital ocean is that they give free credits for 60 days, which helps a person to try their platform. They have one of the best & most up-to-date documentations. One thing I dislike about DigitalOcean is that they don't have many geographical locations for the droplets; as feedback, I would love to see more locations, even in the India region. I am using DigitalOcean droplets & Spaces to do most of my business, and that's the thing I love most about the DigitalOcean I can manage my whole business over one place. ",
-      "reviewDilikes": "One thing I dislike about DigitalOcean is that they don't have many geographical locations for the droplets; as feedback, I would love to see more locations, even in the India region. "
+      "reviewData": "2025-07-31",
+      "reviewRate": 4.0,
+      "reviewTitle": "Simple, Affordable, and Reliable Cloud Hosting",
+      "reviewLikes": "What I like best about DigitalOcean is its intuitive and clean interface, which makes managing servers and deployments incredibly straightforward - even for users who aren’t cloud experts. The pricing is also very transparent and affordable, allowing me to scale projects without worrying about unexpected costs. On top of that, the platform’s performance is consistently reliable, with fast server response times and minimal downtime, which is essential for my work.",
+      "reviewDilikes": "While I’m generally very satisfied with DigitalOcean, if I had to mention a downside, it would be that some advanced features and integrations found in larger cloud providers are missing or require more manual setup. Additionally, more detailed documentation or tutorials for certain use cases would be helpful for users looking to expand their projects."
     }
   },
   {
     "author": {
-      "authorName": "Rupesh C.",
-      "authorProfile": "https://www.g2.com/users/c0eaa0a0-6cd2-4975-bbe7-08715c94d93d",
+      "authorName": "Azeem C.",
+      "authorProfile": "https://www.g2.com/users/207c0228-9ccb-4a33-a321-1825ea6ea0aa",
+      "authorPosition": "Senior Software Engineer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-05-07",
+      "reviewRate": 4.5,
+      "reviewTitle": "Very good selection of services. 99.99% Uptime.",
+      "reviewLikes": "DigitalOcean has very good selection of services. You can create VPS server of all sizes and quantities. For instance, you can create a vps host (with 1cpu and 10gb hard disk) for as little as $4 per month. It can go all the way up to $1630/mo with 60 CPUs. \n\nYou can create GPU droplets as well.\n\nOther think is about almost 100% uptime. Initially there some speed issues over the past. It could kick in once or twice in a month. But I think DigitalOcean has worked on this. I created an uptime monitoring service  (which also is from DigitalOcean). It says, last outage was around 175 days ago. That is very nice.\n\nIt's website is neatly structured. Great ease of use.\n\nCustomer support is also very good. Very responsive. I am using the free plan. In this plan, they reply you within 24 hours. Every time I opened  a ticket, they would promptly answer it.",
+      "reviewDilikes": "I dislike a couple of things about DigitalOcean. Centos 10 was released on December 12, 2024. But it is not available yet in DigitalOcean as of today (7th May). Other providers like Vultr has it already. The selection of linux distributions is also limited. Compared to Vultr, DigitalOcean does not have that much choice of linux distributions."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Ujjwal A.",
+      "authorProfile": "https://www.g2.com/users/301601e8-18fc-4b96-9343-0f274646d0da",
+      "authorPosition": "Devops Engineer",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 invite"
+      ],
+      "reviewData": "2025-08-07",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best and Developer Friendly Cloud Platform",
+      "reviewLikes": "1 - Very Easy to setup and manage droplets that is we can spin up servers or apps in just few minutes.\n2 - Simple and Clean UI\n3 - Transparent pricing we always know what we are spending\n4 - Great documentation and community support",
+      "reviewDilikes": "1 - It has limited advanced services when comapred to aws.\n2 - Load balancer and monitoring features are basic."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Lajith K.",
+      "authorProfile": "https://www.g2.com/users/811058dd-d83a-4d36-8e1e-f5da661c499d",
       "authorPosition": "Software Engineer",
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
+        "Incentivized",
+        "Source: Seller invite"
       ],
-      "reviewData": "2023-11-09",
+      "reviewData": "2025-04-28",
       "reviewRate": 5.0,
-      "reviewTitle": "Its great for hosting apps and easy to maintain",
-      "reviewLikes": "Its is very helpfull to manage vps and full access of controll VAT invoices are not generated for nepal It gives 100% uptime to my vps and makes me easy to work from anywhere ",
-      "reviewDilikes": "VAT invoices are not generated for nepal "
+      "reviewTitle": "Fast & secure & most reliable",
+      "reviewLikes": "Clean UI & UX: The control panel is intuitive and uncluttered, making it easy to spin up and manage virtual machines, databases, and other services even for beginners.\n\nTransparent pricing: Their pricing model is straightforward and predictable—especially attractive for startups and developers who need to keep tight control over costs.\n\nDeveloper community & documentation: DigitalOcean has built a strong library of tutorials and guides, which are often more accessible and practical than what you find from bigger cloud providers.\n\nDroplets (VMs): Launching a Droplet is fast, and performance tends to be solid for most general-purpose applications.\n\nManaged services: They’ve expanded into managed databases, Kubernetes, app platform (PaaS), etc., offering more flexibility while maintaining simplicity.",
+      "reviewDilikes": "Additional payment methods should be introduced to support currencies other than the US Dollar, such as Indian Rupees for customers in India."
     }
   },
   {
     "author": {
-      "authorName": null,
+      "authorName": "Jeff L.",
+      "authorProfile": "https://www.g2.com/users/430b4bb4-4514-4d75-b9a9-d71643a1a26a",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 4.0,
+      "reviewTitle": "Two Years with DigitalOcean: A Simple and Smooth Experience for My Projects",
+      "reviewLikes": "I've been using DigitalOcean for two years to support my own project. What stands out the most is how easy it is to use. The platform is beginner-friendly, the UI is clean, and setting up servers or other resources is straightforward without needing to dig through complex configurations. This simplicity helped me focus more on building my project rather than managing infrastructure.",
+      "reviewDilikes": "One downside I've noticed is the lack of a free tier for cloud databases. For beginners or small projects, having a zero-cost starting point would make it easier to experiment and grow without upfront costs. Compared to other providers that offer limited free database options, this can make DigitalOcean feel less accessible for early-stage users."
+    }
+  },
+  {
+    "author": {
+      "authorName": "David P.",
+      "authorProfile": "https://www.g2.com/users/27dfd888-c410-43b1-84ec-33bba5a98e37",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Very flexible, powerful API and website, decent prices!",
+      "reviewLikes": "As an occasional web developer and someone who wants to move forward with creating a bunch of powerful APPs in the future... Digital Ocean allows me to expand as my needs fit.  I also love the fact I can choose to run my websites/APP's on AMD processors.\n\nIf you need more space... drag the slider.  If you want another droplet, add one.  If you want a load balancer, add one.  It's very flexible and even as an intermediate web developer their systems are quite well done.\n\nPrices seem fair and we use the Toronto location for hosting.  We are now hosting 12 domains on a single simple low cost server.  We will be expanding and coding for years to come and at least we know that if we need more... Digital Ocean can handle it.",
+      "reviewDilikes": "Using G2 to submit a review.  After finishing the entire review, it FAILED to submit for no reason whatsoever...   I wasted 25 min of my time.\n\nI had very detailed answers in every category to be very thorough...  the question remains... should I redo everything and waste another 25 min only to have it fail again?   And now, most likely won't be chosen for the $25 gift card all because your site wouldn't submit my review and I don't feel like giving super detailed answers having to do this twice.  \n\nUgh...\n\n--------\nI am just going to summarize my answers since I already gave detailed ones...   please fix your website.\n--------\nMy answer for what I dislike about DO?\n\nSo far nothing.  It's been fine, but as I had posted on before, if I had to find a fault with DO...  (ugh)... I can't even remember what I wrote now.  How frustrating this has become.   I'm on a deadline, thought this wouldn't take that long... and now that I have to redo it... I'm all frustrated... can't think..."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Luca P.",
+      "authorProfile": "https://www.g2.com/users/lucapiccinotti",
+      "authorPosition": "✅ CTO - Growth Marketer full stack #MarTech | ⚡️ SaaS Advisor",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "G2 Icon",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: G2 Gives Campaign"
+      ],
+      "reviewData": "2025-07-04",
+      "reviewRate": 5.0,
+      "reviewTitle": "Reliable cloud infrastructure for developers and SMBs",
+      "reviewLikes": "DigitalOcean delivers a robust suite of cloud infrastructure products tailored for developers, startups, and SMBs.\n\nThe platform stands out for its intuitive user interface and predictable pricing model, which simplifies resource management and cost forecasting. Key features include Droplets (scalable Linux-based virtual machines), a fully managed Kubernetes service with a free control plane, and an App Platform for rapid deployment of web applications and APIs using PaaS principles. \n\nIt supports managed databases (PostgreSQL, MySQL, MongoDB, Kafka), object storage (Spaces), and block storage. Recent additions like GPU compute options (via the Paperspace acquisition) and GenAI Platform for building and deploying AI agents expand its capabilities for machine learning and generative AI workloads.\n\nThe API ecosystem is comprehensive, enabling automation and integration across a range of programming languages. One-click app deployment (e.g., WordPress, Docker) and clear documentation further streamline the developer experience.",
+      "reviewDilikes": "While the overall experience is streamlined, I find that advanced configuration options can be limited in some managed services, particularly within the App Platform. Customizing deployment environments sometimes requires restarting instances from scratch, which may result in lost changes if not managed carefully. Additionally, migration to other public clouds is not always straightforward, and the process can be confusing or restrictive in certain scenarios."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Deepjyoti R.",
+      "authorProfile": "https://www.g2.com/users/950f009b-cfc1-409f-87d2-27f93975ffda",
+      "authorPosition": "Cyber Security Analyst",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (8/3/2025)",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-08-01",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best cloud provider for beginners",
+      "reviewLikes": "Digital Ocean is easy to use, with a clean interface and simple pricing. Setting up servers takes minutes. A strong community make it friendly, reliable, and great for beginners.",
+      "reviewDilikes": "Sudden account lockouts, limited OS choices and unexpected data deletion."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vee D.",
+      "authorProfile": "https://www.g2.com/users/6bc9b282-76bf-47bf-959d-8ef874dce3cd",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.5,
+      "reviewTitle": "Long time customer, still going strong",
+      "reviewLikes": "Love the fact that they are one of the most transparent providers. I've been with them since 2016, regularly. Contemplated moving to AWS but I cannot deal with the complexity for now.\n\nSome products can make it expensive but the ease of use and implementation makes me want to stay.\n\nMoreover, their blog is always updated - which requires less support and customer service emails!",
+      "reviewDilikes": "Wish their functions section was a little bit easier to debug. Had to go back to my own personal VPS functions because DO Functions wasn't easy to debug."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Consulting",
       "authorProfile": null,
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
+        "Current User",
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Organic"
+        "Incentivized",
+        "Source: Seller invite"
       ],
-      "reviewData": "2023-10-08",
-      "reviewRate": 0.0,
-      "reviewTitle": "Worst Customer Support of any Cloud Providers by Far",
-      "reviewLikes": "Clean administration interface. Not many features but reliable. The customer support is close to non existent, non-helpful and borderline disrepectful.\n\nThey use other companie's technology (i.e S3 for storage) but only implement it halfway. You spend hours debugging an issue on your side when it's actually missing on their side. And when you contact support  first thing the do is  to push you the fault on your implementation, tell you to read the doc, and then disappear for the next 24h. Cloud provider. ",
-      "reviewDilikes": "The customer support is close to non existent, non-helpful and borderline disrepectful.\n\nThey use other companie's technology (i.e S3 for storage) but only implement it halfway. You spend hours debugging an issue on your side when it's actually missing on their side. And when you contact support  first thing the do is  to push you the fault on your implementation, tell you to read the doc, and then disappear for the next 24h. "
-    }
-  },
-  {
-    "author": {
-      "authorName": "Derotino S.",
-      "authorProfile": "https://www.g2.com/users/deb4eaf1-d6ec-453f-9c60-80b384d05890",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-05-16",
+      "reviewData": "2025-02-12",
       "reviewRate": 5.0,
-      "reviewTitle": "DigitalOcean: Exceptional Support and Performance",
-      "reviewLikes": "I am extremely satisfied with the exceptional support and outstanding performance they offer. The support team is always responsive, knowledgeable, and goes above and beyond to assist with any issues or inquiries. The performance of their services is top-notch, providing fast and reliable infrastructure that consistently meets my expectations. I highly recommend DigitalOcean for their remarkable support and impressive service performance. While DigitalOcean has many advantages, it's important to acknowledge a couple of limitations. One downside is the limited flexibility in terms of memory and processing combinations. Depending on your specific requirements, you may find it challenging to fine-tune the allocation of resources to match your needs precisely.\n\nAnother drawback is the pricing structure when a droplet (virtual machine) is powered off. DigitalOcean charges for the allocated resources even if the droplet is not actively running. This can be a disadvantage if you frequently need to pause or turn off your droplets to save costs.\n\nDespite these limitations, DigitalOcean still offers a robust cloud platform with excellent support and performance. It's important to consider your specific use case and evaluate whether these disadvantages significantly impact your workflow before making a decision. With DigitalOcean, you can quickly create and configure droplets without the need for complex setup processes. This benefits users by saving time and making it simpler to run their applications or websites in the cloud. In terms of security, DigitalOcean offers various features to protect your droplets and data. They provide firewall options to control incoming and outgoing network traffic, ensuring only authorized connections are allowed. DigitalOcean also offers private networking, which allows you to isolate your droplets from the public internet and enhance the security of your infrastructure. ",
-      "reviewDilikes": "While DigitalOcean has many advantages, it's important to acknowledge a couple of limitations. One downside is the limited flexibility in terms of memory and processing combinations. Depending on your specific requirements, you may find it challenging to fine-tune the allocation of resources to match your needs precisely.\n\nAnother drawback is the pricing structure when a droplet (virtual machine) is powered off. DigitalOcean charges for the allocated resources even if the droplet is not actively running. This can be a disadvantage if you frequently need to pause or turn off your droplets to save costs.\n\nDespite these limitations, DigitalOcean still offers a robust cloud platform with excellent support and performance. It's important to consider your specific use case and evaluate whether these disadvantages significantly impact your workflow before making a decision. "
+      "reviewTitle": "Very easy-to-use interface and instant response droplets",
+      "reviewLikes": "I like how easy it is to create and destroy droplets. I also like how reponsive the servers are – every change or request is instant.  This makes it effortless to implement complex applications including complex web apps. The uptime is just so good. \n\nI feel the best part is the pricing. I run a small business and DigitalOcean's packages are quite affordable.\n\nCustomer support is always available and responds within a reasonable time.",
+      "reviewDilikes": "Every experience I've had with DigitalOcen has been wonderful. I can't think of anything I dislike."
     }
   },
   {
     "author": {
-      "authorName": "Carlo W.",
-      "authorProfile": "https://www.g2.com/users/394e0bfa-c5ad-4e81-8ce6-8f9e29ae2603",
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
-    },
-    "review": {
-      "reviewTags": [
-        "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
-      ],
-      "reviewData": "2023-02-28",
-      "reviewRate": 5.0,
-      "reviewTitle": "Fantastic platform with an equally as fantastic support behind it",
-      "reviewLikes": "The user interface by far, is the standout item to me. This is because there is never really a question of whether something does the thing you want or is the thing you are looking for.\n\nIt is clean, clear and understandable, from launching a particular service to understanding your billing.\n\nI have been using DigitalOcean for a long time, and I have watched them add so many services to the platform; usually, with the addition of services, there is a degradation in usability due to the complexities introduced with each, but at every step, they have put thought and time into the design.\n\nAs I switched from more traditional server-based setups to App Platform, I can honestly say that that was the easiest and smoothest transfer I have done. There aren't too many downsides that I have run into. In most cases they listen to their community and provide updates regularly. The only gripe I would have (and I am really stretching here) is that sometimes their documentation can be lacking key specifications and I have to rely on the community for answers. I needed a platform to host my upcoming AI-based app from frontend to middleware to backend with databases, block storage and machine learning. I didn't want all of my technology in different servers, on different platforms, and custom-created to run on a particular infrastructure. As such, DigitalOcean provided me with all of the above and made it next to seamless to integrate with each other. ",
-      "reviewDilikes": "There aren't too many downsides that I have run into. In most cases they listen to their community and provide updates regularly. The only gripe I would have (and I am really stretching here) is that sometimes their documentation can be lacking key specifications and I have to rely on the community for answers. "
-    }
-  },
-  {
-    "author": {
-      "authorName": null,
+      "authorName": "Verified User in Internet",
       "authorProfile": null,
-      "authorPosition": null,
-      "authorCompanySize": [
-        "Small-Business",
-        "(50 or fewer emp.)"
-      ]
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.0,
+      "reviewTitle": "Stable and easy to use cloud solution",
+      "reviewLikes": "Ease of use, basically instant set up of new droplets or other products, straightforward approach on accessing your resources. Essentially it's set and forget, which is the best.",
+      "reviewDilikes": "Pricing, lack of granularity on upgrading/changing configuration of products. There is a lot of options for droplets, but as a one-man hobbyist I just need a small enough server with non-standard RAM size, and I am locked on a config that's not ideal for me. Same for the database, it is a pain to set up some advanced use cases, or it's impossible at all (like implementing a specified PostgreSQL extension)."
+    }
+  },
+  {
+    "author": {
+      "authorName": "J. Antonio A.",
+      "authorProfile": "https://www.g2.com/users/d87dba53-7035-4e91-b4df-7d7a0c4300bc",
+      "authorPosition": "Product Manager",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
     },
     "review": {
       "reviewTags": [
         "Validated Reviewer",
-        "Verified Current User",
-        "Review source: Seller invite",
-        "Incentivized Review"
+        "Incentivized",
+        "Source: Seller invite"
       ],
-      "reviewData": "2023-08-10",
+      "reviewData": "2025-02-12",
+      "reviewRate": 4.5,
+      "reviewTitle": "Awesome service, performance and cost somehow very technical but totally worthy",
+      "reviewLikes": "I like everything is super clear about the costs and features you'll get. There's also a lot of tutorials in blogs in youtube so it was then easy to use, implement and then integrate with my stuff. Getting some coupons for start was the key to me to migrate my services here, it felt like no risk and their Customer Support help me with a couple of questions. Security and Stability were another factors to consider, because of the nature of my frequent use of the service.",
+      "reviewDilikes": "Even DigitalOcen offers different easy-to-config options, it can be perceived as a hard choice for tech people with few time or the regular people who just want to set a website or service."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Gerardo  B.",
+      "authorProfile": "https://www.g2.com/users/e544c460-bc69-46ab-969c-13674bfc673f",
+      "authorPosition": "Co-founder. COO y Administración de los servidores",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
       "reviewRate": 5.0,
-      "reviewTitle": "Great, affordable and easy to use cloud provider",
-      "reviewLikes": "Simplicity. Apps are my favourite service provided by DO, configuration is straightforward and easy, but also allows more advanced setup.\nBringing up infranstructure is hassle free.\nThere is no steep learning curve, you can always start simple and then do more advanced setups. I'd like to say prices but it's really one of the cheapest cloud provider on market. Maybe an official mobile app for management would be nice but it isn't a must have. It gives me an easy way to deploy my apps and do play with them when prototyping. Limiting the overhead related to infrastructure configuration and automation saves me a lot of time. ",
-      "reviewDilikes": "I'd like to say prices but it's really one of the cheapest cloud provider on market. Maybe an official mobile app for management would be nice but it isn't a must have. "
+      "reviewTitle": "Simplicidad de un producto que funciona",
+      "reviewLikes": "Primero es que cumple con su funcionalidad con una baja o casi nula curva de aprendizaje en desplegar nuevas implementaciones. Nos abastece de sus servicios en los cuales confiamos y ponemos nuestro trabajo día a día, minuto a minuto desde desde después de la pandemia. Gracias a Digital Ocean nosotros estamos online con nuestra propuesta y llegamos a nuestros usuarios de todo Latam y parte de Europa. Realmente nos sentimos muy cómodos aquí y no nos interesa cambiarnos de proveedor en el mediano plazo (tampoco en el largo plazo). \nAntes de ser clientes de Digital Ocean, ya consultábamos toda la buena documentación de la comunidad, eso es algo que nos fue y es de mucha ayuda, principalmente en los momentos de inicio de los desarrollos y al adoptar nuevas tecnologías. \nEl soporte de cliente, lo hemos utilizado muy pocas veces, casi nunca, y siempre hemos tenido la mejor atención solucionando y aclarando los distintos inconvenientes.",
+      "reviewDilikes": "Puntualmente utilizamos droplets y nuestro desarrollo es bastante puntual, así que sentimos que hoy y en el mediano plazo cumple con nuestras espectativas. Me gustaría que tenga más servicios como lo tiene AWS, pero hoy en día no los estaríamos aprovechando. En el día de mañana tal vez necesitemos algunas herramientas para escalar o aumentar la productividad pero la tecnología hoy en día avanza muy rápido y es posible que también estemos cubiertos con las nuevas features."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Jonathan P.",
+      "authorProfile": "https://www.g2.com/users/13b4b965-4e8d-4454-8555-65a95bf6b6aa",
+      "authorPosition": "Company Director, CTO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (5/5/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
+      "reviewRate": 4.5,
+      "reviewTitle": "Feels like you are really working with other developers",
+      "reviewLikes": "The number one reason I like DigitalOcean is that you feel like you are working with other developers. Yes they have commercial marketing, but it's quite, not 'in your face' like other providers.\nJust as much a number one reason is cost, where else can you get a cloud presence for $6/month that is professionally maintained, easy to use and in my case, after almost 7 years, never let me down.",
+      "reviewDilikes": "Honestly, it's difficult to think of anything negative. Yes I've had the odd issue, but between their excellent documentation and their customer tech support it's never been an issue to the extent that I've experienced with other providers.\nThere's a few extra's that I would like to see like domain registration, all in all a good place to be for a developer"
+    }
+  },
+  {
+    "author": {
+      "authorName": "P B.",
+      "authorProfile": "https://www.g2.com/users/0fa0065a-847f-4353-b5b6-bf3a5d282d26",
+      "authorPosition": "CTO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-19",
+      "reviewRate": 5.0,
+      "reviewTitle": "What AWS should have been",
+      "reviewLikes": "Digital Ocean (DO) is amazing for one fact - its super simple to use.  AWS, while powerful, gives me a headache trying to figure out what things mean or how to use them.  DO has been amazing in that regard - its easy to spin up servers or new services, and hardly requires any babysitting. It runs 90% of our company, and has for years.",
+      "reviewDilikes": "There isn't much to complain about here.  I guess a few of the services could be a bit cheaper."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Linus .",
+      "authorProfile": "https://www.g2.com/users/ea72d925-c14e-426d-b473-09da23b6d215",
+      "authorPosition": "Game Designer / Game Lead Director",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-11-04",
+      "reviewRate": 5.0,
+      "reviewTitle": "Excellent serivce for a fair affordable price",
+      "reviewLikes": "We use Digital Ocean to host Perforce Helix Core version control for unreal engine 5. DigitalOcean provides a very affordable service for our small team with good plans to choose from. \nWe use it for our whole development of games, therefor it's great to choose only what we really need and have the option to easily expand our plan when needed.\nThe implementation was easy and we had no struggles.",
+      "reviewDilikes": "Sadly (as far as we know) you can only see how much space you are already using in percentage and not written like: 20GB/25GB. That would be a great addition if you can't keep track how much space you provide to a droplet."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Dillon D.",
+      "authorProfile": "https://www.g2.com/users/ff9feaaa-ce36-4dd2-aa55-311ab73e119b",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Easy, fast, and flexible",
+      "reviewLikes": "Web UI is very intuitive and easy to use. Resources are readily available and performance meets expectations.",
+      "reviewDilikes": "Not the cheapest option for large servers but still good value."
+    }
+  },
+  {
+    "author": {
+      "authorName": "HEJOIR S.",
+      "authorProfile": "https://www.g2.com/users/2ee44b4f-9d5a-4e4c-ab94-ffecc4649bb0",
+      "authorPosition": "developer",
+      "authorCompanySize": "Mid-Market (51-1000 emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 5.0,
+      "reviewTitle": "Great for small businesses with tech skills",
+      "reviewLikes": "DigitalOcean is a flexible and scalable platform that works perfectly for small and medium-sized businesses. It offers an intuitive interface, fast server deployment, and affordable pricing, which makes it ideal for startups or growing companies. The technical documentation is extensive and very helpful for developers.",
+      "reviewDilikes": "The main downside is the lack of customer support in Spanish. This can be a challenge for non-English-speaking users, especially during critical issues. It would be great to see more localized support for Latin America and Spanish-speaking users."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Kenneth K.",
+      "authorProfile": "https://www.g2.com/users/2e79f60c-175c-4bec-9c7f-3a90ed0e27e2",
+      "authorPosition": "CEO",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-18",
+      "reviewRate": 5.0,
+      "reviewTitle": "Best affordable Cloud Provider",
+      "reviewLikes": "I'm working on a startup together with a friend. We haven't gone live yet, but I feel compelled to give an honest review of DigitalOcean after having used their droplets for almost 4 months now.\n\nWell, just like most startups, we have a tight budget yet need massive resources to run a video sharing MERN app.\nWe first tried AWS, but that was way out of out budget. After a lot of research, we came across DigitalOcean, tried their droplets for three months using their free trial and haven't looked back.\n\nWhat I love most is how easy it is to manage our kubernetes cluster without worrying about how much we'll pay at the end of the month. All we  needed to do is select how many droplets we needed based on number of vCPUs, RAM, and disk storage, and we're guaranteed to pay only for those droplets . The only other cost is space storage, persistent storage, and load balancer, all of which are also so easy to estimate and cheap.\n\nTheir customer service is also really good, and they'll respond even during weekends. But you have to be very clear on what you need help on so they can assist you with the fewest number of messages since they do not respond immediately. But they also offer premium customer service options if you need immediate responses. \n\nAnother option is BobCares, which they do promote on their site also. It's a third-party customer service for kubernetes which I've used before and didn't like it at all. First, they're pretty expensive - about $99 per hour - and you're not guaranteed they'll solve your issue. Second, you have to give them access to your kubernetes cluster, which could be a potential source of a security breach for your cluster. \n\nFor someone who didn't know how to spin up a kubernetes cluster from scratch for a MERN app, I'd say choosing DigitalOcean was my best decision ever. I have control over everything and have an amazing group of specialists waiting to help any time I get stuck.\n\nTheir online publications are also super helpful and very well documented. I can't talk much about their DigitalOcean managed kubernetes (DOKS), but if you're looking to spin up a kubernetes cluster from scratch inside droplets, you'll need their CSI driver, which is just as easy as copying and pasting it from their Github.",
+      "reviewDilikes": "The only negative experience I've had is in setting up firewall for my droplets using their firewall dashboard. I noticed that anytime I could add firewall rules, my site got really slow. I'm not sure why and didn't bother asking them so I can't blame it all on them. I went for the alternative of setting up firewall using iptables, which works fine now. I honestly can't think of any other negative experience.\n\nSince I'm using Droplets rather than their managed kubernetes service (DOKS), most of the issues I come across are things I can solve since I have control over the entire kubernetes set up. That's why it's kind of difficult to address any negatives; I can't fault them."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vasilis",
+      "authorProfile": "https://www.g2.com/users/94d371fd-a84c-48af-b1ef-8ba0d8c6f0a1",
+      "authorPosition": "Chief Technical Officer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 4.5,
+      "reviewTitle": "Great and simple to use cloud provider",
+      "reviewLikes": "It strikes the best balance of provided services and low complexity for SMBs. We don't have dedicated SREs, we don't wanna spend countless hours setting up IAMs, dozens of configs just to do the simplest of things, or trying to figure out what services is the best.\n\nIf you're looking for simple to use and straightfoward servers, DBs, containers, DNS management, S3 buckets, etc, the Digital Ocean is a great solution.",
+      "reviewDilikes": "We would like juuuust a tad more permission management, specifically giving people permissions on a project-based level, so that we can isolate between prod and dev.\n\nBut as I already mentioned, we appreciate the simplicity and straight forwardness of DO, so I'd rather use what they have right now."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Vince  C.",
+      "authorProfile": "https://www.g2.com/users/1cf14acd-7f7f-44cf-b46e-50327694d690",
+      "authorPosition": "Owner",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 4.5,
+      "reviewTitle": "Solid reliable cloud services with great value",
+      "reviewLikes": "I've been with DigitalOcean for almost 10 years and extremely happy with their services, which don't overwhelm you with options and are a great value. Customer support when needed is excellent and they have lots of self-help support in the form of how-to documents and examples.",
+      "reviewDilikes": "So far I have no complaints, they meet my needs perfectly. If I was with a larger Enterprise or government Institution they might be a harder sell as they don't have the same credibility as a Microsoft or Amazon, but for what most people need digital ocean is great."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Filipe V.",
+      "authorProfile": "https://www.g2.com/users/e68afb74-b175-4380-9ca9-f17a64ad82b3",
+      "authorPosition": "Full Stack Engineer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Fantastic and stable product",
+      "reviewLikes": "I really like they are predictable regarding the pricing and offers stable products that have zero downtime. I am a client over more than 10 years and only had positive interactions with their support team and product. Zero headaches and awesome performance.",
+      "reviewDilikes": "In the past they only offered droplets which was kinda limiting, but now they offer a wide array of services so I don't think there's anything that I dislike about it."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Stephen Douglas S.",
+      "authorProfile": "https://www.g2.com/users/bluewizard",
+      "authorPosition": "Founder",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (2/11/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2024-05-09",
+      "reviewRate": 4.5,
+      "reviewTitle": "High value for the price, and their customer service is good.  They added PaperSpace (GPUs for AI)",
+      "reviewLikes": "The value for the price, and their customer service.  The control panel / UI is easy to navigate.  I have Digital Ocea to manage some Docker packages, including my web hosting service.  I more recently started to explore the deployment of some AI platforms, but I'd rather purchase my hardware to develop in-house, and then deploy to the Cloud when it is production ready.",
+      "reviewDilikes": "Their offerings don't compare to something like AWS, but for small and medium-sized businesses they have a nice platform that keeps improving."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Verified User in Facilities Services",
+      "authorProfile": null,
+      "authorPosition": "Small-Business (50 or fewer emp.)",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Rating Updated (5/25/2025)",
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite",
+        "AI Translated"
+      ],
+      "reviewData": "2025-04-29",
+      "reviewRate": 3.5,
+      "reviewTitle": "My point of view on Digital Ocean as a product",
+      "reviewLikes": "What I like best about Digital Ocean is that the process and UI are easy to understand for new users. They are giving simple options to make the changes and make them effective.",
+      "reviewDilikes": "Several times we have faced the problem with deployment regarding cache issues in the newly deployed build. It gets deployed, but new changes are not reflecting. In that case, we have to go and restart the app with a clear build cache. It's a headache."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Ryan  D.",
+      "authorProfile": "https://www.g2.com/users/bdec8dd0-ad23-4a6e-b165-aec65a81e9a5",
+      "authorPosition": "Sole Trader",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-04-28",
+      "reviewRate": 5.0,
+      "reviewTitle": "Cheap, easy to use",
+      "reviewLikes": "It just works, setup was easy and I've had no issues with the platform since then. Recovery tools just work when you need them and adding additional volumes is just a few clicks with really clear pricing.",
+      "reviewDilikes": "Have not had any downsides yet beyond but being cheapest in the market but that's balanced out by the updates. I don't have experience with their support services or other products so have limited knowledge of their downsides"
+    }
+  },
+  {
+    "author": {
+      "authorName": "Yahya L.",
+      "authorProfile": "https://www.g2.com/users/bad78889-6929-458b-8873-fe7d9670648c",
+      "authorPosition": "Owner of the Company",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Incentivized",
+        "Source: Seller invite"
+      ],
+      "reviewData": "2025-02-14",
+      "reviewRate": 4.5,
+      "reviewTitle": "when i started using DO i never changed them",
+      "reviewLikes": "DO is fast, clean, was first in kind once they started, cheap, they have great doccumentation, they have toturials, easy to use, fast and serious customer support and great products.",
+      "reviewDilikes": "i had never got problems with them except this last two months my droplet that runs my website stops working as expected and just hand and services get down, thats maybe because they have added many many other services and products and updates, and my droplet is up from 2014/2015 maybe."
+    }
+  },
+  {
+    "author": {
+      "authorName": "Filip S.",
+      "authorProfile": "https://www.g2.com/users/475d1c0c-c5e9-4053-93e7-931b6e80816a",
+      "authorPosition": "student, and attempting to became java developer",
+      "authorCompanySize": "Small-Business (50 or fewer emp.)"
+    },
+    "review": {
+      "reviewTags": [
+        "Current User",
+        "Validated Reviewer",
+        "Source: Organic"
+      ],
+      "reviewData": "2025-02-12",
+      "reviewRate": 4.5,
+      "reviewTitle": "Over 4 months of using services of Digital Ocean.",
+      "reviewLikes": "Support was very quick and informative, providing helpful assistance.\n\nFrom the perspective of ease of use, this is the first service of this type that I’m using, so it’s hard to judge as I have no comparison. However, the overall process wasn’t difficult, and I managed to achieve what I was looking for.",
+      "reviewDilikes": "If I had to point out something, it would be the price—and one situation I resolved with support, where I believe the price differed from what I signed up for. However, since I had the option to downgrade my plan, I'm still satisfied."
     }
   }
 ]

--- a/g2-scraper/results/search.json
+++ b/g2-scraper/results/search.json
@@ -193,17 +193,6 @@
     ]
   },
   {
-    "name": "Oracle Cloud Infrastructure Archive Storage Classic",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-archive-storage-classic/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5bfe1591b8ea3a1a883779b66578382/oracle-cloud-infrastructure-archive-storage-classic.jpg",
-    "rate": 4.4,
-    "reviewsNumber": 34,
-    "description": "The most cost-effective storage in the industry, designed for infrequently accessed data with enterprise-grade security, resilience, and elastic scalability.",
-    "categories": [
-      "Archive Storage Solutions"
-    ]
-  },
-  {
     "name": "Oracle Cloud Infrastructure Tagging",
     "link": "https://www.g2.com/products/oracle-cloud-infrastructure-tagging/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-tagging.png",
@@ -223,6 +212,17 @@
     "description": "Notifications is a fully managed publish-subscribe service that allows for messages to be pushed with massive scale and reliability.",
     "categories": [
       "IT Alerting"
+    ]
+  },
+  {
+    "name": "Oracle Cloud Infrastructure Archive Storage Classic",
+    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-archive-storage-classic/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5bfe1591b8ea3a1a883779b66578382/oracle-cloud-infrastructure-archive-storage-classic.jpg",
+    "rate": 4.4,
+    "reviewsNumber": 34,
+    "description": "The most cost-effective storage in the industry, designed for infrequently accessed data with enterprise-grade security, resilience, and elastic scalability.",
+    "categories": [
+      "Archive Storage Solutions"
     ]
   },
   {

--- a/g2-scraper/results/search.json
+++ b/g2-scraper/results/search.json
@@ -4,10 +4,10 @@
     "link": "https://www.g2.com/products/oracle-oracle-cloud-infrastructure/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_2753ea8c7953188158425365667be750/oracle-oracle-cloud-infrastructure.png",
     "rate": 4.2,
-    "reviewsNumber": 371,
+    "reviewsNumber": 376,
     "description": null,
     "categories": [
-      "Other Product Suites"
+      "Product Suites"
     ]
   },
   {
@@ -15,21 +15,11 @@
     "link": "https://www.g2.com/products/nutanix-cloud-infrastructure-nci/reviews",
     "image": "https://images.g2crowd.com/uploads/product/hd_favicon/16abd9cd27db884c0f93e6fe06630051/nutanix-cloud-infrastructure-nci.svg",
     "rate": 4.6,
-    "reviewsNumber": 268,
+    "reviewsNumber": 271,
     "description": "Nutanix Cloud Infrastructure (NCI) combines feature-rich software-defined storage with built-in virtualization in a turnkey hyperconverged infrastructure solution that can run any application at any scale.",
     "categories": [
-      "Hyperconverged Infrastructure (HCI) Solutions"
-    ]
-  },
-  {
-    "name": "Data Center Virtualization and Cloud Infrastructure",
-    "link": "https://www.g2.com/products/data-center-virtualization-and-cloud-infrastructure/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_b786517d9ff0c2ebbc03614aaa4b38e0/data-center-virtualization-and-cloud-infrastructure.jpg",
-    "rate": 4.6,
-    "reviewsNumber": 343,
-    "description": null,
-    "categories": [
-      "Other Product Suites"
+      "Hyperconverged Infrastructure (HCI) Solutions",
+      "Server Virtualization"
     ]
   },
   {
@@ -37,7 +27,7 @@
     "link": "https://www.g2.com/products/splunk-infrastructure-monitoring/reviews",
     "image": "https://images.g2crowd.com/uploads/product/hd_favicon/658dd11af574d5228f22a7f5855f32dc/splunk-infrastructure-monitoring.svg",
     "rate": 4.3,
-    "reviewsNumber": 47,
+    "reviewsNumber": 51,
     "description": "Splunk Infrastructure Monitoring proactively finds and fixes problems before it impacts business performance through high resolution, full fidelity metrics monitoring that automatically detects and accurately alerts on critical patterns in seconds using real-time, AI-driven streaming analytics. Splunk Infrastructure Monitoring significantly shortens MTTD and MTTR by providing unmatched instant visibility across the infrastructure and application stack that builds on the value of an extensible Sp",
     "categories": [
       "Server Monitoring",
@@ -48,7 +38,7 @@
       "Log Analysis",
       "Network Monitoring",
       "Enterprise Monitoring",
-      "Observability Solution Suites"
+      "Observability Software"
     ]
   },
   {
@@ -56,10 +46,21 @@
     "link": "https://www.g2.com/products/oracle-cloud-infrastructure-compute/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-compute.png",
     "rate": 4.1,
-    "reviewsNumber": 67,
+    "reviewsNumber": 68,
     "description": "Compute options range from VMs to GPUs to bare metal servers, and includes options for dense I/O workloads, high performance computing (HPC), and AMD EPYC processors.",
     "categories": [
       "Container Engine"
+    ]
+  },
+  {
+    "name": "Oracle Cloud Infrastructure Logging",
+    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-logging/reviews",
+    "image": "https://images.g2crowd.com/uploads/vendor/image/378/large_detail_3f7254e5663d9141aae265f49b468543.jpeg",
+    "rate": 4.7,
+    "reviewsNumber": 49,
+    "description": "Oracle Cloud Infrastructure Logging is a fully managed, scalable service that centralizes the collection, management, and analysis of log data from various sources, including infrastructure, applications, databases, and audit logs. Designed to enhance DevOps efficiency and ensure security compliance, OCI Logging provides a unified platform for monitoring and troubleshooting across an organization's entire IT environment.\n\nKey Features and Functionality:\n\n- Centralized Log Management: Enables one",
+    "categories": [
+      "Log Analysis"
     ]
   },
   {
@@ -70,7 +71,7 @@
     "reviewsNumber": 22,
     "description": "Icinga is a monitoring software project that began as a fork of Nagios.",
     "categories": [
-      "Observability Solution Suites",
+      "Observability Software",
       "Enterprise Monitoring",
       "Server Monitoring",
       "Cloud Infrastructure Monitoring",
@@ -86,22 +87,11 @@
     ]
   },
   {
-    "name": "Oracle Cloud Infrastructure Logging",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-logging/reviews",
-    "image": null,
-    "rate": 4.7,
-    "reviewsNumber": 47,
-    "description": null,
-    "categories": [
-      "Log Analysis"
-    ]
-  },
-  {
     "name": "Oracle Cloud Infrastructure Vault",
     "link": "https://www.g2.com/products/oracle-cloud-infrastructure-vault/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_ebc397a24911cc79962c8898752c5359/oracle-cloud-infrastructure-vault.png",
-    "rate": 4.2,
-    "reviewsNumber": 35,
+    "rate": 4.3,
+    "reviewsNumber": 36,
     "description": "Oracle Cloud Infrastructure Key Management is a managed service that enables you to encrypt your data using keys that you control.",
     "categories": [
       "Encryption Key Management"
@@ -119,29 +109,12 @@
     ]
   },
   {
-    "name": "Pixis AI Infrastructure",
-    "link": "https://www.g2.com/products/pixis-ai-infrastructure/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/hd_favicon/0a1eebf574585c7da13fd26a733fd829/pixis-ai-infrastructure.svg",
-    "rate": 4.6,
-    "reviewsNumber": 14,
-    "description": null,
-    "categories": [
-      "Cross-Channel Advertising",
-      "Video Advertising",
-      "Social Media Advertising",
-      "Mobile Advertising",
-      "Search Advertising",
-      "MLOps Platforms",
-      "Personalization Engines"
-    ]
-  },
-  {
-    "name": "Virtual Infrastructure Management",
-    "link": "https://www.g2.com/products/virtual-infrastructure-management/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_5527633040d2267966345beea4bcc3b5/virtual-infrastructure-management.PNG",
-    "rate": 4.1,
-    "reviewsNumber": 13,
-    "description": "Manage your NetApp storage operations directly from VMware vCenter.",
+    "name": "Huawei FusionCube Hyper-converged Infrastructure",
+    "link": "https://www.g2.com/products/huawei-fusioncube-hyper-converged-infrastructure/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_369c40a79df25676a207b8b5dd3b1c89/huawei-fusioncube-hyper-converged-infrastructure.jpg",
+    "rate": 4.3,
+    "reviewsNumber": 39,
+    "description": "The Huawei FusionCube hyper-converged infrastructure (HCI) brings compute, storage, network, virtualization, and management into one tightly integrated package to achieve high performance, low latency, and rapid deployment. FusionCube leverages Huawei-proprietary built-in distributed storage engines to enable deep convergence of compute and storage, eliminating performance bottlenecks while allowing for flexible capacity expansion.",
     "categories": [
       "Hyperconverged Infrastructure (HCI) Solutions"
     ]
@@ -159,14 +132,14 @@
     ]
   },
   {
-    "name": "Oracle Cloud Infrastructure",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_e53b2ac9e45157f057f8d034b4a77635/oracle-cloud-infrastructure.png",
-    "rate": 4.3,
-    "reviewsNumber": 9,
-    "description": "Our Oracle Cloud Services team has over 25 years of experience designing, implementing and supporting Oracle solutions across a wide range of industry sectors. Helping our clients reduce costs, become agile and deliver on their business goals. We have multiple Oracle Cloud accreditations and Oracle Expertise, we even won Oracle Digital Partner of the Year 2020!",
+    "name": "Google Cloud AI Infrastructure",
+    "link": "https://www.g2.com/products/google-cloud-ai-infrastructure/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_9bffa359ebdf62613b74920d787d784b/google-cloud-ai-infrastructure.jpg",
+    "rate": 4.6,
+    "reviewsNumber": 18,
+    "description": "AI Infrastructure\nScalable, high performance, and cost effective infrastructure for every AI workload.\n\nAI Accelerators for every use case from high performance training to low-cost inference\n\nScale faster with GPUs and TPUs on Google Kubernetes Engine or Google Compute Engine\n\nDeployable solutions for Vertex AI, Google Kubernetes Engine, and the Cloud HPC Toolkit\n\nGet the most out of our AI Infrastructure by deploying the AI Hypercomputer architecture",
     "categories": [
-      "Oracle Cloud Application Resellers"
+      "Generative AI Infrastructure"
     ]
   },
   {
@@ -181,14 +154,42 @@
     ]
   },
   {
-    "name": "Oracle Cloud Infrastructure Tagging",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-tagging/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-tagging.png",
+    "name": "Google Cloud Infrastructure Manager",
+    "link": "https://www.g2.com/products/google-cloud-infrastructure-manager/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_9bffa359ebdf62613b74920d787d784b/google-cloud-infrastructure-manager.jpg",
     "rate": 4.2,
-    "reviewsNumber": 11,
-    "description": "Script bulk actions on exactly the Oracle Cloud Infrastructure resources you want, identified by tags",
+    "reviewsNumber": 13,
+    "description": "Google Cloud Infrastructure Manager\n\nProduct Description:\n\nGoogle Cloud Infrastructure Manager is a managed service that automates the deployment and management of Google Cloud infrastructure resources using Terraform. By integrating Terraform's infrastructure-as-code capabilities directly into the Google Cloud ecosystem, Infra Manager enables users to define, deploy, and manage cloud resources in a consistent, repeatable, and efficient manner. This service eliminates the need for maintaining se",
     "categories": [
-      "Data Center Infrastructure Management (DCIM)"
+      "Cloud Infrastructure Automation"
+    ]
+  },
+  {
+    "name": "Firefly Cloud Infrastructure Automation",
+    "link": "https://www.g2.com/products/firefly-cloud-infrastructure-automation/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/hd_favicon/2f3ab1243e922bb96884d6b9f493adb1/firefly-cloud-infrastructure-automation.svg",
+    "rate": 4.8,
+    "reviewsNumber": 11,
+    "description": "Firefly’s Cloud Infrastructure Automation Platform enables organizations to automate, manage, and govern their entire cloud footprint with IaC. Agile and efficient cloud practitioners use Firefly for its AI-assisted remediations, streamlined IaC orchestration, and a unified system of record for Cloud Asset Management. With Firefly, Platform and DevOps teams can finally uncomplicate their cloud, while accelerating cloud innovation and maintaining security and performance at scale.",
+    "categories": [
+      "Cloud Management Platforms",
+      "Cloud Infrastructure Automation",
+      "Configuration Management"
+    ]
+  },
+  {
+    "name": "Cisco Application Centric Infrastructure (ACI)",
+    "link": "https://www.g2.com/products/cisco-application-centric-infrastructure-aci/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_47bf20a76fe88056707e198b1947bb33/cisco-application-centric-infrastructure-aci.jpg",
+    "rate": 4.3,
+    "reviewsNumber": 22,
+    "description": "Application Centric Infrastructure (ACI) simplifies, optimizes, and accelerates the application deployment lifecycle in next-generation data centers and clouds.",
+    "categories": [
+      "Data Center Security Solutions",
+      "Network Automation Tools",
+      "Data Center Networking",
+      "Data Center Infrastructure Management (DCIM)",
+      "Network Management Tools"
     ]
   },
   {
@@ -203,6 +204,28 @@
     ]
   },
   {
+    "name": "Oracle Cloud Infrastructure Tagging",
+    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-tagging/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-tagging.png",
+    "rate": 4.2,
+    "reviewsNumber": 11,
+    "description": "Script bulk actions on exactly the Oracle Cloud Infrastructure resources you want, identified by tags",
+    "categories": [
+      "Cloud Management Platforms"
+    ]
+  },
+  {
+    "name": "Oracle Cloud Infrastructure Notifications",
+    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-notifications/reviews",
+    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5da7ea5c8a9ac38a30700df9f063a73/oracle-cloud-infrastructure-notifications.jpg",
+    "rate": 4.6,
+    "reviewsNumber": 10,
+    "description": "Notifications is a fully managed publish-subscribe service that allows for messages to be pushed with massive scale and reliability.",
+    "categories": [
+      "IT Alerting"
+    ]
+  },
+  {
     "name": "Oracle Cloud Infrastructure Email Delivery",
     "link": "https://www.g2.com/products/oracle-cloud-infrastructure-email-delivery/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c530bc70f0bda21b5716a731ba2b0b4e/oracle-cloud-infrastructure-email-delivery.jpg",
@@ -214,272 +237,14 @@
     ]
   },
   {
-    "name": "TrueSight Infrastructure Management",
-    "link": "https://www.g2.com/products/truesight-infrastructure-management/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d60001ac7dc134b8f34867dd731eefe5/truesight-infrastructure-management.jpg",
-    "rate": 4.4,
-    "reviewsNumber": 10,
-    "description": "Enable IT operations with cloud- and vendor-agnostic infrastructure monitoring and management",
-    "categories": [
-      "Container Monitoring",
-      "Enterprise IT Management",
-      "IT Alerting",
-      "Database Monitoring",
-      "Network Monitoring",
-      "Cloud Infrastructure Monitoring"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Streaming",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-streaming/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5da7ea5c8a9ac38a30700df9f063a73/oracle-cloud-infrastructure-streaming.jpg",
-    "rate": 4.3,
-    "reviewsNumber": 12,
-    "description": "Ingest and store continuous, high-volume data streams and process them in real-time with Oracle Cloud Infrastructure Streaming service.",
-    "categories": [
-      "Event Stream Processing"
-    ]
-  },
-  {
     "name": "Oracle Cloud Infrastructure Object Storage",
     "link": "https://www.g2.com/products/oracle-cloud-infrastructure-object-storage/reviews",
     "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-object-storage.png",
-    "rate": 4.3,
-    "reviewsNumber": 19,
+    "rate": 4.2,
+    "reviewsNumber": 20,
     "description": "Automatically replicates objects across multiple fault domains for high durability. Actively monitored for data integrity and availability",
     "categories": [
       "Object Storage Solutions"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Storage Gateway",
-    "link": "https://www.g2.com/products/oracle-oracle-cloud-infrastructure-storage-gateway/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_1fdb202cf6dec0f94a008403c07bcba4/oracle-oracle-cloud-infrastructure-storage-gateway.jpg",
-    "rate": 4.5,
-    "reviewsNumber": 15,
-    "description": "A simple NAS gateway for end users and applications which provides a secure, POSIX compliant, local NFS interface for cloud storage.",
-    "categories": [
-      "Cloud File Storage",
-      "Hybrid Cloud Storage Solutions",
-      "On-Premise Data Integration"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure File Storage",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-file-storage/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-file-storage.png",
-    "rate": 4.3,
-    "reviewsNumber": 15,
-    "description": "Oracle Cloud Infrastructure File Storage is a persistent shared filesystem in the cloud with massive scalability, availability, durability, and performance. Oracle File Storage supports NFSv3, snapshots, and encryption",
-    "categories": [
-      "Cloud File Storage"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure VPN for Dedicated Compute Classic",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-vpn-for-dedicated-compute-classic/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5bfe1591b8ea3a1a883779b66578382/oracle-cloud-infrastructure-vpn-for-dedicated-compute-classic.jpg",
-    "rate": 4.2,
-    "reviewsNumber": 41,
-    "description": "Networking Classic Site to Site VPN is a secure, reliable, and cost-effective solution for expanding your private network. Enterprises can securely connect to Dedicated Compute Classic zone over IPSec tunnels as part of their virtual private network. Networking Classic Site to Site VPN eliminates the need to invest in leased lines for more security and peace of mind. Available as a Service (VPNaaS) on Oracle Cloud Infrastructure Dedicated Compute Classic in Regional Cloud.",
-    "categories": [
-      "Virtual Private Cloud (VPC)"
-    ]
-  },
-  {
-    "name": "NetApp Infrastructure Assessment",
-    "link": "https://www.g2.com/products/netapp-infrastructure-assessment/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_5527633040d2267966345beea4bcc3b5/netapp-infrastructure-assessment.PNG",
-    "rate": 4.3,
-    "reviewsNumber": 7,
-    "description": "NetApp Infrastructure Assessment is powered by award-winning, industry-leading, enterprise-class productsnot scripts and proprietary tools. Performed remotely and securely to minimize your time and effort. Reviewed by an independent third party with positive customer reviews. Complimentary and quickat no cost to you",
-    "categories": [
-      "IT Risk Management"
-    ]
-  },
-  {
-    "name": "Oracle Infrastructure Monitoring Cloud Service",
-    "link": "https://www.g2.com/products/oracle-infrastructure-monitoring-cloud-service/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-infrastructure-monitoring-cloud-service.png",
-    "rate": 4.0,
-    "reviewsNumber": 14,
-    "description": "Oracle Infrastructure Monitoring Cloud Service delivers the insight needed to understand the health of your resources, optimize the performance of your applications, and respond to anomalies in real time.",
-    "categories": [
-      "Cloud Infrastructure Monitoring"
-    ]
-  },
-  {
-    "name": "Stack Infrastructure",
-    "link": "https://www.g2.com/products/stack-infrastructure/reviews",
-    "image": null,
-    "rate": null,
-    "reviewsNumber": null,
-    "description": null,
-    "categories": [
-      "Data Center Infrastructure"
-    ]
-  },
-  {
-    "name": "YOTTA Infrastructure",
-    "link": "https://www.g2.com/products/yotta-infrastructure/reviews",
-    "image": null,
-    "rate": null,
-    "reviewsNumber": null,
-    "description": "We secure, manage, analyze and provide access to memories, decisions, ideas, entertainment, finances, communication and much more!With our comprehensive suite of Datacenter Colocation and Tech Services such as Cloud services, Network & Connectivity, IT Security and IT Management services.",
-    "categories": [
-      "Managed IT Services",
-      "Cloud Consulting"
-    ]
-  },
-  {
-    "name": "IT Infrastructure Monitoring",
-    "link": "https://www.g2.com/products/it-infrastructure-monitoring/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_0e3e98b9f9bd368e59c6340e50f176ab/it-infrastructure-monitoring.png",
-    "rate": null,
-    "reviewsNumber": null,
-    "description": "SAC monitoring dashboard consuming parameters of various systems recorded by Solman and other SAP Systems. The Solman’s managed landscape (BW/ERP etc) captures various information like users (online, offline, developer, end user etc), server parameters (memory, cpu, disc etc) and charm / transport requests from the connected systems.",
-    "categories": [
-      "SAP Store"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Archive Storage",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-archive-storage/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-archive-storage.png",
-    "rate": 4.5,
-    "reviewsNumber": 13,
-    "description": "Use and manage Archive Storage with the same identity mechanisms and common console, SDK, and APIs as Oracle Cloud Infrastructure Object Storage.",
-    "categories": [
-      "Archive Storage Solutions"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Load Balancing",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-load-balancing/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-load-balancing.png",
-    "rate": 4.5,
-    "reviewsNumber": 16,
-    "description": "Increase application availability and performance with highly-available and provisioned bandwidth load balancing.",
-    "categories": [
-      "Load Balancing"
-    ]
-  },
-  {
-    "name": "Huawei FusionCube Hyper-converged Infrastructure",
-    "link": "https://www.g2.com/products/huawei-fusioncube-hyper-converged-infrastructure/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_369c40a79df25676a207b8b5dd3b1c89/huawei-fusioncube-hyper-converged-infrastructure.jpg",
-    "rate": 4.0,
-    "reviewsNumber": 10,
-    "description": "The Huawei FusionCube hyper-converged infrastructure (HCI) brings compute, storage, network, virtualization, and management into one tightly integrated package to achieve high performance, low latency, and rapid deployment. FusionCube leverages Huawei-proprietary built-in distributed storage engines to enable deep convergence of compute and storage, eliminating performance bottlenecks while allowing for flexible capacity expansion.",
-    "categories": [
-      "Hyperconverged Infrastructure (HCI) Solutions"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Container Registry",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-container-registry/reviews",
-    "image": null,
-    "rate": 4.4,
-    "reviewsNumber": 10,
-    "description": null,
-    "categories": [
-      "Container Registry"
-    ]
-  },
-  {
-    "name": "F5 Distributed Cloud App Infrastructure Protection (AIP)",
-    "link": "https://www.g2.com/products/f5-distributed-cloud-app-infrastructure-protection-aip/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/hd_favicon/f8782e7a6c053e1a1057f92a6b1fb13e/f5-distributed-cloud-app-infrastructure-protection-aip.svg",
-    "rate": 4.4,
-    "reviewsNumber": 44,
-    "description": "F5 Distributed Cloud App Infrastructure Protection (AIP) provides continuous security monitoring for public, private, and hybrid cloud infrastructures protecting servers, and the data they access, from intrusion and data loss.",
-    "categories": [
-      "Cloud Security Monitoring and Analytics",
-      "Cloud Compliance",
-      "Cloud Infrastructure Monitoring",
-      "Container Security",
-      "Cloud Workload Protection Platforms",
-      "Cloud Security Posture Management (CSPM)"
-    ]
-  },
-  {
-    "name": "Cloud Voice Infrastructure",
-    "link": "https://www.g2.com/products/cloud-voice-infrastructure/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c1fcdebe23ddbc831f43d042f422ae2f/cloud-voice-infrastructure.png",
-    "rate": 5.0,
-    "reviewsNumber": 1,
-    "description": "A cloud-based, hosted infrastructure solution which provides a fully managed, end-to-end service that enables customers to take advantage of a hosted telephony solution with a full suite of Unified Communications features and capabilities.",
-    "categories": [
-      "Call Center Infrastructure (CCI)"
-    ]
-  },
-  {
-    "name": "CA Unified Infrastructure Management",
-    "link": "https://www.g2.com/products/broadcom-ca-unified-infrastructure-management/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_59dddda64a056efaca287f0d6c23b635/broadcom-ca-unified-infrastructure-management.png",
-    "rate": 3.3,
-    "reviewsNumber": 4,
-    "description": "Saas solution to core IT Service Management processes. Rapid setup and configuration for quick time to value.",
-    "categories": [
-      "Server Monitoring",
-      "Enterprise Monitoring"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Identity and Access Management",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-identity-and-access-management/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-identity-and-access-management.png",
-    "rate": 4.0,
-    "reviewsNumber": 15,
-    "description": "Define privileges for specific groups of users with simple, SQL-like policies",
-    "categories": [
-      "Privileged Access Management (PAM)",
-      "Identity and Access Management (IAM)"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Object Storage Classic",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-object-storage-classic/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_d5bfe1591b8ea3a1a883779b66578382/oracle-cloud-infrastructure-object-storage-classic.jpg",
-    "rate": 4.4,
-    "reviewsNumber": 13,
-    "description": "Secure, resilient and elastic object storage in the cloud, which provides enterprise-class data protection and sharing with easy access from anywhere on the internet.",
-    "categories": [
-      "Object Storage Solutions"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure Container Engine for Kubernetes",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-container-engine-for-kubernetes/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_aca40b5464fcf97310dbc332c2296b5c/oracle-cloud-infrastructure-container-engine-for-kubernetes.png",
-    "rate": 3.8,
-    "reviewsNumber": 11,
-    "description": "A developer friendly, container-native, and enterprise-ready managed Kubernetes service for running highly available clusters with the control, security, and predictable performance of Oracles Cloud Infrastructure",
-    "categories": [
-      "Container Orchestration",
-      "Container Management"
-    ]
-  },
-  {
-    "name": "Oracle Cloud Infrastructure DNS",
-    "link": "https://www.g2.com/products/oracle-cloud-infrastructure-dns/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c530bc70f0bda21b5716a731ba2b0b4e/oracle-cloud-infrastructure-dns.jpg",
-    "rate": 5.0,
-    "reviewsNumber": 2,
-    "description": "Oracle Cloud Infrastructure DNS is a tool for network resiliency, optimizing global web application performance, and managing traffic across hybrid cloud environments",
-    "categories": [
-      "Managed DNS Providers"
-    ]
-  },
-  {
-    "name": "Verizon Network Infrastructure Services",
-    "link": "https://www.g2.com/products/verizon-network-infrastructure-services/reviews",
-    "image": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_ed751f34ad82a65adf133ee845c518fc/verizon-network-infrastructure-services.jpg",
-    "rate": 4.8,
-    "reviewsNumber": 2,
-    "description": "Verizons Network Infrastructure Services give you the building blocks to design, plan, and manage your network solution. Delivered together as-a-service or standalone, well help execute your strategy with a prioritized roadmap to a future-ready network design.",
-    "categories": [
-      "IT Infrastructure Utility Services"
     ]
   }
 ]

--- a/g2-scraper/run.py
+++ b/g2-scraper/run.py
@@ -38,7 +38,7 @@ async def run():
         product="digitalocean"
     )
     with open(output.joinpath("alternatives.json"), "w", encoding="utf-8") as file:
-        json.dump(alternatives_data, file, indent=2, ensure_ascii=False)    
+        json.dump(alternatives_data, file, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Updated all XPath selectors in `parse_search_page` and `parse_review_page` to align with recent HTML changes.
- Adjusted the review scraper's logic to account for a new layout of 10 reviews per page (down from 25).
- Corrected product link extraction to always produce absolute URLs.
- Fixed a typo in the data output, renaming `reviewDilikes` to `reviewDislikes`

Note: the sometimes the usual descriptions is not present for alternative top 10 products (in that case scraper outputs null for description)

Example url: https://www.g2.com/products/digitalocean/competitors/alternatives
<img width="1251" height="389" alt="Screenshot 2025-08-13 at 20 51 49" src="https://github.com/user-attachments/assets/f321190f-ce9e-4043-99a9-2dc4604cbf31" />

<img width="1248" height="730" alt="Screenshot 2025-08-13 at 20 51 38" src="https://github.com/user-attachments/assets/4234fbae-75b1-47e6-9069-e6e9c813d4a9" />


