### PR TITLE
[google] Add AI Mode scraping functionality

### DIFF
--- a/google-scraper/README.md
+++ b/google-scraper/README.md
@@ -46,4 +46,5 @@ This Google.com scraper uses __Python 3.10__ with [scrapfly-sdk](https://pypi.or
     $ poetry run pytest test.py -k test_keyword_scraping
     $ poetry run pytest test.py -k test_place_url_scraping    
     $ poetry run pytest test.py -k test_place_scraping
+    $ poetry run pytest test.py  -k test_ai_mode_scraping
     ```

--- a/google-scraper/google.py
+++ b/google-scraper/google.py
@@ -7,10 +7,10 @@ $ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
 
 import os
 import operator
-
+from datetime import datetime, timezone
 from urllib.parse import quote
 from loguru import logger as log
-from typing import Dict, List
+from typing import Dict, List, TypedDict
 from scrapfly import ScrapeConfig, ScrapflyClient, ScrapeApiResponse
 
 
@@ -170,6 +170,39 @@ def parse_keywords(response: ScrapeApiResponse) -> List[str]:
     return {"related_search": related_search, "people_ask_for": people_ask_for}
 
 
+EXTRACTION_PROMPT = (
+    "Extract a JSON object from this Google AI Mode search result page (udm=50). "
+    "Ignore the top navigation, cookie banner, sign-in prompts, sidebar, "
+    "related searches, and the follow-up input at the bottom.\n"
+    "Fields:\n"
+    "- query: the original search query shown above the AI answer\n"
+    "- answer: the AI Mode answer text from the main answer column only. "
+    "Return plain text with paragraph breaks. Do not include markdown links, "
+    "bullet markdown syntax, tables, or inline citation URLs.\n"
+    "- sources: array of source cards from the dedicated sources panel attached "
+    "to the AI answer (small cards with a title, external link, and snippet). "
+    "Include only those panel cards, not inline links mentioned inside the answer "
+    "body and not sidebar or related-result links. Each item has:\n"
+    "  - title: source page title\n"
+    "  - url: full destination URL\n"
+    "  - snippet: short excerpt on the card, or null if missing\n"
+    "Return only the JSON object."
+)
+
+
+class AiModeSource(TypedDict):
+    title: str
+    url: str
+    snippet: str | None
+
+
+class AiModeResult(TypedDict):
+    query: str
+    answer: str
+    sources: List[AiModeSource]
+    captured_at: str
+
+
 async def scrape_keywords(query: str) -> List[str]:
     """request google search page for keyword data"""
     response = await SCRAPFLY.async_scrape(
@@ -248,3 +281,23 @@ async def scrape_serp(query: str, max_pages: int = None) -> List[Dict]:
     log.success(f"scraped {len(results)} SERP results of the query: {query}")
     results.sort(key=operator.itemgetter("position"))
     return results
+
+async def scrape_ai_mode(query: str, hl: str = "en", gl: str = "US") -> AiModeResult:
+    """scrape Google AI Mode (udm=50) search results"""
+    url = f"https://www.google.com/search?q={quote(query)}&udm=50&hl={hl}&gl={gl}"
+    log.info(f"scraping Google AI Mode for query: {query!r}")
+    response = await SCRAPFLY.async_scrape(
+        ScrapeConfig(
+            url,
+            **BASE_CONFIG,
+            extraction_prompt=EXTRACTION_PROMPT,
+            wait_for_selector='button[aria-label="Good response"][aria-pressed="false"]',
+            rendering_wait=5000,
+        )
+    )
+    scrape_result = response.scrape_result or {}
+    extracted = scrape_result.get("extracted_data") or {}
+    data = extracted.get("data")
+    data["captured_at"] = datetime.now(timezone.utc).isoformat()
+    log.success(f"scraped AI Mode answer ({len(data.get('sources', []))} sources)")
+    return data

--- a/google-scraper/results/ai_mode.json
+++ b/google-scraper/results/ai_mode.json
@@ -1,0 +1,77 @@
+{
+  "query": "best web scraping tools 2026",
+  "answer": "Based on developments in early 2026, the best web scraping tools emphasize AI-driven extraction, headless browser automation, and LLM-ready data structuring. The landscape is split between open-source frameworks for engineers and no-code AI agents for automated workflows.\nHere are the top web scraping tools for 2026:\nTop AI & No-Code Scraping Agents\n* Browse AI: Highly recommended for no-code, point-and-click scraping with visual training capabilities.\n* Firecrawl : A top choice for LLM applications that converts websites into clean markdown data.\n* ScrapeGraph AI: An open-source Python library that uses LLMs to create scraping pipelines from natural language prompts, ideal for non-technical users.\n* Diffbot : A commercial platform utilizing machine learning and computer vision to crawl complex, changing websites.\nTop Open-Source Frameworks & Libraries (For Developers)\n* Scrapy : A robust Python-based framework, ideal for large-scale crawling projects.\n* Playwright : A modern, fast browser automation tool excellent for rendering dynamic, JavaScript-heavy sites.\n* Puppeteer : A Google-developed NodeJS library focused on headless browser automation.\n* Beautiful Soup : A classic Python library best for parsing static HTML and XML content.\nEnterprise & Data Extraction Platforms\n* Kadoa : Positioned for enterprise-level, self-healing data extraction at scale.\n* CrawlforAI : An open-source tool that converts web content into structured formats ready for LLMs.\nKey Trends & Tips for 2026\n* AI Integration: The best tools now automatically detect relevant content, reducing the need for manual selector updates.\n* Proxy Integration: To avoid detection, tools like Data Impulse proxies are commonly integrated for region-specific data extraction.\n* Data Quality: Firecrawl is a top choice for LLM-focused data cleaning.\nFor most users needing fast, automated scraping in 2026,Browse AIandFirecrawloffer the best combination of ease-of-use and advanced capability.",
+  "sources": [
+    {
+      "title": "AI web scraper comparison (2026): 9 tools tested head-to-head",
+      "url": "https://www.browse.ai/blog/the-best-ai-web-scraper-tools",
+      "snippet": "Mar 20, 2026 — Quick take: Use Browse AI if you want point-and-click no-code scraping with visual training. Choose Firecrawl if you're building L..."
+    },
+    {
+      "url": "https://www.youtube.com/watch?v=gD903XbQ_K0",
+      "snippet": "Feb 3, 2026 — top companies use web crawlers to stay ahead in the business world let's review the most powerful crawling tools for 2026. who doe...",
+      "title": "Top Web Crawlers for 2026!"
+    },
+    {
+      "title": "Best headless browsers for web scraping in 2026",
+      "url": "https://www.zyte.com/learn/best-headless-browsers-for-web-scraping/",
+      "snippet": "Best headless browsers for web scraping in 2026 Headless browsers have become a foundational part of modern web scraping stacks. A..."
+    },
+    {
+      "title": "10 bedste AI-webscrapere i 2026: rangeret og anmeldt",
+      "url": "https://www.flowhunt.io/da/blog/best-ai-web-scrapers/",
+      "snippet": "May 18, 2026 — In 2026, the best AI web scrapers combine intelligent extraction with workflow automation, turning raw web data into actionable bu..."
+    },
+    {
+      "title": "What is the Best n8n Web Scraper in 2026",
+      "url": "https://parsera.org/blog/best-n8n-ai-scraping-tool-parsera-vs-scrapegraphai",
+      "snippet": "Feb 25, 2026 — 💬 What is AI Web Scrapers: AI web scraping uses large language models (LLMs) to understand a webpage's layout and extract meaning..."
+    },
+    {
+      "snippet": "Jan 19, 2026 — You'll find the best web scraping tools, Python and others, for custom builds. These open-source frameworks and libraries form the...",
+      "title": "Best Web Scraping Tools in 2026",
+      "url": "https://proxy-seller.com/blog/best_web_scraping_tools_to_get_ahead_in_2025/"
+    },
+    {
+      "snippet": "May 8, 2026 — Best Open-Source Libraries for Developers Who Want Full Control If you want to own the scraper stack end to end, these are the mos...",
+      "title": "Best 15 Web Page Scrapers You Should Know About in 2026",
+      "url": "https://thunderbit.com/blog/best-web-page-scraper"
+    },
+    {
+      "title": "Top Web Crawler Tools in 2026",
+      "url": "https://scrapfly.io/blog/posts/top-web-crawler-tools",
+      "snippet": "Jun 11, 2026 — Scrapfly Alternative for JavaScript-Heavy Sites This approach eliminates the need to manage browser instances while providing the ..."
+    },
+    {
+      "title": "Top 7 JavaScript Web Scraping Libraries in 2026",
+      "url": "https://serpapi.com/blog/top-javascript-web-scraping-libraries/",
+      "snippet": "Oct 30, 2023 — Handling Dynamic Content: Since Playwright controls a real browser, just like Puppeteer, it can handle JavaScript-heavy and dynami..."
+    },
+    {
+      "title": "Beyond Browsers: My Deep Dive into the Most Advanced Web Scraping Tools of 2025",
+      "url": "https://levelup.gitconnected.com/beyond-browsers-my-deep-dive-into-the-most-advanced-web-scraping-tools-of-2025-1d2c9efc1010",
+      "snippet": "Aug 17, 2025 — Playwright-Python: The Browser Automation Powerhouse Playwright has quietly overtaken Selenium as the go-to tool for browser autom..."
+    },
+    {
+      "title": "9 best Python web scraping libraries for 2026",
+      "url": "https://blog.apify.com/what-are-the-best-python-web-scraping-libraries/",
+      "snippet": "May 20, 2026 — 3. Playwright Playwright offers reliable browser automation that works well for complex, modern sites. It's the default choice if ..."
+    },
+    {
+      "title": "What Is Web Scraping? The Complete Guide (2026)",
+      "url": "https://www.browse.ai/blog/what-is-web-scraping",
+      "snippet": "Mar 18, 2026 — For developers building custom scrapers, Python with Playwright is the current standard. For large-scale enterprise scraping, Brig..."
+    },
+    {
+      "title": "Best Open Source Web Scraping Libraries September 2025",
+      "url": "https://www.skyvern.com/blog/best-open-source-web-scraping-libraries-in-2025/",
+      "snippet": "Sep 8, 2025 — Final thoughts on choosing the right web scraping approach You can eliminate the constant maintenance headaches of traditional scr..."
+    },
+    {
+      "title": "What Is Browse AI? 2026 Guide to Features, Pricing & Alternatives",
+      "url": "https://firebearstudio.com/blog/browse-ai-review.html",
+      "snippet": "Mar 5, 2026 — Browse AI remains one of the best web scraping tools for beginners and non-technical users who need a fast, no-code solution to co..."
+    }
+  ],
+  "captured_at": "2026-06-17T19:00:51.212361+00:00"
+}

--- a/google-scraper/run.py
+++ b/google-scraper/run.py
@@ -52,6 +52,12 @@ async def run():
     )
     with open(output.joinpath("google_map_places.json"), "w", encoding="utf-8") as file:
         json.dump(google_map_places, file, indent=2, ensure_ascii=False)
+        
+    ai_mode_data = await google.scrape_ai_mode(
+        query="best web scraping tools 2026",
+    )
+    with open(output.joinpath("ai_mode.json"), "w", encoding="utf-8") as file:
+        json.dump(ai_mode_data, file, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/google-scraper/test.py
+++ b/google-scraper/test.py
@@ -68,6 +68,23 @@ map_place_schema = {
     "1_stars": {"type": "string"},
 }
 
+ai_mode_source_schema = {
+    "title": {"type": "string", "required": True, "minlength": 1},
+    "url": {"type": "string", "required": True, "minlength": 1},
+    "snippet": {"type": "string", "nullable": True},
+}
+
+ai_mode_schema = {
+    "query": {"type": "string", "required": True, "minlength": 1},
+    "answer": {"type": "string", "required": True, "minlength": 1},
+    "sources": {
+        "type": "list",
+        "required": True,
+        "schema": {"type": "dict", "schema": ai_mode_source_schema},
+    },
+    "captured_at": {"type": "string", "required": True, "minlength": 1},
+}
+
 
 @pytest.mark.asyncio
 @pytest.mark.flaky(reruns=3, reruns_delay=30)
@@ -142,5 +159,21 @@ async def test_place_scraping():
     if os.getenv("SAVE_TEST_RESULTS") == "true":
         result.sort(key=lambda x: x["name"])
         (Path(__file__).parent / 'results/google_map_places.json').write_text(
+            json.dumps(result, indent=2, ensure_ascii=False, default=str)
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_ai_mode_scraping():
+    result = await google.scrape_ai_mode(
+        query="best web scraping tools 2026",
+    )
+    validator = Validator(ai_mode_schema, allow_unknown=True)
+    validate_or_fail(result, validator)
+    assert len(result["answer"]) > 50
+    assert len(result["sources"]) > 0
+    if os.getenv("SAVE_TEST_RESULTS") == "true":
+        (Path(__file__).parent / "results/ai_mode.json").write_text(
             json.dumps(result, indent=2, ensure_ascii=False, default=str)
         )


### PR DESCRIPTION
Required schema.

```
{
  "query": "...",
  "answer": "...",
  "sources": [{"title": "...", "url": "...", "snippet": "..."}],
  "captured_at": "ISO-8601"
} 
```

I have built another one using selectors. If you'd like, you can use it instead of extraction ai