### PR TITLE
[goat] updated hidden fields name

### DIFF
--- a/goat-scraper/goat.py
+++ b/goat-scraper/goat.py
@@ -66,11 +66,11 @@ async def scrape_search(query: str, max_pages: int = 10) -> List[Dict]:
             "num_results_per_page": "24",
             "sort_by": "relevance",
             "sort_order": "descending",
-            "fmt_options[hidden_fields]": "gp_lowest_price_cents_3",
-            "fmt_options[hidden_fields]": "gp_instant_ship_lowest_price_cents_3",
-            "fmt_options[hidden_facets]": "gp_lowest_price_cents_3",
-            "fmt_options[hidden_facets]": "gp_instant_ship_lowest_price_cents_3",
-            "_dt": int(datetime.utcnow().timestamp() * 1000),  # current timestamp in milliseconds
+            "fmt_options[hidden_fields]": "gp_lowest_price_cents_",
+            "fmt_options[hidden_fields]": "gp_instant_ship_lowest_price_cents_",
+            "fmt_options[hidden_facets]": "gp_lowest_price_cents_",
+            "fmt_options[hidden_facets]": "gp_instant_ship_lowest_price_cents_",
+            "_dt": int(datetime.now().timestamp() * 1000),  # current timestamp in milliseconds
         }
         return f"https://ac.cnstrc.com/search/{quote(query)}?{urlencode(params)}"
 


### PR DESCRIPTION
Updated hidden fields that reflect current request params.
Still unable to get the data, although the hardcoded key is the same on the JS
goat's website request is working fine, but the underlying API request that it uses to get the search data is unable to get that. log: https://scrapfly.io/dashboard/monitoring/log/01K2PM2ED3ZYBTJERS0THM9KKR