### PR TITLE
Update Twitter scraper to use new selector for user tweets

### DIFF
--- a/twitter-scraper/twitter.py
+++ b/twitter-scraper/twitter.py
@@ -117,7 +117,7 @@ async def scrape_profile(url: str) -> Dict:
     https://x.com/scrapfly_dev
     returns user data and latest tweets
     """
-    result = await _scrape_twitter_app(url, wait_for_selector="xhr:TweetResultByRestId")
+    result = await _scrape_twitter_app(url, wait_for_selector="xhr:UserTweets")
     # capture background requests and extract ones that contain user data
     # and their latest tweets
     _xhr_calls = result.scrape_result["browser_data"]["xhr_call"]


### PR DESCRIPTION
Updated the old selector. The data was retrieved using it, but when I checked the logs, I saw that the selector was not found.
<img width="1206" height="345" alt="image" src="https://github.com/user-attachments/assets/955c6b53-2a1f-4a3b-aa2a-b3205039cbb5" />
