### PR TITLE
Add target scraper

### DIFF
--- a/target-scraper/README.md
+++ b/target-scraper/README.md
@@ -1,0 +1,49 @@
+# Target.com Scraper
+
+This scraper is using [scrapfly.io](https://scrapfly.io/) and Python to scrape product and store data from Target.com.
+
+The scraping code is located in the `target.py` file. It's fully documented and simplified for educational purposes and the example scraper run code can be found in `run.py` file.
+
+This scraper scrapes:
+- Target product pages for product data, variants, pricing, and stock status
+- Target search pages for product listing data
+- Target RedSky API for product availability and fulfillment by store and zip code
+- Target store sitemap for store location URLs
+- Target RedSky API for store location details by store ID
+
+For output examples see the `./results` directory.
+
+## Fair Use Disclaimer
+
+Note that this code is provided free of charge as is, and Scrapfly does __not__ provide free web scraping support or consultation. For any bugs, see the issue tracker.
+
+## Setup and Use
+
+This Target.com scraper uses __Python 3.10__ with [scrapfly-sdk](https://pypi.org/project/scrapfly-sdk/) package which is used to scrape and parse Target's data.
+
+0. Ensure you have __Python 3.10__ and [poetry Python package manager](https://python-poetry.org/docs/#installation) on your system.
+1. Retrieve your Scrapfly API key from <https://scrapfly.io/dashboard> and set `SCRAPFLY_KEY` environment variable:
+    ```shell
+    $ export SCRAPFLY_KEY="YOUR SCRAPFLY KEY"
+    ```
+2. Clone and install Python environment:
+    ```shell
+    $ git clone https://github.com/scrapfly/scrapfly-scrapers.git
+    $ cd scrapfly-scrapers/target-scraper
+    $ poetry install
+    ```
+3. Run example scrape:
+    ```shell
+    $ poetry run python run.py
+    ```
+4. Run tests:
+    ```shell
+    $ poetry install --with dev
+    $ poetry run pytest test.py
+    # or specific scraping areas
+    $ poetry run pytest test.py -k test_product_scraping
+    $ poetry run pytest test.py -k test_search_scraping
+    $ poetry run pytest test.py -k test_availability_scraping
+    $ poetry run pytest test.py -k test_store_locations_sitemap
+    $ poetry run pytest test.py -k test_store_locations
+    ```

--- a/target-scraper/pyproject.toml
+++ b/target-scraper/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.poetry]
+name = "scrapfly-target"
+version = "0.1.0"
+description = "demo web scraper for Target.com using Scrapfly"
+authors = ["Abdelrahman Arafa <abdelrahman@scrapfly.io>"]
+license = "NPOS-3.0"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+scrapfly-sdk = {extras = ["all"], version = "^0.8.5"}
+loguru = "^0.7.0"
+parsel = "^1.7.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.3.0"
+ruff = "^0.0.269"
+cerberus = "^1.3.4"
+pytest = "^7.3.1"
+pytest-asyncio = "^0.21.0"
+pytest-rerunfailures = "^14.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+python_files = "test.py"
+
+[tool.black]
+line-length = 120
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+
+[tool.ruff]
+line-length = 120

--- a/target-scraper/results/availability.json
+++ b/target-scraper/results/availability.json
@@ -40,7 +40,7 @@
           },
           "order_pickup": {
             "availability_status": "IN_STOCK",
-            "pickup_date": "2026-07-06",
+            "pickup_date": "2026-07-07",
             "guest_pick_sla": 120,
             "location_locale": "America/Chicago"
           },

--- a/target-scraper/results/availability.json
+++ b/target-scraper/results/availability.json
@@ -1,0 +1,59 @@
+{
+  "88440369": {
+    "tcin": "88440369",
+    "title": "Amazon Echo Show 5 (3rd Gen, 2023 release) | Smart Display with Deeper Bass and Clearer Sound - Charcoal",
+    "price": {
+      "current_retail": 89.99,
+      "display_was_now": false,
+      "formatted_current_price": "$89.99",
+      "formatted_current_price_type": "reg",
+      "reg_retail": 89.99,
+      "location_id": 3991
+    },
+    "free_shipping": true,
+    "fulfillment": {
+      "product_id": "88440369",
+      "is_out_of_stock_in_all_store_locations": false,
+      "sold_out": false,
+      "shipping_options": {
+        "availability_status": "IN_STOCK",
+        "loyalty_availability_status": "IN_STOCK",
+        "services": [
+          {
+            "cutoff": "2026-07-07T18:00:00Z",
+            "shipping_method_id": "STANDARD",
+            "min_delivery_date": "2026-07-09",
+            "max_delivery_date": "2026-07-09",
+            "is_two_day_shipping": true,
+            "is_base_shipping_method": true
+          }
+        ]
+      },
+      "store_options": [
+        {
+          "search_response_store_type": "PRIMARY",
+          "location_available_to_promise_quantity": 1.0,
+          "pre_order_location_available_to_promise_quantity": 0.0,
+          "location_id": "1771",
+          "store": {
+            "location_name": "Cedar Rapids South"
+          },
+          "order_pickup": {
+            "availability_status": "IN_STOCK",
+            "pickup_date": "2026-07-06",
+            "guest_pick_sla": 120,
+            "location_locale": "America/Chicago"
+          },
+          "in_store_only": {
+            "availability_status": "IN_STOCK"
+          }
+        }
+      ],
+      "scheduled_delivery": {
+        "availability_status": "IN_STOCK",
+        "location_available_to_promise_quantity": 1.0
+      }
+    },
+    "in_stock": true
+  }
+}

--- a/target-scraper/results/product.json
+++ b/target-scraper/results/product.json
@@ -1,0 +1,371 @@
+{
+  "tcin": "95213693",
+  "title": "Women's Lace Godet Tank Top - Wild Fable™ Black XXS",
+  "rating": 3.67,
+  "review_count": 3,
+  "variants": [
+    {
+      "tcin": "1009050067",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "1009050068",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205378",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205379",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205380",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205381",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205382",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205383",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205384",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205385",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205386",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205387",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205388",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205389",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205390",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205391",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205392",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205393",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205394",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205395",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205396",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205397",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205398",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205399",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205400",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205401",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205402",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205403",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205404",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    },
+    {
+      "tcin": "95205405",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205406",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205407",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": false
+    },
+    {
+      "tcin": "95205408",
+      "price": {
+        "current_retail": 15.0,
+        "reg_retail": 15.0,
+        "formatted_current_price": "$15.00",
+        "location_id": 3991
+      },
+      "free_shipping": false,
+      "in_stock": true
+    }
+  ]
+}

--- a/target-scraper/results/search.json
+++ b/target-scraper/results/search.json
@@ -1,0 +1,482 @@
+[
+  {
+    "tcin": "1011111213",
+    "url": "https://www.target.com/p/lenovo-v15-g4-15-6-fhd-ryzen-5-7430u-16gb-ram-1tb-ssd-amd-radeon-graphics-wi-fi-6-win11-pro-black/-/A-1011111213?preselect=1011111213",
+    "title": "LENOVO V15 G4 Laptop, 15.6\" FHD, Ryzen 5, 16GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$699.99",
+    "reg_price": "$1,166.65"
+  },
+  {
+    "tcin": "1011102739",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-24gb-ram-1tb-ssd-radeon-wi-fi-6-win11-home-black/-/A-1011102739",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 24GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Home, Black",
+    "brand": "Lenovo",
+    "price": "$729.99",
+    "reg_price": "$1,216.65"
+  },
+  {
+    "tcin": "1009742946",
+    "url": "https://www.target.com/p/lenovo-thinkpad-l16-gen-2-business-laptop-16-fhd-1920x1200-intel-core-ultra-7-255u-32gb-ddr5-sodimm-2tb-pcie-ssd-wi-fi-6-windows-11-pro/-/A-1009742946",
+    "title": "LENOVO ThinkPad L16 Gen 2 Business Laptop, 16\" FHD+ 1920x1200, Intel Core Ultra 7 255U, 32GB DDR5 SODIMM, 2TB PCIe SSD, Wi-Fi 6, Windows 11 Pro",
+    "brand": "Lenovo",
+    "price": "$1,599.99",
+    "reg_price": "$2,666.65"
+  },
+  {
+    "tcin": "1011892690",
+    "url": "https://www.target.com/p/hp-essential-14-hd-laptop-intel-n-series-n150-intel-graphics-4gb-ram-128gb-emmc-wi-fi-6-windows-11-home-blue/-/A-1011892690",
+    "title": "HP Essential 14\" HD Laptop, Intel N150, 4GB RAM, 128GB eMMC, Windows 11 Home, 1-Year Microsoft 365 Included, Blue",
+    "brand": "HP Inc.",
+    "price": "$279.99",
+    "reg_price": "$466.65"
+  },
+  {
+    "tcin": "1011021120",
+    "url": "https://www.target.com/p/hp-14-laptop-intel-processor-n150-beat-i3-1-year-office-365-copilot-ai-win11-wifi6-w-gm-accessory/-/A-1011021120?preselect=1011021121",
+    "title": "HP 14\" Laptop, Intel Processor N150 (Beat i3) 1-Year Office 365 Copilot AI Win11 WiFi6",
+    "brand": "HP Inc.",
+    "price": "$299.99 - $329.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "1011111206",
+    "url": "https://www.target.com/p/lenovo-v15-g4-15-6-fhd-ryzen-5-7430u-16gb-ram-512gb-ssd-amd-radeon-graphics-wi-fi-6-win11-pro-black/-/A-1011111206?preselect=1011111206",
+    "title": "LENOVO V15 G4 Laptop, 15.6\" FHD, Ryzen 5, 16GB RAM, 512GB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$599.99",
+    "reg_price": "$999.98"
+  },
+  {
+    "tcin": "1009569567",
+    "url": "https://www.target.com/p/hp-essential-17-entry-laptop-17-3-hd-touch-intel-core-i3-n305-8gb-ram-128gb-emmc-wi-fi-6-win-11-pro/-/A-1009569567",
+    "title": "HP Essential 17 Laptop, 17.3\" HD+ Touch, i3-N305, UHD Graphics, 8GB RAM, 128GB eMMC, Wi-Fi 6, Win 11 Pro",
+    "brand": "HP Inc.",
+    "price": "$539.99",
+    "reg_price": "$899.98"
+  },
+  {
+    "tcin": "1011698610",
+    "url": "https://www.target.com/p/lenovo-thinkpad-t14-14-fhd-business-ai-laptop-intel-core-ultra-7-155u-intel-graphics-16gb-ddr5-1tb-ssd-wi-fi-6-win11-pro-grey/-/A-1011698610",
+    "title": "Lenovo ThinkPad T14 14\" FHD+ Business AI Laptop, Intel Core Ultra 7 155U, Intel Graphics, 16GB DDR5, 1TB SSD, Wi-Fi 6, Win11 Pro, Grey",
+    "brand": "Lenovo",
+    "price": "$1,269.99",
+    "reg_price": "$2,116.65"
+  },
+  {
+    "tcin": "1011102614",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-24gb-ram-1tb-ssd-radeon-wi-fi-6-win11-pro-black/-/A-1011102614",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 24GB RAM, 1TB SSD, AMD Radeon Graphics, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$759.99",
+    "reg_price": "$1,266.65"
+  },
+  {
+    "tcin": "1010257878",
+    "url": "https://www.target.com/p/hp-14-hd-touchscreen-notebook-intel-n150-4gb-ram-128gb-ssd-winter-lavender-intel-n150-quad-core-processor-14-hd-touchscreen-anti-glare-display/-/A-1010257878",
+    "title": "HP 14\" HD Touchscreen Notebook Intel N150 4GB RAM 128GB SSD Winter Lavender + HP Wireless Mouse + One Year M365 Subscription",
+    "brand": "HP Inc.",
+    "price": "$339.99",
+    "reg_price": "$599.99"
+  },
+  {
+    "tcin": "1006740063",
+    "url": "https://www.target.com/p/refurbished-hp-14-ep20-stream-14-hd-laptop-celeron-n150-4gb-128gb-windows-11-manufacturer-refurbished/-/A-1006740063",
+    "title": "Refurbished: HP Stream - 14\" HD Laptop - Intel Celeron N150 - 4GB - 128GB - Windows 11 H - Manufacturer Refurbished",
+    "brand": "HP Inc.",
+    "price": "$209.99",
+    "reg_price": "$449.99"
+  },
+  {
+    "tcin": "95288385",
+    "url": "https://www.target.com/p/apple-macbook-neo-a18-pro-2026-laptop/-/A-95288385?preselect=91122045",
+    "title": "Apple MacBook Neo (A18 Pro, 2026) Laptop - 256GB, Blush",
+    "brand": "Apple",
+    "price": "$699.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "94082936",
+    "url": "https://www.target.com/p/acer-chromebook-315-cb315-4h-c0vn-chromebook-manufacturer-refurbished/-/A-94082936",
+    "title": "Acer Chromebook 315 - 15.6\" Laptop Intel Celeron N4500 - 4GB LPDDR5 RAM 64GB eMMC UHD Graphics - CB315-4H-C0VN - Manufacturer Refurbished",
+    "brand": "Acer",
+    "price": "$149.99",
+    "reg_price": "$299.99"
+  },
+  {
+    "tcin": "1006120927",
+    "url": "https://www.target.com/p/hp-omnibook-7-laptop-computer-16-2k-touch-screen-intel-core-ultra-5-16-gb/-/A-1006120927",
+    "title": "HP OmniBook 7 Laptop Computer 16\" 2K Touch Screen Intel Core Ultra 5 16 GB",
+    "brand": "HP Inc.",
+    "price": "$1,199.99",
+    "reg_price": "$1,399.99"
+  },
+  {
+    "tcin": "1009949717",
+    "url": "https://www.target.com/p/lenovo-ideapad-1-15-6-fhd-laptop-intel-pentium-n6000-ram-emmc-wi-fi-6-win-11-grey/-/A-1009949717?preselect=1009570243",
+    "title": "Lenovo IdeaPad 1 15.6\" FHD Laptop, Intel Pentium N6000, RAM + eMMC, Wi-Fi 6, Win 11, Grey",
+    "brand": "Lenovo",
+    "price": "$339.99 - $629.99",
+    "reg_price": "$566.65 - $1,049.98"
+  },
+  {
+    "tcin": "1006406168",
+    "url": "https://www.target.com/p/acer-aspire-go-15-ai-ready-laptop-15-6-full-hd-ips-intel-core-i7-13620h-32gb-ddr5-1tb-ssd-ag15-71pt-7378/-/A-1006406168",
+    "title": "Acer Aspire Go 15 AI Ready Laptop, 15.6\" Full HD IPS Intel Core i7-13620H 32GB DDR5 1TB SSD AG15-71PT-7378",
+    "brand": "Acer",
+    "price": "$849.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "1011482848",
+    "url": "https://www.target.com/p/refurbished-hp-15-fd0001dx-15-6-hd-laptop-pc-intel-n100-4gb-ram-128gb-ufs-w11h-manufacturer-refurbished/-/A-1011482848",
+    "title": "Refurbished: HP 15-fd0001dx 15.6\" HD Laptop PC, Intel N100, 4GB Ram, 128GB UFS W11H - Manufacturer Refurbished",
+    "brand": "HP Inc.",
+    "price": "$214.99",
+    "reg_price": "$499.99"
+  },
+  {
+    "tcin": "1004642278",
+    "url": "https://www.target.com/p/hp-essential-17t-cn300-laptop-17-3-hd-touch-i7-1355u-64gb-ram-2tb-ssd-iris-xe-graphics-wi-fi-6-windows-11-home-silver/-/A-1004642278",
+    "title": "HP Essential 17.3\" HD+ Touch Laptop, i7-1355U, 64GB RAM, 2TB SSD, Iris Xe Graphics, Wi-Fi 6, Windows 11 Home, Silver",
+    "brand": "HP Inc.",
+    "price": "$1,299.99",
+    "reg_price": "$2,166.65"
+  },
+  {
+    "tcin": "1005955889",
+    "url": "https://www.target.com/p/hp-chromebook-laptop-computer-14-hd-intel-celeron-4-gb-memory-64-gb-emmc/-/A-1005955889",
+    "title": "HP Chromebook Laptop Computer 14\" HD Intel Celeron 4 GB memory;64 GB eMMC",
+    "brand": "HP Inc.",
+    "price": "$199.99",
+    "reg_price": "$399.99"
+  },
+  {
+    "tcin": "1007664152",
+    "url": "https://www.target.com/p/omen-gaming-laptop-16-2k-amd-ryzen-ai-7-16-gb-memory-1-tb-ssd-windows-11-home/-/A-1007664152?preselect=1004798218",
+    "title": "OMEN Gaming Laptop 16\" 2K AMD Ryzen AI 7 16 GB memory;1 TB SSD Windows 11 Home",
+    "brand": "HP Inc.",
+    "price": "$1,299.99",
+    "reg_price": "$2,099.99"
+  },
+  {
+    "tcin": "92610962",
+    "url": "https://www.target.com/p/hp-inc-chromebook-laptop-computer-14-fhd-intel-core-i3-8-gb-memory-128-gb-ufs/-/A-92610962",
+    "title": "HP Chromebook Laptop Computer 14\" FHD Intel Core i3 8 GB memory; 128 GB UFS",
+    "brand": "HP Inc.",
+    "price": "$319.99",
+    "reg_price": "$649.99"
+  },
+  {
+    "tcin": "1011102739",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-24gb-ram-1tb-ssd-radeon-wi-fi-6-win11-home-black/-/A-1011102739",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 24GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Home, Black",
+    "brand": "Lenovo",
+    "price": "$729.99",
+    "reg_price": "$1,216.65"
+  },
+  {
+    "tcin": "1010320474",
+    "url": "https://www.target.com/p/hp-14-hd-touchscreen-notebook-intel-n150-4gb-ram-128gb-ssd-moonlight-blue-hp-wireless-mouse/-/A-1010320474",
+    "title": "HP 14\" HD Touchscreen Notebook Intel N150 4GB RAM 128GB SSD Moonlight Blue + HP Wireless Mouse + One Year M365 Subscription",
+    "brand": "HP Inc.",
+    "price": "$339.99",
+    "reg_price": "$599.99"
+  },
+  {
+    "tcin": "1005955892",
+    "url": "https://www.target.com/p/hp-omnibook-5-laptop-computer-14-2k-touch-screen-snapdragon-x-plus-32-gb/-/A-1005955892",
+    "title": "HP OmniBook 5 Laptop Computer 14\" 2K Touch Screen Snapdragon X Plus 32 GB",
+    "brand": "HP Inc.",
+    "price": "$1,549.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "1009569567",
+    "url": "https://www.target.com/p/hp-essential-17-entry-laptop-17-3-hd-touch-intel-core-i3-n305-8gb-ram-128gb-emmc-wi-fi-6-win-11-pro/-/A-1009569567",
+    "title": "HP Essential 17 Laptop, 17.3\" HD+ Touch, i3-N305, UHD Graphics, 8GB RAM, 128GB eMMC, Wi-Fi 6, Win 11 Pro",
+    "brand": "HP Inc.",
+    "price": "$539.99",
+    "reg_price": "$899.98"
+  },
+  {
+    "tcin": "95288385",
+    "url": "https://www.target.com/p/apple-macbook-neo-a18-pro-2026-laptop/-/A-95288385?preselect=91122081",
+    "title": "Apple MacBook Neo (A18 Pro, 2026) Laptop - 256GB, Silver",
+    "brand": "Apple",
+    "price": "$699.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "1012121995",
+    "url": "https://www.target.com/p/lenovo-v15-g4-amn-15-6-fhd-notebook-amd-ryzen-3-16gb-ram-512gb-ssd-windows-11-h-business-black-83cq0023us/-/A-1012121995",
+    "title": "Lenovo V15 G4 AMN 15.6\" FHD Notebook, AMD Ryzen 3, 16GB RAM, 512GB SSD, Windows 11 H, Business Black (83CQ0023US)",
+    "brand": "Lenovo",
+    "price": "$499.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "95288385",
+    "url": "https://www.target.com/p/apple-macbook-neo-a18-pro-2026-laptop/-/A-95288385?preselect=91122085",
+    "title": "Apple MacBook Neo (A18 Pro, 2026) Laptop - 256GB, Indigo",
+    "brand": "Apple",
+    "price": "$699.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "95288385",
+    "url": "https://www.target.com/p/apple-macbook-neo-a18-pro-2026-laptop/-/A-95288385?preselect=85966253",
+    "title": "Apple MacBook Neo (A18 Pro, 2026) Laptop - 256GB, Citrus",
+    "brand": "Apple",
+    "price": "$699.99",
+    "reg_price": null
+  },
+  {
+    "tcin": "1009881032",
+    "url": "https://www.target.com/p/hp-elitebook-840-g8-14-i5-1145g7-16gb-256gb-ssd-w11p-low-battery-health-scratch-dent/-/A-1009881032",
+    "title": "Refurbished Hp Elitebook 840 G8 14\" Laptop i5-1145G7 16GB 256GB SSD W11P (Low Batt Health) - Scratch & Dent Seller Refurbished",
+    "brand": "HP Inc.",
+    "price": "$199.99",
+    "reg_price": "$399.99"
+  },
+  {
+    "tcin": "1011111215",
+    "url": "https://www.target.com/p/lenovo-v15-g4-15-6-fhd-ryzen-5-7430u-40gb-ram-1tb-ssd-amd-radeon-graphics-wi-fi-6-win11-pro-black/-/A-1011111215?preselect=1011111215",
+    "title": "LENOVO V15 G4 Laptop, 15.6\" FHD, Ryzen 5 7430U, 40GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$879.99",
+    "reg_price": "$1,466.65"
+  },
+  {
+    "tcin": "1010480021",
+    "url": "https://www.target.com/p/thunderobot-storm-17-3-qhd-165hz-gaming-laptop-intel-i7-13620h-rtx-5060-16gb-ddr5-512gb-pcie-ssd-wi-fi-6-win11-home-black/-/A-1010480021",
+    "title": "THUNDEROBOT Storm 17.3\" QHD 165Hz Gaming Laptop, Intel i7-13620H, RTX 5060, 16GB DDR5, 512GB PCIe SSD, Wi-Fi 6, Win11 Home, Black",
+    "brand": "ThundeRobot",
+    "price": "$1,069.00",
+    "reg_price": "$1,781.67"
+  },
+  {
+    "tcin": "1010480210",
+    "url": "https://www.target.com/p/thunderobot-storm-17-3-qhd-165hz-gaming-laptop-intel-i7-13620h-rtx-5060-32gb-ddr5-1tb-pcie-ssd-wi-fi-6-win11-home-black/-/A-1010480210",
+    "title": "THUNDEROBOT Storm 17.3\" QHD 165Hz Gaming Laptop, Intel i7-13620H, RTX 5060, 32GB DDR5, 1TB PCIe SSD, Wi-Fi 6, Win11 Home, Black",
+    "brand": "ThundeRobot",
+    "price": "$1,299.00",
+    "reg_price": "$2,165.00"
+  },
+  {
+    "tcin": "93733431",
+    "url": "https://www.target.com/p/hp-inc-chromebook-laptop-computer-14-fhd-touch-screen-intel-core-i3-8-gb-memory/-/A-93733431",
+    "title": "HP Chromebook Laptop Computer 14\" FHD Touch Screen Intel Core i3 8 GB memory;",
+    "brand": "HP Inc.",
+    "price": "$319.99",
+    "reg_price": "$739.99"
+  },
+  {
+    "tcin": "1006061558",
+    "url": "https://www.target.com/p/acer-aspire-14-ai-a14-52m-72fh-14-inch-laptop-intel-core-ultra-7-8-core-16gb-ram-512gb-ssd-windows-11/-/A-1006061558",
+    "title": "Acer Aspire 14 AI 14\" Laptop Intel Core Ultra 7 256V 8-Core 16GB RAM 1TB SSD - Windows 11 Home - AI-Ready Portable PC - Silver A14-52M-72FH",
+    "brand": "Acer",
+    "price": "$599.99",
+    "reg_price": "$679.99"
+  },
+  {
+    "tcin": "1004642278",
+    "url": "https://www.target.com/p/hp-essential-17t-cn300-laptop-17-3-hd-touch-i7-1355u-64gb-ram-2tb-ssd-iris-xe-graphics-wi-fi-6-windows-11-home-silver/-/A-1004642278",
+    "title": "HP Essential 17.3\" HD+ Touch Laptop, i7-1355U, 64GB RAM, 2TB SSD, Iris Xe Graphics, Wi-Fi 6, Windows 11 Home, Silver",
+    "brand": "HP Inc.",
+    "price": "$1,299.99",
+    "reg_price": "$2,166.65"
+  },
+  {
+    "tcin": "1010548348",
+    "url": "https://www.target.com/p/hp-essential-17-17-3-hd-touch-laptop-ryzen-5-7430u-8gb-ddr4-ssd-radeon-graphics-wi-fi-6-windows-11-blue/-/A-1010548348?preselect=1009627305",
+    "title": "HP Essential 17 17.3\" HD+ Touch Laptop, Ryzen 5 7430U, 8GB DDR4, SSD, Radeon Graphics, Wi-Fi 6, Windows 11, Blue",
+    "brand": "HP Inc.",
+    "price": "$639.99 - $929.99",
+    "reg_price": "$1,066.65 - $1,549.98"
+  },
+  {
+    "tcin": "1011698612",
+    "url": "https://www.target.com/p/lenovo-thinkpad-t14-14-fhd-business-ai-laptop-intel-core-ultra-7-155u-intel-graphics-32gb-ddr5-1tb-ssd-wi-fi-6-win11-pro-grey/-/A-1011698612",
+    "title": "Lenovo ThinkPad T14 14\" FHD+ Business AI Laptop, Intel Core Ultra 7 155U, Intel Graphics, 32GB DDR5, 1TB SSD, Wi-Fi 6, Win11 Pro, Grey",
+    "brand": "Lenovo",
+    "price": "$1,459.99",
+    "reg_price": "$2,433.32"
+  },
+  {
+    "tcin": "1010170575",
+    "url": "https://www.target.com/p/hp-essential-17-entry-laptop-17-3-hd-touch-intel-core-i3-n305-ram-emmc-ssd-wi-fi-6-win-11-home/-/A-1010170575?preselect=1009568914",
+    "title": "HP Essential 17 Laptop, 17.3\" HD+ Touch, Intel Core i3-N305, up to 32GB RAM, eMMC + SSD, Wi-Fi 6, Win 11 Home",
+    "brand": "HP Inc.",
+    "price": "$509.99 - $949.99",
+    "reg_price": "$849.98 - $1,583.32"
+  },
+  {
+    "tcin": "1011102750",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-16gb-ram-512gbssd-radeon-wi-fi-6-win11-home-black/-/A-1011102750",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 16GB RAM, 512GBSSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Home, Black",
+    "brand": "Lenovo",
+    "price": "$559.99",
+    "reg_price": "$933.32"
+  },
+  {
+    "tcin": "1010911847",
+    "url": "https://www.target.com/p/hp-essential-14-dq3015dx-14-hd-1366-768-intel-celeron-n4500-intel-uhd-graphics-8gb-ddr4-64gb-emmc-wi-fi-6-windows-11-home-rose/-/A-1010911847",
+    "title": "HP Essential 14-dq3015dx, 14\" HD 1366×768, Intel Celeron N4500, Intel UHD Graphics, 8GB DDR4, 64GB eMMC, Wi-Fi 6, Windows 11 Home, Rose",
+    "brand": "HP Inc.",
+    "price": "$269.99",
+    "reg_price": "$449.98"
+  },
+  {
+    "tcin": "1010801658",
+    "url": "https://www.target.com/p/hp-17-3-hd-touchscreen-notebook-intel-n100-4gb-ram-128gb-ufs-chai-latte-hp-wireless-mouse/-/A-1010801658",
+    "title": "HP 17.3\" HD+ Touchscreen Notebook Intel N100 4GB RAM 128GB UFS Chai Latte + HP Wireless Mouse",
+    "brand": "HP Inc.",
+    "price": "$459.99",
+    "reg_price": "$799.99"
+  },
+  {
+    "tcin": "1006851898",
+    "url": "https://www.target.com/p/hp-essential-17-3-touch-laptop-i3-n305-uhd-graphics-16gb-ram-128gb-emmc-512gb-ssd-wi-fi-6-windows-11-pro-silver/-/A-1006851898",
+    "title": "HP Essential 17 Laptop, 17.3\" HD+ Touch, i3-N305, UHD Graphics, 16GB RAM, 128GB eMMC + 512GB SSD, Wi-Fi 6, Windows 11 Pro, Silver",
+    "brand": "HP Inc.",
+    "price": "$639.99",
+    "reg_price": "$1,066.65"
+  },
+  {
+    "tcin": "1010966768",
+    "url": "https://www.target.com/p/hp-omnibook-3-laptop-computer-14-2k-intel-core-5-8-gb-memory-512-gb-ssd/-/A-1010966768",
+    "title": "HP OmniBook 3 Laptop Computer 14\" 2K Intel Core 5 8 GB memory;512 GB SSD",
+    "brand": "HP Inc.",
+    "price": "$499.99",
+    "reg_price": "$849.99"
+  },
+  {
+    "tcin": "1011102633",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-40gb-ram-1tb-ssd-radeon-wi-fi-6-win11-pro-black/-/A-1011102633?preselect=1011102633",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 40GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$869.99",
+    "reg_price": "$1,449.98"
+  },
+  {
+    "tcin": "1009741834",
+    "url": "https://www.target.com/p/hp-omnibook-7-17t-dc000-17-3-fhd-touch-core-ultra-7-258v-32gb-ram-1tb-ssd-intel-arc-wi-fi-7-win-11-pro-silver/-/A-1009741834",
+    "title": "HP OmniBook 7 Laptop, 17.3\" FHD Touch, Core Ultra 7, 32GB RAM, 1TB SSD, Intel Arc, Wi-Fi 7, Win 11 Pro, Silver",
+    "brand": "HP Inc.",
+    "price": "$1,129.99",
+    "reg_price": "$1,883.32"
+  },
+  {
+    "tcin": "1011102582",
+    "url": "https://www.target.com/p/lenovo-v15-gen-4-15-6-fhd-ryzen-7-7730u-16gb-ram-512gb-ssd-radeon-wi-fi-6-win11-pro-black/-/A-1011102582?preselect=1011102582",
+    "title": "Lenovo V15 Gen 4 Laptop, 15.6\" FHD, AMD Ryzen 7, 16GB RAM, 512GB SSD, AMD Radeon Graphics, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$589.99",
+    "reg_price": "$983.32"
+  },
+  {
+    "tcin": "1011523178",
+    "url": "https://www.target.com/p/hp-essential-14-laptop-14-hd-60hz-intel-n-series-n150-intel-graphics-16gb-ddr4-sodimm-128gb-emmc-wi-fi-6-windows-11-home-silver/-/A-1011523178",
+    "title": "HP Essential 14 Laptop, 14\" HD 60Hz, Intel N-Series N150, Intel Graphics, 16GB DDR4 SODIMM, 128GB eMMC, Wi-Fi 6, Windows 11 Home, Silver",
+    "brand": "HP Inc.",
+    "price": "$379.99",
+    "reg_price": "$633.32"
+  },
+  {
+    "tcin": "1003943417",
+    "url": "https://www.target.com/p/gateway-ultra-slim-15-6-fhd-laptop-intel-core-i3-1115g4-8gb-256gb-win10h-manufacturer-refurbished/-/A-1003943417",
+    "title": "Refurbished: Gateway Ultra Slim 15.6\" FHD Laptop Intel Core i3-1115G4 8GB 256GB Win11H - Manufacturer Refurbished",
+    "brand": "Gateway",
+    "price": "$199.99",
+    "reg_price": "$799.99"
+  },
+  {
+    "tcin": "1012079709",
+    "url": "https://www.target.com/p/hp-essential-14-hd-copilot-ai-laptop-intel-n150-16gb-ram-128gb-emmc-windows-11-home-lightweight-portable-student-everyday-use-notebook/-/A-1012079709?preselect=1012096079",
+    "title": "HP Essential 14\" HD Laptop, Intel N150, 16GB RAM, 128GB eMMC, Windows 11 Home, 1-Year Microsoft 365 Included",
+    "brand": "HP Inc.",
+    "price": "$379.99 - $389.99",
+    "reg_price": "$633.32 - $649.98"
+  },
+  {
+    "tcin": "1011440807",
+    "url": "https://www.target.com/p/hp-omnibook-3-16-laptop-fhd-60hz-qualcomm-8-core-cpu-adreno-x1-45-16gb-ram-1tb-ssd-wi-fi-6-win11-pro-black/-/A-1011440807",
+    "title": "HP OmniBook 3 16\" Laptop, FHD+ 60Hz, Qualcomm 8-Core CPU, Adreno X1-45, 16GB RAM, 1TB SSD, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "HP Inc.",
+    "price": "$749.99",
+    "reg_price": "$1,249.98"
+  },
+  {
+    "tcin": "1010305983",
+    "url": "https://www.target.com/p/hp-14-hd-touchscreen-notebook-intel-n150-4gb-ram-128gb-ssd-snowflake-white-hp-wireless-mouse/-/A-1010305983",
+    "title": "HP 14\" HD Touchscreen Notebook Intel N150 4GB RAM 128GB SSD Snowflake White + HP Wireless Mouse + One Year M365 Subscription",
+    "brand": "HP Inc.",
+    "price": "$339.99",
+    "reg_price": "$599.99"
+  },
+  {
+    "tcin": "1010805419",
+    "url": "https://www.target.com/p/hp-17-3-hd-touchscreen-notebook-intel-n100-4gb-ram-128gb-ufs-winter-lavender-hp-wireless-mouse/-/A-1010805419",
+    "title": "HP 17.3\" HD+ Touchscreen Notebook Intel N100 4GB RAM 128GB UFS Winter Lavender + HP Wireless Mouse + One Year M365 Subscription",
+    "brand": "HP Inc.",
+    "price": "$459.99",
+    "reg_price": "$799.99"
+  },
+  {
+    "tcin": "1011111215",
+    "url": "https://www.target.com/p/lenovo-v15-g4-15-6-fhd-ryzen-5-7430u-40gb-ram-1tb-ssd-amd-radeon-graphics-wi-fi-6-win11-pro-black/-/A-1011111215?preselect=1011111215",
+    "title": "LENOVO V15 G4 Laptop, 15.6\" FHD, Ryzen 5 7430U, 40GB RAM, 1TB SSD, AMD Radeon Graphics, Wi-Fi 6, Win11 Pro, Black",
+    "brand": "Lenovo",
+    "price": "$879.99",
+    "reg_price": "$1,466.65"
+  },
+  {
+    "tcin": "91678426",
+    "url": "https://www.target.com/p/hp-15-dw0083wm-15-6-hd-laptop-intel-pentium-n5000-1-1ghz-4gb-128gb-w10h-manufacturer-refurbished/-/A-91678426",
+    "title": "Refurbished: HP 15-dw00 15.6\" HD Laptop - Intel Pentium N5000 - 4GB|128GB - Win 11 Home - Manufacturer Refurbished",
+    "brand": "HP Inc.",
+    "price": "$194.99",
+    "reg_price": "$499.99"
+  },
+  {
+    "tcin": "1009712376",
+    "url": "https://www.target.com/p/refurbished-hp-elitebook-845-g7-laptop-14-fhd-amd-ryzen-5-4650u-16gb-256gb-w11p-manufacturer-refurbished/-/A-1009712376",
+    "title": "Refurbished: HP EliteBook 845 G7 Laptop, 14\" FHD , AMD Ryzen 5 4650U, 16GB, 256GB, W11P - Manufacturer Refurbished",
+    "brand": "HP Inc.",
+    "price": "$344.99",
+    "reg_price": "$1,499.99"
+  },
+  {
+    "tcin": "1005647000",
+    "url": "https://www.target.com/p/refurbished-hp-elitebook-845-g8-14-fhd-laptop-amd-ryzen-5-pro-5650u-16gb-256gb-w11p-manufacturer-refurbished/-/A-1005647000",
+    "title": "Refurbished: HP Elitebook 845 G8 14\" FHD Laptop AMD Ryzen 5 PRO 5650U 16GB 256GB W11P - Manufacturer Refurbished",
+    "brand": "HP Inc.",
+    "price": "$379.99",
+    "reg_price": "$1,499.99"
+  },
+  {
+    "tcin": "1009644715",
+    "url": "https://www.target.com/p/hp-essential-14-laptop-14-hd-display-intel-n150-16gb-ram-128gb-emmc-wi-fi-6-windows-11-pro-rose/-/A-1009644715",
+    "title": "HP Essential 14\" HD Laptop, Intel N150, 16GB RAM, 128GB eMMC, Windows 11 Pro, Rose, Lightweight Portable Student Everyday Use Notebook",
+    "brand": "HP Inc.",
+    "price": "$399.99",
+    "reg_price": "$666.65"
+  },
+  {
+    "tcin": "1010396437",
+    "url": "https://www.target.com/p/hp-17-3-hd-touchscreen-notebook-intel-n100-4gb-ram-128gb-ufs-spring-iridescence-hp-wireless-mouse/-/A-1010396437",
+    "title": "HP 17.3\" HD+ Touchscreen Notebook Intel N100 4GB RAM 128GB UFS Spring Iridescence + HP Wireless Mouse + One Year M365 Subscription",
+    "brand": "HP Inc.",
+    "price": "$459.99",
+    "reg_price": "$799.99"
+  },
+  {
+    "tcin": "1010966796",
+    "url": "https://www.target.com/p/hp-omnibook-5-laptop-computer-16-2k-intel-core-5-8-gb-memory-512-gb-ssd/-/A-1010966796",
+    "title": "HP OmniBook 5 Laptop Computer 16\" 2K Intel Core 5 8 GB memory;512 GB SSD",
+    "brand": "HP Inc.",
+    "price": "$529.99",
+    "reg_price": "$1,049.99"
+  }
+]

--- a/target-scraper/results/store_locations.json
+++ b/target-scraper/results/store_locations.json
@@ -1,0 +1,10047 @@
+[
+  {
+    "url": "https://www.target.com/sl/crystal/3",
+    "slug": "crystal",
+    "store_id": "3"
+  },
+  {
+    "url": "https://www.target.com/sl/duluth/4",
+    "slug": "duluth",
+    "store_id": "4"
+  },
+  {
+    "url": "https://www.target.com/sl/bloomington-79th-and-penn/5",
+    "slug": "bloomington-79th-and-penn",
+    "store_id": "5"
+  },
+  {
+    "url": "https://www.target.com/sl/bridgeton/12",
+    "slug": "bridgeton",
+    "store_id": "12"
+  },
+  {
+    "url": "https://www.target.com/sl/north-dallas/13",
+    "slug": "north-dallas",
+    "store_id": "13"
+  },
+  {
+    "url": "https://www.target.com/sl/tulsa/19",
+    "slug": "tulsa",
+    "store_id": "19"
+  },
+  {
+    "url": "https://www.target.com/sl/ballwin/26",
+    "slug": "ballwin",
+    "store_id": "26"
+  },
+  {
+    "url": "https://www.target.com/sl/oklahoma-city-north/43",
+    "slug": "oklahoma-city-north",
+    "store_id": "43"
+  },
+  {
+    "url": "https://www.target.com/sl/arvada/48",
+    "slug": "arvada",
+    "store_id": "48"
+  },
+  {
+    "url": "https://www.target.com/sl/east-lake-street-and-hwy-55/52",
+    "slug": "east-lake-street-and-hwy-55",
+    "store_id": "52"
+  },
+  {
+    "url": "https://www.target.com/sl/medallion/55",
+    "slug": "medallion",
+    "store_id": "55"
+  },
+  {
+    "url": "https://www.target.com/sl/fargo/61",
+    "slug": "fargo",
+    "store_id": "61"
+  },
+  {
+    "url": "https://www.target.com/sl/boulder/64",
+    "slug": "boulder",
+    "store_id": "64"
+  },
+  {
+    "url": "https://www.target.com/sl/plano/67",
+    "slug": "plano",
+    "store_id": "67"
+  },
+  {
+    "url": "https://www.target.com/sl/east-st-paul/68",
+    "slug": "east-st-paul",
+    "store_id": "68"
+  },
+  {
+    "url": "https://www.target.com/sl/valley-west/69",
+    "slug": "valley-west",
+    "store_id": "69"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-westchase/75",
+    "slug": "houston-westchase",
+    "store_id": "75"
+  },
+  {
+    "url": "https://www.target.com/sl/sioux-falls/76",
+    "slug": "sioux-falls",
+    "store_id": "76"
+  },
+  {
+    "url": "https://www.target.com/sl/alton/78",
+    "slug": "alton",
+    "store_id": "78"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-collins/79",
+    "slug": "fort-collins",
+    "store_id": "79"
+  },
+  {
+    "url": "https://www.target.com/sl/wichita-falls/80",
+    "slug": "wichita-falls",
+    "store_id": "80"
+  },
+  {
+    "url": "https://www.target.com/sl/waukesha/82",
+    "slug": "waukesha",
+    "store_id": "82"
+  },
+  {
+    "url": "https://www.target.com/sl/lubbock-university-ave/83",
+    "slug": "lubbock-university-ave",
+    "store_id": "83"
+  },
+  {
+    "url": "https://www.target.com/sl/minot/85",
+    "slug": "minot",
+    "store_id": "85"
+  },
+  {
+    "url": "https://www.target.com/sl/dubuque/86",
+    "slug": "dubuque",
+    "store_id": "86"
+  },
+  {
+    "url": "https://www.target.com/sl/memphis-central/90",
+    "slug": "memphis-central",
+    "store_id": "90"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-junction/93",
+    "slug": "grand-junction",
+    "store_id": "93"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-north/95",
+    "slug": "austin-north",
+    "store_id": "95"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-south-lamar/96",
+    "slug": "austin-south-lamar",
+    "store_id": "96"
+  },
+  {
+    "url": "https://www.target.com/sl/ridgedale/100",
+    "slug": "ridgedale",
+    "store_id": "100"
+  },
+  {
+    "url": "https://www.target.com/sl/evansville-north/108",
+    "slug": "evansville-north",
+    "store_id": "108"
+  },
+  {
+    "url": "https://www.target.com/sl/kokomo/111",
+    "slug": "kokomo",
+    "store_id": "111"
+  },
+  {
+    "url": "https://www.target.com/sl/bloomington-normal/137",
+    "slug": "bloomington-normal",
+    "store_id": "137"
+  },
+  {
+    "url": "https://www.target.com/sl/new-albany/139",
+    "slug": "new-albany",
+    "store_id": "139"
+  },
+  {
+    "url": "https://www.target.com/sl/rivergate/144",
+    "slug": "rivergate",
+    "store_id": "144"
+  },
+  {
+    "url": "https://www.target.com/sl/white-bridge/146",
+    "slug": "white-bridge",
+    "store_id": "146"
+  },
+  {
+    "url": "https://www.target.com/sl/arapahoe/147",
+    "slug": "arapahoe",
+    "store_id": "147"
+  },
+  {
+    "url": "https://www.target.com/sl/knoxville-west/151",
+    "slug": "knoxville-west",
+    "store_id": "151"
+  },
+  {
+    "url": "https://www.target.com/sl/racine/152",
+    "slug": "racine",
+    "store_id": "152"
+  },
+  {
+    "url": "https://www.target.com/sl/colorado-springs-north/154",
+    "slug": "colorado-springs-north",
+    "store_id": "154"
+  },
+  {
+    "url": "https://www.target.com/sl/beaumont/158",
+    "slug": "beaumont",
+    "store_id": "158"
+  },
+  {
+    "url": "https://www.target.com/sl/little-rock-north/162",
+    "slug": "little-rock-north",
+    "store_id": "162"
+  },
+  {
+    "url": "https://www.target.com/sl/casper/164",
+    "slug": "casper",
+    "store_id": "164"
+  },
+  {
+    "url": "https://www.target.com/sl/alexandria/167",
+    "slug": "alexandria",
+    "store_id": "167"
+  },
+  {
+    "url": "https://www.target.com/sl/billings-west/171",
+    "slug": "billings-west",
+    "store_id": "171"
+  },
+  {
+    "url": "https://www.target.com/sl/bitters/176",
+    "slug": "bitters",
+    "store_id": "176"
+  },
+  {
+    "url": "https://www.target.com/sl/pacoima/183",
+    "slug": "pacoima",
+    "store_id": "183"
+  },
+  {
+    "url": "https://www.target.com/sl/alhambra/184",
+    "slug": "alhambra",
+    "store_id": "184"
+  },
+  {
+    "url": "https://www.target.com/sl/orange-show/188",
+    "slug": "orange-show",
+    "store_id": "188"
+  },
+  {
+    "url": "https://www.target.com/sl/commerce/189",
+    "slug": "commerce",
+    "store_id": "189"
+  },
+  {
+    "url": "https://www.target.com/sl/south-gate/190",
+    "slug": "south-gate",
+    "store_id": "190"
+  },
+  {
+    "url": "https://www.target.com/sl/garden-grove-harbor/192",
+    "slug": "garden-grove-harbor",
+    "store_id": "192"
+  },
+  {
+    "url": "https://www.target.com/sl/brookhurst/193",
+    "slug": "brookhurst",
+    "store_id": "193"
+  },
+  {
+    "url": "https://www.target.com/sl/long-beach-bellflower/195",
+    "slug": "long-beach-bellflower",
+    "store_id": "195"
+  },
+  {
+    "url": "https://www.target.com/sl/culver-city-jefferson/198",
+    "slug": "culver-city-jefferson",
+    "store_id": "198"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-beach/199",
+    "slug": "manhattan-beach",
+    "store_id": "199"
+  },
+  {
+    "url": "https://www.target.com/sl/torrance/200",
+    "slug": "torrance",
+    "store_id": "200"
+  },
+  {
+    "url": "https://www.target.com/sl/sports-arena/201",
+    "slug": "sports-arena",
+    "store_id": "201"
+  },
+  {
+    "url": "https://www.target.com/sl/chula-vista-broadway/203",
+    "slug": "chula-vista-broadway",
+    "store_id": "203"
+  },
+  {
+    "url": "https://www.target.com/sl/kearny-mesa/205",
+    "slug": "kearny-mesa",
+    "store_id": "205"
+  },
+  {
+    "url": "https://www.target.com/sl/riverside/212",
+    "slug": "riverside",
+    "store_id": "212"
+  },
+  {
+    "url": "https://www.target.com/sl/st-cloud-crossroads/215",
+    "slug": "st-cloud-crossroads",
+    "store_id": "215"
+  },
+  {
+    "url": "https://www.target.com/sl/lincoln/217",
+    "slug": "lincoln",
+    "store_id": "217"
+  },
+  {
+    "url": "https://www.target.com/sl/abilene/219",
+    "slug": "abilene",
+    "store_id": "219"
+  },
+  {
+    "url": "https://www.target.com/sl/eden-prairie/220",
+    "slug": "eden-prairie",
+    "store_id": "220"
+  },
+  {
+    "url": "https://www.target.com/sl/amarillo/221",
+    "slug": "amarillo",
+    "store_id": "221"
+  },
+  {
+    "url": "https://www.target.com/sl/puente-hills/222",
+    "slug": "puente-hills",
+    "store_id": "222"
+  },
+  {
+    "url": "https://www.target.com/sl/milwaukee-chase/223",
+    "slug": "milwaukee-chase",
+    "store_id": "223"
+  },
+  {
+    "url": "https://www.target.com/sl/cheyenne/224",
+    "slug": "cheyenne",
+    "store_id": "224"
+  },
+  {
+    "url": "https://www.target.com/sl/laverne/226",
+    "slug": "laverne",
+    "store_id": "226"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-fe-springs/227",
+    "slug": "santa-fe-springs",
+    "store_id": "227"
+  },
+  {
+    "url": "https://www.target.com/sl/west-hills/228",
+    "slug": "west-hills",
+    "store_id": "228"
+  },
+  {
+    "url": "https://www.target.com/sl/cypress/229",
+    "slug": "cypress",
+    "store_id": "229"
+  },
+  {
+    "url": "https://www.target.com/sl/orange/230",
+    "slug": "orange",
+    "store_id": "230"
+  },
+  {
+    "url": "https://www.target.com/sl/paradise-valley/233",
+    "slug": "paradise-valley",
+    "store_id": "233"
+  },
+  {
+    "url": "https://www.target.com/sl/appleton/238",
+    "slug": "appleton",
+    "store_id": "238"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia/239",
+    "slug": "columbia",
+    "store_id": "239"
+  },
+  {
+    "url": "https://www.target.com/sl/lancaster/245",
+    "slug": "lancaster",
+    "store_id": "245"
+  },
+  {
+    "url": "https://www.target.com/sl/simi-valley-cochran-street/246",
+    "slug": "simi-valley-cochran-street",
+    "store_id": "246"
+  },
+  {
+    "url": "https://www.target.com/sl/westminster/249",
+    "slug": "westminster",
+    "store_id": "249"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-ana-south-coast/250",
+    "slug": "santa-ana-south-coast",
+    "store_id": "250"
+  },
+  {
+    "url": "https://www.target.com/sl/mesa-central/251",
+    "slug": "mesa-central",
+    "store_id": "251"
+  },
+  {
+    "url": "https://www.target.com/sl/great-falls/253",
+    "slug": "great-falls",
+    "store_id": "253"
+  },
+  {
+    "url": "https://www.target.com/sl/san-angelo/254",
+    "slug": "san-angelo",
+    "store_id": "254"
+  },
+  {
+    "url": "https://www.target.com/sl/irving/255",
+    "slug": "irving",
+    "store_id": "255"
+  },
+  {
+    "url": "https://www.target.com/sl/aurora-se/256",
+    "slug": "aurora-se",
+    "store_id": "256"
+  },
+  {
+    "url": "https://www.target.com/sl/valencia/257",
+    "slug": "valencia",
+    "store_id": "257"
+  },
+  {
+    "url": "https://www.target.com/sl/chino-philadelphia-street/258",
+    "slug": "chino-philadelphia-street",
+    "store_id": "258"
+  },
+  {
+    "url": "https://www.target.com/sl/aliso-viejo/259",
+    "slug": "aliso-viejo",
+    "store_id": "259"
+  },
+  {
+    "url": "https://www.target.com/sl/st-louis-park-hwy-100/260",
+    "slug": "st-louis-park-hwy-100",
+    "store_id": "260"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-east/264",
+    "slug": "las-vegas-east",
+    "store_id": "264"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-flamingo/265",
+    "slug": "las-vegas-flamingo",
+    "store_id": "265"
+  },
+  {
+    "url": "https://www.target.com/sl/roseville-douglas-blvd/267",
+    "slug": "roseville-douglas-blvd",
+    "store_id": "267"
+  },
+  {
+    "url": "https://www.target.com/sl/douglas-county/271",
+    "slug": "douglas-county",
+    "store_id": "271"
+  },
+  {
+    "url": "https://www.target.com/sl/modesto-mchenry-ave/273",
+    "slug": "modesto-mchenry-ave",
+    "store_id": "273"
+  },
+  {
+    "url": "https://www.target.com/sl/escondido/274",
+    "slug": "escondido",
+    "store_id": "274"
+  },
+  {
+    "url": "https://www.target.com/sl/fresno-west/275",
+    "slug": "fresno-west",
+    "store_id": "275"
+  },
+  {
+    "url": "https://www.target.com/sl/lakeside/278",
+    "slug": "lakeside",
+    "store_id": "278"
+  },
+  {
+    "url": "https://www.target.com/sl/dearborn/279",
+    "slug": "dearborn",
+    "store_id": "279"
+  },
+  {
+    "url": "https://www.target.com/sl/southland/280",
+    "slug": "southland",
+    "store_id": "280"
+  },
+  {
+    "url": "https://www.target.com/sl/westland/281",
+    "slug": "westland",
+    "store_id": "281"
+  },
+  {
+    "url": "https://www.target.com/sl/madison-heights/282",
+    "slug": "madison-heights",
+    "store_id": "282"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-ana-17th-street/286",
+    "slug": "santa-ana-17th-street",
+    "store_id": "286"
+  },
+  {
+    "url": "https://www.target.com/sl/woodland-hills/288",
+    "slug": "woodland-hills",
+    "store_id": "288"
+  },
+  {
+    "url": "https://www.target.com/sl/cerritos-bloomfield-avenue/289",
+    "slug": "cerritos-bloomfield-avenue",
+    "store_id": "289"
+  },
+  {
+    "url": "https://www.target.com/sl/gardena/290",
+    "slug": "gardena",
+    "store_id": "290"
+  },
+  {
+    "url": "https://www.target.com/sl/riverside-arlington/291",
+    "slug": "riverside-arlington",
+    "store_id": "291"
+  },
+  {
+    "url": "https://www.target.com/sl/fullerton-yorba-linda/293",
+    "slug": "fullerton-yorba-linda",
+    "store_id": "293"
+  },
+  {
+    "url": "https://www.target.com/sl/north-hollywood/294",
+    "slug": "north-hollywood",
+    "store_id": "294"
+  },
+  {
+    "url": "https://www.target.com/sl/poway/296",
+    "slug": "poway",
+    "store_id": "296"
+  },
+  {
+    "url": "https://www.target.com/sl/ventura-main-street/298",
+    "slug": "ventura-main-street",
+    "store_id": "298"
+  },
+  {
+    "url": "https://www.target.com/sl/northridge/299",
+    "slug": "northridge",
+    "store_id": "299"
+  },
+  {
+    "url": "https://www.target.com/sl/alicia-parkway/300",
+    "slug": "alicia-parkway",
+    "store_id": "300"
+  },
+  {
+    "url": "https://www.target.com/sl/rancho-cucamonga/301",
+    "slug": "rancho-cucamonga",
+    "store_id": "301"
+  },
+  {
+    "url": "https://www.target.com/sl/duarte/302",
+    "slug": "duarte",
+    "store_id": "302"
+  },
+  {
+    "url": "https://www.target.com/sl/oceanside/303",
+    "slug": "oceanside",
+    "store_id": "303"
+  },
+  {
+    "url": "https://www.target.com/sl/el-cajon/304",
+    "slug": "el-cajon",
+    "store_id": "304"
+  },
+  {
+    "url": "https://www.target.com/sl/mira-mesa/305",
+    "slug": "mira-mesa",
+    "store_id": "305"
+  },
+  {
+    "url": "https://www.target.com/sl/palm-springs/307",
+    "slug": "palm-springs",
+    "store_id": "307"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-maria/309",
+    "slug": "santa-maria",
+    "store_id": "309"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-riverside/310",
+    "slug": "sacramento-riverside",
+    "store_id": "310"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-madison/311",
+    "slug": "sacramento-madison",
+    "store_id": "311"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-arden/312",
+    "slug": "sacramento-arden",
+    "store_id": "312"
+  },
+  {
+    "url": "https://www.target.com/sl/stockton/313",
+    "slug": "stockton",
+    "store_id": "313"
+  },
+  {
+    "url": "https://www.target.com/sl/fresno-south/314",
+    "slug": "fresno-south",
+    "store_id": "314"
+  },
+  {
+    "url": "https://www.target.com/sl/chico/317",
+    "slug": "chico",
+    "store_id": "317"
+  },
+  {
+    "url": "https://www.target.com/sl/yuba-city/318",
+    "slug": "yuba-city",
+    "store_id": "318"
+  },
+  {
+    "url": "https://www.target.com/sl/tempe/319",
+    "slug": "tempe",
+    "store_id": "319"
+  },
+  {
+    "url": "https://www.target.com/sl/colma/320",
+    "slug": "colma",
+    "store_id": "320"
+  },
+  {
+    "url": "https://www.target.com/sl/redwood-city/321",
+    "slug": "redwood-city",
+    "store_id": "321"
+  },
+  {
+    "url": "https://www.target.com/sl/mountain-view/322",
+    "slug": "mountain-view",
+    "store_id": "322"
+  },
+  {
+    "url": "https://www.target.com/sl/cupertino-de-anza-blvd/323",
+    "slug": "cupertino-de-anza-blvd",
+    "store_id": "323"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-west/324",
+    "slug": "san-jose-west",
+    "store_id": "324"
+  },
+  {
+    "url": "https://www.target.com/sl/dublin/328",
+    "slug": "dublin",
+    "store_id": "328"
+  },
+  {
+    "url": "https://www.target.com/sl/pleasant-hill/330",
+    "slug": "pleasant-hill",
+    "store_id": "330"
+  },
+  {
+    "url": "https://www.target.com/sl/vallejo/331",
+    "slug": "vallejo",
+    "store_id": "331"
+  },
+  {
+    "url": "https://www.target.com/sl/corpus-christi/335",
+    "slug": "corpus-christi",
+    "store_id": "335"
+  },
+  {
+    "url": "https://www.target.com/sl/irvine/336",
+    "slug": "irvine",
+    "store_id": "336"
+  },
+  {
+    "url": "https://www.target.com/sl/everett/337",
+    "slug": "everett",
+    "store_id": "337"
+  },
+  {
+    "url": "https://www.target.com/sl/lynnwood/338",
+    "slug": "lynnwood",
+    "store_id": "338"
+  },
+  {
+    "url": "https://www.target.com/sl/factoria/339",
+    "slug": "factoria",
+    "store_id": "339"
+  },
+  {
+    "url": "https://www.target.com/sl/north-tacoma/341",
+    "slug": "north-tacoma",
+    "store_id": "341"
+  },
+  {
+    "url": "https://www.target.com/sl/puyallup/342",
+    "slug": "puyallup",
+    "store_id": "342"
+  },
+  {
+    "url": "https://www.target.com/sl/vancouver-plaza-dr/343",
+    "slug": "vancouver-plaza-dr",
+    "store_id": "343"
+  },
+  {
+    "url": "https://www.target.com/sl/beaverton/344",
+    "slug": "beaverton",
+    "store_id": "344"
+  },
+  {
+    "url": "https://www.target.com/sl/washington-square/345",
+    "slug": "washington-square",
+    "store_id": "345"
+  },
+  {
+    "url": "https://www.target.com/sl/clackamas/346",
+    "slug": "clackamas",
+    "store_id": "346"
+  },
+  {
+    "url": "https://www.target.com/sl/saginaw/347",
+    "slug": "saginaw",
+    "store_id": "347"
+  },
+  {
+    "url": "https://www.target.com/sl/bellingham/348",
+    "slug": "bellingham",
+    "store_id": "348"
+  },
+  {
+    "url": "https://www.target.com/sl/lakewood/349",
+    "slug": "lakewood",
+    "store_id": "349"
+  },
+  {
+    "url": "https://www.target.com/sl/flint/350",
+    "slug": "flint",
+    "store_id": "350"
+  },
+  {
+    "url": "https://www.target.com/sl/rochester/351",
+    "slug": "rochester",
+    "store_id": "351"
+  },
+  {
+    "url": "https://www.target.com/sl/dearborn-heights/353",
+    "slug": "dearborn-heights",
+    "store_id": "353"
+  },
+  {
+    "url": "https://www.target.com/sl/canton-ford-road/354",
+    "slug": "canton-ford-road",
+    "store_id": "354"
+  },
+  {
+    "url": "https://www.target.com/sl/topeka/355",
+    "slug": "topeka",
+    "store_id": "355"
+  },
+  {
+    "url": "https://www.target.com/sl/albuquerque-wyoming/356",
+    "slug": "albuquerque-wyoming",
+    "store_id": "356"
+  },
+  {
+    "url": "https://www.target.com/sl/albuquerque-lomas/357",
+    "slug": "albuquerque-lomas",
+    "store_id": "357"
+  },
+  {
+    "url": "https://www.target.com/sl/clovis/358",
+    "slug": "clovis",
+    "store_id": "358"
+  },
+  {
+    "url": "https://www.target.com/sl/rancho-california/359",
+    "slug": "rancho-california",
+    "store_id": "359"
+  },
+  {
+    "url": "https://www.target.com/sl/eagan/360",
+    "slug": "eagan",
+    "store_id": "360"
+  },
+  {
+    "url": "https://www.target.com/sl/lansing-south/361",
+    "slug": "lansing-south",
+    "store_id": "361"
+  },
+  {
+    "url": "https://www.target.com/sl/hillsboro/362",
+    "slug": "hillsboro",
+    "store_id": "362"
+  },
+  {
+    "url": "https://www.target.com/sl/scottsdale-talking-stick-way/363",
+    "slug": "scottsdale-talking-stick-way",
+    "store_id": "363"
+  },
+  {
+    "url": "https://www.target.com/sl/wausau/364",
+    "slug": "wausau",
+    "store_id": "364"
+  },
+  {
+    "url": "https://www.target.com/sl/okemos/365",
+    "slug": "okemos",
+    "store_id": "365"
+  },
+  {
+    "url": "https://www.target.com/sl/lexington/366",
+    "slug": "lexington",
+    "store_id": "366"
+  },
+  {
+    "url": "https://www.target.com/sl/smyrna/373",
+    "slug": "smyrna",
+    "store_id": "373"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-rapids-north/397",
+    "slug": "grand-rapids-north",
+    "store_id": "397"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha-nw/530",
+    "slug": "omaha-nw",
+    "store_id": "530"
+  },
+  {
+    "url": "https://www.target.com/sl/lawrence/531",
+    "slug": "lawrence",
+    "store_id": "531"
+  },
+  {
+    "url": "https://www.target.com/sl/papillion/532",
+    "slug": "papillion",
+    "store_id": "532"
+  },
+  {
+    "url": "https://www.target.com/sl/davenport/533",
+    "slug": "davenport",
+    "store_id": "533"
+  },
+  {
+    "url": "https://www.target.com/sl/portage/604",
+    "slug": "portage",
+    "store_id": "604"
+  },
+  {
+    "url": "https://www.target.com/sl/silverdale/606",
+    "slug": "silverdale",
+    "store_id": "606"
+  },
+  {
+    "url": "https://www.target.com/sl/olympia/607",
+    "slug": "olympia",
+    "store_id": "607"
+  },
+  {
+    "url": "https://www.target.com/sl/salem/608",
+    "slug": "salem",
+    "store_id": "608"
+  },
+  {
+    "url": "https://www.target.com/sl/albany/609",
+    "slug": "albany",
+    "store_id": "609"
+  },
+  {
+    "url": "https://www.target.com/sl/battle-creek/610",
+    "slug": "battle-creek",
+    "store_id": "610"
+  },
+  {
+    "url": "https://www.target.com/sl/farmington-hills/611",
+    "slug": "farmington-hills",
+    "store_id": "611"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield/612",
+    "slug": "springfield",
+    "store_id": "612"
+  },
+  {
+    "url": "https://www.target.com/sl/medford/613",
+    "slug": "medford",
+    "store_id": "613"
+  },
+  {
+    "url": "https://www.target.com/sl/bakersfield-ne/614",
+    "slug": "bakersfield-ne",
+    "store_id": "614"
+  },
+  {
+    "url": "https://www.target.com/sl/redding/615",
+    "slug": "redding",
+    "store_id": "615"
+  },
+  {
+    "url": "https://www.target.com/sl/west-lansing/616",
+    "slug": "west-lansing",
+    "store_id": "616"
+  },
+  {
+    "url": "https://www.target.com/sl/boise/617",
+    "slug": "boise",
+    "store_id": "617"
+  },
+  {
+    "url": "https://www.target.com/sl/pueblo/618",
+    "slug": "pueblo",
+    "store_id": "618"
+  },
+  {
+    "url": "https://www.target.com/sl/shoreview/619",
+    "slug": "shoreview",
+    "store_id": "619"
+  },
+  {
+    "url": "https://www.target.com/sl/lacrosse/620",
+    "slug": "lacrosse",
+    "store_id": "620"
+  },
+  {
+    "url": "https://www.target.com/sl/toledo-alexis-road/622",
+    "slug": "toledo-alexis-road",
+    "store_id": "622"
+  },
+  {
+    "url": "https://www.target.com/sl/toledo-monroe-street/623",
+    "slug": "toledo-monroe-street",
+    "store_id": "623"
+  },
+  {
+    "url": "https://www.target.com/sl/holland-mall-drive/624",
+    "slug": "holland-mall-drive",
+    "store_id": "624"
+  },
+  {
+    "url": "https://www.target.com/sl/coors/625",
+    "slug": "coors",
+    "store_id": "625"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-landess/626",
+    "slug": "san-jose-landess",
+    "store_id": "626"
+  },
+  {
+    "url": "https://www.target.com/sl/south-center/627",
+    "slug": "south-center",
+    "store_id": "627"
+  },
+  {
+    "url": "https://www.target.com/sl/kelso/628",
+    "slug": "kelso",
+    "store_id": "628"
+  },
+  {
+    "url": "https://www.target.com/sl/port-huron/632",
+    "slug": "port-huron",
+    "store_id": "632"
+  },
+  {
+    "url": "https://www.target.com/sl/ann-arbor/634",
+    "slug": "ann-arbor",
+    "store_id": "634"
+  },
+  {
+    "url": "https://www.target.com/sl/north-spokane/636",
+    "slug": "north-spokane",
+    "store_id": "636"
+  },
+  {
+    "url": "https://www.target.com/sl/west-seattle/637",
+    "slug": "west-seattle",
+    "store_id": "637"
+  },
+  {
+    "url": "https://www.target.com/sl/west-boca-raton/638",
+    "slug": "west-boca-raton",
+    "store_id": "638"
+  },
+  {
+    "url": "https://www.target.com/sl/mesa-east/639",
+    "slug": "mesa-east",
+    "store_id": "639"
+  },
+  {
+    "url": "https://www.target.com/sl/merced/641",
+    "slug": "merced",
+    "store_id": "641"
+  },
+  {
+    "url": "https://www.target.com/sl/delray-beach/642",
+    "slug": "delray-beach",
+    "store_id": "642"
+  },
+  {
+    "url": "https://www.target.com/sl/apple-valley/643",
+    "slug": "apple-valley",
+    "store_id": "643"
+  },
+  {
+    "url": "https://www.target.com/sl/regency/645",
+    "slug": "regency",
+    "store_id": "645"
+  },
+  {
+    "url": "https://www.target.com/sl/altamonte-springs/647",
+    "slug": "altamonte-springs",
+    "store_id": "647"
+  },
+  {
+    "url": "https://www.target.com/sl/east-colonial/649",
+    "slug": "east-colonial",
+    "store_id": "649"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando-sand-lake-rd/650",
+    "slug": "orlando-sand-lake-rd",
+    "store_id": "650"
+  },
+  {
+    "url": "https://www.target.com/sl/boot-ranch/652",
+    "slug": "boot-ranch",
+    "store_id": "652"
+  },
+  {
+    "url": "https://www.target.com/sl/largo/654",
+    "slug": "largo",
+    "store_id": "654"
+  },
+  {
+    "url": "https://www.target.com/sl/north-dale-mabry/655",
+    "slug": "north-dale-mabry",
+    "store_id": "655"
+  },
+  {
+    "url": "https://www.target.com/sl/university-plaza/656",
+    "slug": "university-plaza",
+    "store_id": "656"
+  },
+  {
+    "url": "https://www.target.com/sl/bemidji/657",
+    "slug": "bemidji",
+    "store_id": "657"
+  },
+  {
+    "url": "https://www.target.com/sl/moorhead/658",
+    "slug": "moorhead",
+    "store_id": "658"
+  },
+  {
+    "url": "https://www.target.com/sl/brainerd/659",
+    "slug": "brainerd",
+    "store_id": "659"
+  },
+  {
+    "url": "https://www.target.com/sl/fontana/660",
+    "slug": "fontana",
+    "store_id": "660"
+  },
+  {
+    "url": "https://www.target.com/sl/willmar/661",
+    "slug": "willmar",
+    "store_id": "661"
+  },
+  {
+    "url": "https://www.target.com/sl/cottage-grove/662",
+    "slug": "cottage-grove",
+    "store_id": "662"
+  },
+  {
+    "url": "https://www.target.com/sl/mankato/663",
+    "slug": "mankato",
+    "store_id": "663"
+  },
+  {
+    "url": "https://www.target.com/sl/plymouth/664",
+    "slug": "plymouth",
+    "store_id": "664"
+  },
+  {
+    "url": "https://www.target.com/sl/sarasota-tamiami-trail/665",
+    "slug": "sarasota-tamiami-trail",
+    "store_id": "665"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-nw/666",
+    "slug": "columbus-nw",
+    "store_id": "666"
+  },
+  {
+    "url": "https://www.target.com/sl/southside/669",
+    "slug": "southside",
+    "store_id": "669"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield/670",
+    "slug": "springfield",
+    "store_id": "670"
+  },
+  {
+    "url": "https://www.target.com/sl/traverse-city/671",
+    "slug": "traverse-city",
+    "store_id": "671"
+  },
+  {
+    "url": "https://www.target.com/sl/midland/672",
+    "slug": "midland",
+    "store_id": "672"
+  },
+  {
+    "url": "https://www.target.com/sl/jackson/673",
+    "slug": "jackson",
+    "store_id": "673"
+  },
+  {
+    "url": "https://www.target.com/sl/marion/674",
+    "slug": "marion",
+    "store_id": "674"
+  },
+  {
+    "url": "https://www.target.com/sl/fairfield/675",
+    "slug": "fairfield",
+    "store_id": "675"
+  },
+  {
+    "url": "https://www.target.com/sl/salinas/676",
+    "slug": "salinas",
+    "store_id": "676"
+  },
+  {
+    "url": "https://www.target.com/sl/anaheim-hills/677",
+    "slug": "anaheim-hills",
+    "store_id": "677"
+  },
+  {
+    "url": "https://www.target.com/sl/coeur-d'alene/679",
+    "slug": "coeur-d'alene",
+    "store_id": "679"
+  },
+  {
+    "url": "https://www.target.com/sl/henderson-stephanie-street/680",
+    "slug": "henderson-stephanie-street",
+    "store_id": "680"
+  },
+  {
+    "url": "https://www.target.com/sl/kent/681",
+    "slug": "kent",
+    "store_id": "681"
+  },
+  {
+    "url": "https://www.target.com/sl/germantown/682",
+    "slug": "germantown",
+    "store_id": "682"
+  },
+  {
+    "url": "https://www.target.com/sl/woodlands/684",
+    "slug": "woodlands",
+    "store_id": "684"
+  },
+  {
+    "url": "https://www.target.com/sl/palmdale/685",
+    "slug": "palmdale",
+    "store_id": "685"
+  },
+  {
+    "url": "https://www.target.com/sl/pensacola/686",
+    "slug": "pensacola",
+    "store_id": "686"
+  },
+  {
+    "url": "https://www.target.com/sl/gainesville/687",
+    "slug": "gainesville",
+    "store_id": "687"
+  },
+  {
+    "url": "https://www.target.com/sl/daytona-beach/688",
+    "slug": "daytona-beach",
+    "store_id": "688"
+  },
+  {
+    "url": "https://www.target.com/sl/melbourne/689",
+    "slug": "melbourne",
+    "store_id": "689"
+  },
+  {
+    "url": "https://www.target.com/sl/port-charlotte/690",
+    "slug": "port-charlotte",
+    "store_id": "690"
+  },
+  {
+    "url": "https://www.target.com/sl/novato/692",
+    "slug": "novato",
+    "store_id": "692"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-park/693",
+    "slug": "brooklyn-park",
+    "store_id": "693"
+  },
+  {
+    "url": "https://www.target.com/sl/woodbury-valley-creek-plaza/694",
+    "slug": "woodbury-valley-creek-plaza",
+    "store_id": "694"
+  },
+  {
+    "url": "https://www.target.com/sl/cool-springs/695",
+    "slug": "cool-springs",
+    "store_id": "695"
+  },
+  {
+    "url": "https://www.target.com/sl/burlington/696",
+    "slug": "burlington",
+    "store_id": "696"
+  },
+  {
+    "url": "https://www.target.com/sl/twin-falls/699",
+    "slug": "twin-falls",
+    "store_id": "699"
+  },
+  {
+    "url": "https://www.target.com/sl/oro-valley/700",
+    "slug": "oro-valley",
+    "store_id": "700"
+  },
+  {
+    "url": "https://www.target.com/sl/highland/731",
+    "slug": "highland",
+    "store_id": "731"
+  },
+  {
+    "url": "https://www.target.com/sl/cicero/732",
+    "slug": "cicero",
+    "store_id": "732"
+  },
+  {
+    "url": "https://www.target.com/sl/edwardsville/733",
+    "slug": "edwardsville",
+    "store_id": "733"
+  },
+  {
+    "url": "https://www.target.com/sl/albany/734",
+    "slug": "albany",
+    "store_id": "734"
+  },
+  {
+    "url": "https://www.target.com/sl/sierra-vista/735",
+    "slug": "sierra-vista",
+    "store_id": "735"
+  },
+  {
+    "url": "https://www.target.com/sl/norco/736",
+    "slug": "norco",
+    "store_id": "736"
+  },
+  {
+    "url": "https://www.target.com/sl/pinole/737",
+    "slug": "pinole",
+    "store_id": "737"
+  },
+  {
+    "url": "https://www.target.com/sl/tracy/738",
+    "slug": "tracy",
+    "store_id": "738"
+  },
+  {
+    "url": "https://www.target.com/sl/s-colorado-springs/739",
+    "slug": "s-colorado-springs",
+    "store_id": "739"
+  },
+  {
+    "url": "https://www.target.com/sl/mary-esther/740",
+    "slug": "mary-esther",
+    "store_id": "740"
+  },
+  {
+    "url": "https://www.target.com/sl/kendall/746",
+    "slug": "kendall",
+    "store_id": "746"
+  },
+  {
+    "url": "https://www.target.com/sl/lawrenceville/747",
+    "slug": "lawrenceville",
+    "store_id": "747"
+  },
+  {
+    "url": "https://www.target.com/sl/johns-creek-state-st-and-141/749",
+    "slug": "johns-creek-state-st-and-141",
+    "store_id": "749"
+  },
+  {
+    "url": "https://www.target.com/sl/valdosta/750",
+    "slug": "valdosta",
+    "store_id": "750"
+  },
+  {
+    "url": "https://www.target.com/sl/vadnais-heights/751",
+    "slug": "vadnais-heights",
+    "store_id": "751"
+  },
+  {
+    "url": "https://www.target.com/sl/jefferson-city/752",
+    "slug": "jefferson-city",
+    "store_id": "752"
+  },
+  {
+    "url": "https://www.target.com/sl/palatine/753",
+    "slug": "palatine",
+    "store_id": "753"
+  },
+  {
+    "url": "https://www.target.com/sl/north-jackson/754",
+    "slug": "north-jackson",
+    "store_id": "754"
+  },
+  {
+    "url": "https://www.target.com/sl/fayetteville/755",
+    "slug": "fayetteville",
+    "store_id": "755"
+  },
+  {
+    "url": "https://www.target.com/sl/johnson-city/756",
+    "slug": "johnson-city",
+    "store_id": "756"
+  },
+  {
+    "url": "https://www.target.com/sl/owensboro/757",
+    "slug": "owensboro",
+    "store_id": "757"
+  },
+  {
+    "url": "https://www.target.com/sl/eastchase/758",
+    "slug": "eastchase",
+    "store_id": "758"
+  },
+  {
+    "url": "https://www.target.com/sl/potomac-mills/759",
+    "slug": "potomac-mills",
+    "store_id": "759"
+  },
+  {
+    "url": "https://www.target.com/sl/yakima/760",
+    "slug": "yakima",
+    "store_id": "760"
+  },
+  {
+    "url": "https://www.target.com/sl/hemet/761",
+    "slug": "hemet",
+    "store_id": "761"
+  },
+  {
+    "url": "https://www.target.com/sl/pineville/762",
+    "slug": "pineville",
+    "store_id": "762"
+  },
+  {
+    "url": "https://www.target.com/sl/bend/766",
+    "slug": "bend",
+    "store_id": "766"
+  },
+  {
+    "url": "https://www.target.com/sl/san-dimas/767",
+    "slug": "san-dimas",
+    "store_id": "767"
+  },
+  {
+    "url": "https://www.target.com/sl/las-cruces/769",
+    "slug": "las-cruces",
+    "store_id": "769"
+  },
+  {
+    "url": "https://www.target.com/sl/midland/770",
+    "slug": "midland",
+    "store_id": "770"
+  },
+  {
+    "url": "https://www.target.com/sl/sw-military-drive/771",
+    "slug": "sw-military-drive",
+    "store_id": "771"
+  },
+  {
+    "url": "https://www.target.com/sl/fredericksburg/772",
+    "slug": "fredericksburg",
+    "store_id": "772"
+  },
+  {
+    "url": "https://www.target.com/sl/plainfield/773",
+    "slug": "plainfield",
+    "store_id": "773"
+  },
+  {
+    "url": "https://www.target.com/sl/joplin/774",
+    "slug": "joplin",
+    "store_id": "774"
+  },
+  {
+    "url": "https://www.target.com/sl/tyler/775",
+    "slug": "tyler",
+    "store_id": "775"
+  },
+  {
+    "url": "https://www.target.com/sl/fayetteville/778",
+    "slug": "fayetteville",
+    "store_id": "778"
+  },
+  {
+    "url": "https://www.target.com/sl/elizabethtown/779",
+    "slug": "elizabethtown",
+    "store_id": "779"
+  },
+  {
+    "url": "https://www.target.com/sl/jeffersontown/780",
+    "slug": "jeffersontown",
+    "store_id": "780"
+  },
+  {
+    "url": "https://www.target.com/sl/parma/792",
+    "slug": "parma",
+    "store_id": "792"
+  },
+  {
+    "url": "https://www.target.com/sl/cuyahoga-falls/793",
+    "slug": "cuyahoga-falls",
+    "store_id": "793"
+  },
+  {
+    "url": "https://www.target.com/sl/canton/794",
+    "slug": "canton",
+    "store_id": "794"
+  },
+  {
+    "url": "https://www.target.com/sl/knoxville-nw/795",
+    "slug": "knoxville-nw",
+    "store_id": "795"
+  },
+  {
+    "url": "https://www.target.com/sl/gainesville/796",
+    "slug": "gainesville",
+    "store_id": "796"
+  },
+  {
+    "url": "https://www.target.com/sl/bel-air/797",
+    "slug": "bel-air",
+    "store_id": "797"
+  },
+  {
+    "url": "https://www.target.com/sl/town-&-country/798",
+    "slug": "town-&-country",
+    "store_id": "798"
+  },
+  {
+    "url": "https://www.target.com/sl/north-sarasota-fruitville-rd/799",
+    "slug": "north-sarasota-fruitville-rd",
+    "store_id": "799"
+  },
+  {
+    "url": "https://www.target.com/sl/college-station/800",
+    "slug": "college-station",
+    "store_id": "800"
+  },
+  {
+    "url": "https://www.target.com/sl/laredo/801",
+    "slug": "laredo",
+    "store_id": "801"
+  },
+  {
+    "url": "https://www.target.com/sl/harlingen/802",
+    "slug": "harlingen",
+    "store_id": "802"
+  },
+  {
+    "url": "https://www.target.com/sl/south-des-moines/803",
+    "slug": "south-des-moines",
+    "store_id": "803"
+  },
+  {
+    "url": "https://www.target.com/sl/mason-city/804",
+    "slug": "mason-city",
+    "store_id": "804"
+  },
+  {
+    "url": "https://www.target.com/sl/marshfield/805",
+    "slug": "marshfield",
+    "store_id": "805"
+  },
+  {
+    "url": "https://www.target.com/sl/stevens-point/806",
+    "slug": "stevens-point",
+    "store_id": "806"
+  },
+  {
+    "url": "https://www.target.com/sl/oshkosh/807",
+    "slug": "oshkosh",
+    "store_id": "807"
+  },
+  {
+    "url": "https://www.target.com/sl/fond-du-lac/808",
+    "slug": "fond-du-lac",
+    "store_id": "808"
+  },
+  {
+    "url": "https://www.target.com/sl/janesville/809",
+    "slug": "janesville",
+    "store_id": "809"
+  },
+  {
+    "url": "https://www.target.com/sl/rockford/810",
+    "slug": "rockford",
+    "store_id": "810"
+  },
+  {
+    "url": "https://www.target.com/sl/panama-city/811",
+    "slug": "panama-city",
+    "store_id": "811"
+  },
+  {
+    "url": "https://www.target.com/sl/brandon/812",
+    "slug": "brandon",
+    "store_id": "812"
+  },
+  {
+    "url": "https://www.target.com/sl/venice/813",
+    "slug": "venice",
+    "store_id": "813"
+  },
+  {
+    "url": "https://www.target.com/sl/sawgrass/815",
+    "slug": "sawgrass",
+    "store_id": "815"
+  },
+  {
+    "url": "https://www.target.com/sl/stuart/816",
+    "slug": "stuart",
+    "store_id": "816"
+  },
+  {
+    "url": "https://www.target.com/sl/bradenton/817",
+    "slug": "bradenton",
+    "store_id": "817"
+  },
+  {
+    "url": "https://www.target.com/sl/ft-myers/818",
+    "slug": "ft-myers",
+    "store_id": "818"
+  },
+  {
+    "url": "https://www.target.com/sl/clinton-pointe/819",
+    "slug": "clinton-pointe",
+    "store_id": "819"
+  },
+  {
+    "url": "https://www.target.com/sl/northtown/820",
+    "slug": "northtown",
+    "store_id": "820"
+  },
+  {
+    "url": "https://www.target.com/sl/alexandria/821",
+    "slug": "alexandria",
+    "store_id": "821"
+  },
+  {
+    "url": "https://www.target.com/sl/el-paso-west/822",
+    "slug": "el-paso-west",
+    "store_id": "822"
+  },
+  {
+    "url": "https://www.target.com/sl/el-paso-east-george-dieter-dr/823",
+    "slug": "el-paso-east-george-dieter-dr",
+    "store_id": "823"
+  },
+  {
+    "url": "https://www.target.com/sl/mcallen/824",
+    "slug": "mcallen",
+    "store_id": "824"
+  },
+  {
+    "url": "https://www.target.com/sl/peoria-north/825",
+    "slug": "peoria-north",
+    "store_id": "825"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-nw/826",
+    "slug": "las-vegas-nw",
+    "store_id": "826"
+  },
+  {
+    "url": "https://www.target.com/sl/vacaville/827",
+    "slug": "vacaville",
+    "store_id": "827"
+  },
+  {
+    "url": "https://www.target.com/sl/livermore/828",
+    "slug": "livermore",
+    "store_id": "828"
+  },
+  {
+    "url": "https://www.target.com/sl/kennewick/830",
+    "slug": "kennewick",
+    "store_id": "830"
+  },
+  {
+    "url": "https://www.target.com/sl/scottsbluff/831",
+    "slug": "scottsbluff",
+    "store_id": "831"
+  },
+  {
+    "url": "https://www.target.com/sl/roswell/832",
+    "slug": "roswell",
+    "store_id": "832"
+  },
+  {
+    "url": "https://www.target.com/sl/vernon-hills/833",
+    "slug": "vernon-hills",
+    "store_id": "833"
+  },
+  {
+    "url": "https://www.target.com/sl/elgin/834",
+    "slug": "elgin",
+    "store_id": "834"
+  },
+  {
+    "url": "https://www.target.com/sl/west-schaumburg/835",
+    "slug": "west-schaumburg",
+    "store_id": "835"
+  },
+  {
+    "url": "https://www.target.com/sl/glendale-heights/836",
+    "slug": "glendale-heights",
+    "store_id": "836"
+  },
+  {
+    "url": "https://www.target.com/sl/melrose-park/837",
+    "slug": "melrose-park",
+    "store_id": "837"
+  },
+  {
+    "url": "https://www.target.com/sl/wheaton/838",
+    "slug": "wheaton",
+    "store_id": "838"
+  },
+  {
+    "url": "https://www.target.com/sl/batavia/839",
+    "slug": "batavia",
+    "store_id": "839"
+  },
+  {
+    "url": "https://www.target.com/sl/naperville/840",
+    "slug": "naperville",
+    "store_id": "840"
+  },
+  {
+    "url": "https://www.target.com/sl/bedford-park/841",
+    "slug": "bedford-park",
+    "store_id": "841"
+  },
+  {
+    "url": "https://www.target.com/sl/orland-park/842",
+    "slug": "orland-park",
+    "store_id": "842"
+  },
+  {
+    "url": "https://www.target.com/sl/hodgkins/843",
+    "slug": "hodgkins",
+    "store_id": "843"
+  },
+  {
+    "url": "https://www.target.com/sl/tallahassee/844",
+    "slug": "tallahassee",
+    "store_id": "844"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-mary/845",
+    "slug": "lake-mary",
+    "store_id": "845"
+  },
+  {
+    "url": "https://www.target.com/sl/virginia/847",
+    "slug": "virginia",
+    "store_id": "847"
+  },
+  {
+    "url": "https://www.target.com/sl/aberdeen/848",
+    "slug": "aberdeen",
+    "store_id": "848"
+  },
+  {
+    "url": "https://www.target.com/sl/el-paso-central/849",
+    "slug": "el-paso-central",
+    "store_id": "849"
+  },
+  {
+    "url": "https://www.target.com/sl/west-las-vegas/850",
+    "slug": "west-las-vegas",
+    "store_id": "850"
+  },
+  {
+    "url": "https://www.target.com/sl/westridge/851",
+    "slug": "westridge",
+    "store_id": "851"
+  },
+  {
+    "url": "https://www.target.com/sl/rohnert-park/852",
+    "slug": "rohnert-park",
+    "store_id": "852"
+  },
+  {
+    "url": "https://www.target.com/sl/lodi/853",
+    "slug": "lodi",
+    "store_id": "853"
+  },
+  {
+    "url": "https://www.target.com/sl/marana/854",
+    "slug": "marana",
+    "store_id": "854"
+  },
+  {
+    "url": "https://www.target.com/sl/tucson-ne/855",
+    "slug": "tucson-ne",
+    "store_id": "855"
+  },
+  {
+    "url": "https://www.target.com/sl/norfolk/856",
+    "slug": "norfolk",
+    "store_id": "856"
+  },
+  {
+    "url": "https://www.target.com/sl/kearney/857",
+    "slug": "kearney",
+    "store_id": "857"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-nw/858",
+    "slug": "houston-nw",
+    "store_id": "858"
+  },
+  {
+    "url": "https://www.target.com/sl/watertown/859",
+    "slug": "watertown",
+    "store_id": "859"
+  },
+  {
+    "url": "https://www.target.com/sl/burlington/860",
+    "slug": "burlington",
+    "store_id": "860"
+  },
+  {
+    "url": "https://www.target.com/sl/buffalo/861",
+    "slug": "buffalo",
+    "store_id": "861"
+  },
+  {
+    "url": "https://www.target.com/sl/chanhassen/862",
+    "slug": "chanhassen",
+    "store_id": "862"
+  },
+  {
+    "url": "https://www.target.com/sl/menomonee-falls/863",
+    "slug": "menomonee-falls",
+    "store_id": "863"
+  },
+  {
+    "url": "https://www.target.com/sl/delafield/864",
+    "slug": "delafield",
+    "store_id": "864"
+  },
+  {
+    "url": "https://www.target.com/sl/gurnee/865",
+    "slug": "gurnee",
+    "store_id": "865"
+  },
+  {
+    "url": "https://www.target.com/sl/woodridge/866",
+    "slug": "woodridge",
+    "store_id": "866"
+  },
+  {
+    "url": "https://www.target.com/sl/bolingbrook/867",
+    "slug": "bolingbrook",
+    "store_id": "867"
+  },
+  {
+    "url": "https://www.target.com/sl/crestwood/868",
+    "slug": "crestwood",
+    "store_id": "868"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-county/870",
+    "slug": "lake-county",
+    "store_id": "870"
+  },
+  {
+    "url": "https://www.target.com/sl/peoria/871",
+    "slug": "peoria",
+    "store_id": "871"
+  },
+  {
+    "url": "https://www.target.com/sl/northville/872",
+    "slug": "northville",
+    "store_id": "872"
+  },
+  {
+    "url": "https://www.target.com/sl/ocala/873",
+    "slug": "ocala",
+    "store_id": "873"
+  },
+  {
+    "url": "https://www.target.com/sl/orange-city/874",
+    "slug": "orange-city",
+    "store_id": "874"
+  },
+  {
+    "url": "https://www.target.com/sl/cityplace-market/875",
+    "slug": "cityplace-market",
+    "store_id": "875"
+  },
+  {
+    "url": "https://www.target.com/sl/grapevine/876",
+    "slug": "grapevine",
+    "store_id": "876"
+  },
+  {
+    "url": "https://www.target.com/sl/hollywood/877",
+    "slug": "hollywood",
+    "store_id": "877"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-dodge/878",
+    "slug": "fort-dodge",
+    "store_id": "878"
+  },
+  {
+    "url": "https://www.target.com/sl/lincoln-south/879",
+    "slug": "lincoln-south",
+    "store_id": "879"
+  },
+  {
+    "url": "https://www.target.com/sl/woodfield/880",
+    "slug": "woodfield",
+    "store_id": "880"
+  },
+  {
+    "url": "https://www.target.com/sl/eagle-creek/881",
+    "slug": "eagle-creek",
+    "store_id": "881"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-jackson/882",
+    "slug": "lake-jackson",
+    "store_id": "882"
+  },
+  {
+    "url": "https://www.target.com/sl/pasadena/883",
+    "slug": "pasadena",
+    "store_id": "883"
+  },
+  {
+    "url": "https://www.target.com/sl/prescott/884",
+    "slug": "prescott",
+    "store_id": "884"
+  },
+  {
+    "url": "https://www.target.com/sl/missoula/885",
+    "slug": "missoula",
+    "store_id": "885"
+  },
+  {
+    "url": "https://www.target.com/sl/baytown/887",
+    "slug": "baytown",
+    "store_id": "887"
+  },
+  {
+    "url": "https://www.target.com/sl/victoria/888",
+    "slug": "victoria",
+    "store_id": "888"
+  },
+  {
+    "url": "https://www.target.com/sl/galesburg/891",
+    "slug": "galesburg",
+    "store_id": "891"
+  },
+  {
+    "url": "https://www.target.com/sl/wood-dale/893",
+    "slug": "wood-dale",
+    "store_id": "893"
+  },
+  {
+    "url": "https://www.target.com/sl/joliet/894",
+    "slug": "joliet",
+    "store_id": "894"
+  },
+  {
+    "url": "https://www.target.com/sl/bradley/895",
+    "slug": "bradley",
+    "store_id": "895"
+  },
+  {
+    "url": "https://www.target.com/sl/commerce-township/896",
+    "slug": "commerce-township",
+    "store_id": "896"
+  },
+  {
+    "url": "https://www.target.com/sl/oviedo/897",
+    "slug": "oviedo",
+    "store_id": "897"
+  },
+  {
+    "url": "https://www.target.com/sl/casselberry/898",
+    "slug": "casselberry",
+    "store_id": "898"
+  },
+  {
+    "url": "https://www.target.com/sl/naples/899",
+    "slug": "naples",
+    "store_id": "899"
+  },
+  {
+    "url": "https://www.target.com/sl/kalamazoo-west/901",
+    "slug": "kalamazoo-west",
+    "store_id": "901"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-rapids/904",
+    "slug": "grand-rapids",
+    "store_id": "904"
+  },
+  {
+    "url": "https://www.target.com/sl/salina/905",
+    "slug": "salina",
+    "store_id": "905"
+  },
+  {
+    "url": "https://www.target.com/sl/garden-city/906",
+    "slug": "garden-city",
+    "store_id": "906"
+  },
+  {
+    "url": "https://www.target.com/sl/katy/907",
+    "slug": "katy",
+    "store_id": "907"
+  },
+  {
+    "url": "https://www.target.com/sl/ahwatukee/909",
+    "slug": "ahwatukee",
+    "store_id": "909"
+  },
+  {
+    "url": "https://www.target.com/sl/tanasbourne/910",
+    "slug": "tanasbourne",
+    "store_id": "910"
+  },
+  {
+    "url": "https://www.target.com/sl/blackstone-and-nees-ave/911",
+    "slug": "blackstone-and-nees-ave",
+    "store_id": "911"
+  },
+  {
+    "url": "https://www.target.com/sl/chino-hills-grand-avenue/912",
+    "slug": "chino-hills-grand-avenue",
+    "store_id": "912"
+  },
+  {
+    "url": "https://www.target.com/sl/foothill-ranch/913",
+    "slug": "foothill-ranch",
+    "store_id": "913"
+  },
+  {
+    "url": "https://www.target.com/sl/rancho-santa-margarita/914",
+    "slug": "rancho-santa-margarita",
+    "store_id": "914"
+  },
+  {
+    "url": "https://www.target.com/sl/spokane-valley/915",
+    "slug": "spokane-valley",
+    "store_id": "915"
+  },
+  {
+    "url": "https://www.target.com/sl/snellville/917",
+    "slug": "snellville",
+    "store_id": "917"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-se/918",
+    "slug": "charlotte-se",
+    "store_id": "918"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-hill/919",
+    "slug": "spring-hill",
+    "store_id": "919"
+  },
+  {
+    "url": "https://www.target.com/sl/pembroke-pines/920",
+    "slug": "pembroke-pines",
+    "store_id": "920"
+  },
+  {
+    "url": "https://www.target.com/sl/jackson/921",
+    "slug": "jackson",
+    "store_id": "921"
+  },
+  {
+    "url": "https://www.target.com/sl/brighton/922",
+    "slug": "brighton",
+    "store_id": "922"
+  },
+  {
+    "url": "https://www.target.com/sl/woodhaven/923",
+    "slug": "woodhaven",
+    "store_id": "923"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-pleasant/924",
+    "slug": "mt-pleasant",
+    "store_id": "924"
+  },
+  {
+    "url": "https://www.target.com/sl/sw-moline/926",
+    "slug": "sw-moline",
+    "store_id": "926"
+  },
+  {
+    "url": "https://www.target.com/sl/evanston/927",
+    "slug": "evanston",
+    "store_id": "927"
+  },
+  {
+    "url": "https://www.target.com/sl/niles/928",
+    "slug": "niles",
+    "store_id": "928"
+  },
+  {
+    "url": "https://www.target.com/sl/peru/929",
+    "slug": "peru",
+    "store_id": "929"
+  },
+  {
+    "url": "https://www.target.com/sl/st-cloud-east/930",
+    "slug": "st-cloud-east",
+    "store_id": "930"
+  },
+  {
+    "url": "https://www.target.com/sl/stillwater/931",
+    "slug": "stillwater",
+    "store_id": "931"
+  },
+  {
+    "url": "https://www.target.com/sl/flagstaff/935",
+    "slug": "flagstaff",
+    "store_id": "935"
+  },
+  {
+    "url": "https://www.target.com/sl/frank-lloyd-wright-blvd/936",
+    "slug": "frank-lloyd-wright-blvd",
+    "store_id": "936"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-rosa-south/937",
+    "slug": "santa-rosa-south",
+    "store_id": "937"
+  },
+  {
+    "url": "https://www.target.com/sl/modesto-sisk-rd/938",
+    "slug": "modesto-sisk-rd",
+    "store_id": "938"
+  },
+  {
+    "url": "https://www.target.com/sl/apple-valley/939",
+    "slug": "apple-valley",
+    "store_id": "939"
+  },
+  {
+    "url": "https://www.target.com/sl/palm-desert/940",
+    "slug": "palm-desert",
+    "store_id": "940"
+  },
+  {
+    "url": "https://www.target.com/sl/hollister/941",
+    "slug": "hollister",
+    "store_id": "941"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-near-north-elston/942",
+    "slug": "chicago-near-north-elston",
+    "store_id": "942"
+  },
+  {
+    "url": "https://www.target.com/sl/champaign/943",
+    "slug": "champaign",
+    "store_id": "943"
+  },
+  {
+    "url": "https://www.target.com/sl/chesterfield/945",
+    "slug": "chesterfield",
+    "store_id": "945"
+  },
+  {
+    "url": "https://www.target.com/sl/love-field/947",
+    "slug": "love-field",
+    "store_id": "947"
+  },
+  {
+    "url": "https://www.target.com/sl/san-ramon/949",
+    "slug": "san-ramon",
+    "store_id": "949"
+  },
+  {
+    "url": "https://www.target.com/sl/arcadia-crossing/950",
+    "slug": "arcadia-crossing",
+    "store_id": "950"
+  },
+  {
+    "url": "https://www.target.com/sl/farmington/952",
+    "slug": "farmington",
+    "store_id": "952"
+  },
+  {
+    "url": "https://www.target.com/sl/lufkin/953",
+    "slug": "lufkin",
+    "store_id": "953"
+  },
+  {
+    "url": "https://www.target.com/sl/galleria/955",
+    "slug": "galleria",
+    "store_id": "955"
+  },
+  {
+    "url": "https://www.target.com/sl/villa-park/957",
+    "slug": "villa-park",
+    "store_id": "957"
+  },
+  {
+    "url": "https://www.target.com/sl/bowling-green/958",
+    "slug": "bowling-green",
+    "store_id": "958"
+  },
+  {
+    "url": "https://www.target.com/sl/clarksville/959",
+    "slug": "clarksville",
+    "store_id": "959"
+  },
+  {
+    "url": "https://www.target.com/sl/cary/961",
+    "slug": "cary",
+    "store_id": "961"
+  },
+  {
+    "url": "https://www.target.com/sl/rocky-mount/962",
+    "slug": "rocky-mount",
+    "store_id": "962"
+  },
+  {
+    "url": "https://www.target.com/sl/myrtle-beach-17-and-21st-ave/963",
+    "slug": "myrtle-beach-17-and-21st-ave",
+    "store_id": "963"
+  },
+  {
+    "url": "https://www.target.com/sl/goldsboro/964",
+    "slug": "goldsboro",
+    "store_id": "964"
+  },
+  {
+    "url": "https://www.target.com/sl/huntersville/966",
+    "slug": "huntersville",
+    "store_id": "966"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville-beach/967",
+    "slug": "jacksonville-beach",
+    "store_id": "967"
+  },
+  {
+    "url": "https://www.target.com/sl/bird-road/968",
+    "slug": "bird-road",
+    "store_id": "968"
+  },
+  {
+    "url": "https://www.target.com/sl/cartersville/969",
+    "slug": "cartersville",
+    "store_id": "969"
+  },
+  {
+    "url": "https://www.target.com/sl/alpharetta/970",
+    "slug": "alpharetta",
+    "store_id": "970"
+  },
+  {
+    "url": "https://www.target.com/sl/cobb/981",
+    "slug": "cobb",
+    "store_id": "981"
+  },
+  {
+    "url": "https://www.target.com/sl/peachtree-corners/982",
+    "slug": "peachtree-corners",
+    "store_id": "982"
+  },
+  {
+    "url": "https://www.target.com/sl/medina/984",
+    "slug": "medina",
+    "store_id": "984"
+  },
+  {
+    "url": "https://www.target.com/sl/strongsville/985",
+    "slug": "strongsville",
+    "store_id": "985"
+  },
+  {
+    "url": "https://www.target.com/sl/fairlawn/986",
+    "slug": "fairlawn",
+    "store_id": "986"
+  },
+  {
+    "url": "https://www.target.com/sl/stow/988",
+    "slug": "stow",
+    "store_id": "988"
+  },
+  {
+    "url": "https://www.target.com/sl/heath/989",
+    "slug": "heath",
+    "store_id": "989"
+  },
+  {
+    "url": "https://www.target.com/sl/lancaster/990",
+    "slug": "lancaster",
+    "store_id": "990"
+  },
+  {
+    "url": "https://www.target.com/sl/cape-girardeau/992",
+    "slug": "cape-girardeau",
+    "store_id": "992"
+  },
+  {
+    "url": "https://www.target.com/sl/copperfield/993",
+    "slug": "copperfield",
+    "store_id": "993"
+  },
+  {
+    "url": "https://www.target.com/sl/redmond/995",
+    "slug": "redmond",
+    "store_id": "995"
+  },
+  {
+    "url": "https://www.target.com/sl/issaquah/996",
+    "slug": "issaquah",
+    "store_id": "996"
+  },
+  {
+    "url": "https://www.target.com/sl/grossmont/997",
+    "slug": "grossmont",
+    "store_id": "997"
+  },
+  {
+    "url": "https://www.target.com/sl/westminster/1000",
+    "slug": "westminster",
+    "store_id": "1000"
+  },
+  {
+    "url": "https://www.target.com/sl/white-marsh/1001",
+    "slug": "white-marsh",
+    "store_id": "1001"
+  },
+  {
+    "url": "https://www.target.com/sl/bel-air/1002",
+    "slug": "bel-air",
+    "store_id": "1002"
+  },
+  {
+    "url": "https://www.target.com/sl/glen-burnie/1003",
+    "slug": "glen-burnie",
+    "store_id": "1003"
+  },
+  {
+    "url": "https://www.target.com/sl/bowie/1004",
+    "slug": "bowie",
+    "store_id": "1004"
+  },
+  {
+    "url": "https://www.target.com/sl/fairfax/1005",
+    "slug": "fairfax",
+    "store_id": "1005"
+  },
+  {
+    "url": "https://www.target.com/sl/largo/1006",
+    "slug": "largo",
+    "store_id": "1006"
+  },
+  {
+    "url": "https://www.target.com/sl/laurel/1007",
+    "slug": "laurel",
+    "store_id": "1007"
+  },
+  {
+    "url": "https://www.target.com/sl/waldorf/1008",
+    "slug": "waldorf",
+    "store_id": "1008"
+  },
+  {
+    "url": "https://www.target.com/sl/sterling/1009",
+    "slug": "sterling",
+    "store_id": "1009"
+  },
+  {
+    "url": "https://www.target.com/sl/boulevard-mall/1010",
+    "slug": "boulevard-mall",
+    "store_id": "1010"
+  },
+  {
+    "url": "https://www.target.com/sl/eastern-hills/1011",
+    "slug": "eastern-hills",
+    "store_id": "1011"
+  },
+  {
+    "url": "https://www.target.com/sl/niagara-falls/1012",
+    "slug": "niagara-falls",
+    "store_id": "1012"
+  },
+  {
+    "url": "https://www.target.com/sl/north-buffalo/1013",
+    "slug": "north-buffalo",
+    "store_id": "1013"
+  },
+  {
+    "url": "https://www.target.com/sl/walden-galleria/1014",
+    "slug": "walden-galleria",
+    "store_id": "1014"
+  },
+  {
+    "url": "https://www.target.com/sl/new-bern/1015",
+    "slug": "new-bern",
+    "store_id": "1015"
+  },
+  {
+    "url": "https://www.target.com/sl/colonial-heights/1016",
+    "slug": "colonial-heights",
+    "store_id": "1016"
+  },
+  {
+    "url": "https://www.target.com/sl/chester/1017",
+    "slug": "chester",
+    "store_id": "1017"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond-central/1018",
+    "slug": "richmond-central",
+    "store_id": "1018"
+  },
+  {
+    "url": "https://www.target.com/sl/virginia-center-commons/1019",
+    "slug": "virginia-center-commons",
+    "store_id": "1019"
+  },
+  {
+    "url": "https://www.target.com/sl/greenbrier/1021",
+    "slug": "greenbrier",
+    "store_id": "1021"
+  },
+  {
+    "url": "https://www.target.com/sl/greenville/1022",
+    "slug": "greenville",
+    "store_id": "1022"
+  },
+  {
+    "url": "https://www.target.com/sl/park-&-tyrone/1023",
+    "slug": "park-&-tyrone",
+    "store_id": "1023"
+  },
+  {
+    "url": "https://www.target.com/sl/lombard/1024",
+    "slug": "lombard",
+    "store_id": "1024"
+  },
+  {
+    "url": "https://www.target.com/sl/elk-grove/1025",
+    "slug": "elk-grove",
+    "store_id": "1025"
+  },
+  {
+    "url": "https://www.target.com/sl/napa-soscol-ave/1026",
+    "slug": "napa-soscol-ave",
+    "store_id": "1026"
+  },
+  {
+    "url": "https://www.target.com/sl/camarillo/1027",
+    "slug": "camarillo",
+    "store_id": "1027"
+  },
+  {
+    "url": "https://www.target.com/sl/west-covina/1028",
+    "slug": "west-covina",
+    "store_id": "1028"
+  },
+  {
+    "url": "https://www.target.com/sl/encinitas/1029",
+    "slug": "encinitas",
+    "store_id": "1029"
+  },
+  {
+    "url": "https://www.target.com/sl/memphis-ne/1030",
+    "slug": "memphis-ne",
+    "store_id": "1030"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield/1031",
+    "slug": "springfield",
+    "store_id": "1031"
+  },
+  {
+    "url": "https://www.target.com/sl/irving-north/1032",
+    "slug": "irving-north",
+    "store_id": "1032"
+  },
+  {
+    "url": "https://www.target.com/sl/baldwin-park/1033",
+    "slug": "baldwin-park",
+    "store_id": "1033"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-fe/1034",
+    "slug": "santa-fe",
+    "store_id": "1034"
+  },
+  {
+    "url": "https://www.target.com/sl/st-peters/1035",
+    "slug": "st-peters",
+    "store_id": "1035"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-zurich/1036",
+    "slug": "lake-zurich",
+    "store_id": "1036"
+  },
+  {
+    "url": "https://www.target.com/sl/springdale/1037",
+    "slug": "springdale",
+    "store_id": "1037"
+  },
+  {
+    "url": "https://www.target.com/sl/north-miami/1038",
+    "slug": "north-miami",
+    "store_id": "1038"
+  },
+  {
+    "url": "https://www.target.com/sl/dadeland/1039",
+    "slug": "dadeland",
+    "store_id": "1039"
+  },
+  {
+    "url": "https://www.target.com/sl/vista-north-university-drive/1040",
+    "slug": "vista-north-university-drive",
+    "store_id": "1040"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond-midlothian-tpke/1041",
+    "slug": "richmond-midlothian-tpke",
+    "store_id": "1041"
+  },
+  {
+    "url": "https://www.target.com/sl/ellicott-city/1042",
+    "slug": "ellicott-city",
+    "store_id": "1042"
+  },
+  {
+    "url": "https://www.target.com/sl/aberdeen/1043",
+    "slug": "aberdeen",
+    "store_id": "1043"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia/1044",
+    "slug": "columbia",
+    "store_id": "1044"
+  },
+  {
+    "url": "https://www.target.com/sl/owings-mills/1045",
+    "slug": "owings-mills",
+    "store_id": "1045"
+  },
+  {
+    "url": "https://www.target.com/sl/germantown/1046",
+    "slug": "germantown",
+    "store_id": "1046"
+  },
+  {
+    "url": "https://www.target.com/sl/hilltop/1047",
+    "slug": "hilltop",
+    "store_id": "1047"
+  },
+  {
+    "url": "https://www.target.com/sl/norfolk/1048",
+    "slug": "norfolk",
+    "store_id": "1048"
+  },
+  {
+    "url": "https://www.target.com/sl/glen-allen-broad-st/1049",
+    "slug": "glen-allen-broad-st",
+    "store_id": "1049"
+  },
+  {
+    "url": "https://www.target.com/sl/vero-beach/1050",
+    "slug": "vero-beach",
+    "store_id": "1050"
+  },
+  {
+    "url": "https://www.target.com/sl/gandy/1051",
+    "slug": "gandy",
+    "store_id": "1051"
+  },
+  {
+    "url": "https://www.target.com/sl/wyoming/1052",
+    "slug": "wyoming",
+    "store_id": "1052"
+  },
+  {
+    "url": "https://www.target.com/sl/merritt-island/1053",
+    "slug": "merritt-island",
+    "store_id": "1053"
+  },
+  {
+    "url": "https://www.target.com/sl/tanforan/1054",
+    "slug": "tanforan",
+    "store_id": "1054"
+  },
+  {
+    "url": "https://www.target.com/sl/menlo-park/1055",
+    "slug": "menlo-park",
+    "store_id": "1055"
+  },
+  {
+    "url": "https://www.target.com/sl/binghamton-vestal/1056",
+    "slug": "binghamton-vestal",
+    "store_id": "1056"
+  },
+  {
+    "url": "https://www.target.com/sl/orchard-park/1057",
+    "slug": "orchard-park",
+    "store_id": "1057"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-central/1058",
+    "slug": "columbus-central",
+    "store_id": "1058"
+  },
+  {
+    "url": "https://www.target.com/sl/nashville-east/1059",
+    "slug": "nashville-east",
+    "store_id": "1059"
+  },
+  {
+    "url": "https://www.target.com/sl/madison-west/1060",
+    "slug": "madison-west",
+    "store_id": "1060"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-sw/1061",
+    "slug": "austin-sw",
+    "store_id": "1061"
+  },
+  {
+    "url": "https://www.target.com/sl/sand-city/1062",
+    "slug": "sand-city",
+    "store_id": "1062"
+  },
+  {
+    "url": "https://www.target.com/sl/carmel-east-151st-street/1063",
+    "slug": "carmel-east-151st-street",
+    "store_id": "1063"
+  },
+  {
+    "url": "https://www.target.com/sl/wenatchee/1064",
+    "slug": "wenatchee",
+    "store_id": "1064"
+  },
+  {
+    "url": "https://www.target.com/sl/rockwall/1065",
+    "slug": "rockwall",
+    "store_id": "1065"
+  },
+  {
+    "url": "https://www.target.com/sl/round-rock/1066",
+    "slug": "round-rock",
+    "store_id": "1066"
+  },
+  {
+    "url": "https://www.target.com/sl/owatonna/1068",
+    "slug": "owatonna",
+    "store_id": "1068"
+  },
+  {
+    "url": "https://www.target.com/sl/madison-east/1069",
+    "slug": "madison-east",
+    "store_id": "1069"
+  },
+  {
+    "url": "https://www.target.com/sl/waukegan/1070",
+    "slug": "waukegan",
+    "store_id": "1070"
+  },
+  {
+    "url": "https://www.target.com/sl/springhurst/1071",
+    "slug": "springhurst",
+    "store_id": "1071"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-ne/1072",
+    "slug": "columbus-ne",
+    "store_id": "1072"
+  },
+  {
+    "url": "https://www.target.com/sl/carrollton/1073",
+    "slug": "carrollton",
+    "store_id": "1073"
+  },
+  {
+    "url": "https://www.target.com/sl/aventura/1074",
+    "slug": "aventura",
+    "store_id": "1074"
+  },
+  {
+    "url": "https://www.target.com/sl/cutler-ridge/1075",
+    "slug": "cutler-ridge",
+    "store_id": "1075"
+  },
+  {
+    "url": "https://www.target.com/sl/alexandria/1076",
+    "slug": "alexandria",
+    "store_id": "1076"
+  },
+  {
+    "url": "https://www.target.com/sl/winston-salem-university-parkway/1077",
+    "slug": "winston-salem-university-parkway",
+    "store_id": "1077"
+  },
+  {
+    "url": "https://www.target.com/sl/greensboro-wendover/1078",
+    "slug": "greensboro-wendover",
+    "store_id": "1078"
+  },
+  {
+    "url": "https://www.target.com/sl/high-point/1079",
+    "slug": "high-point",
+    "store_id": "1079"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-hwy-70/1080",
+    "slug": "raleigh-hwy-70",
+    "store_id": "1080"
+  },
+  {
+    "url": "https://www.target.com/sl/ne-charlotte/1081",
+    "slug": "ne-charlotte",
+    "store_id": "1081"
+  },
+  {
+    "url": "https://www.target.com/sl/idaho-falls/1082",
+    "slug": "idaho-falls",
+    "store_id": "1082"
+  },
+  {
+    "url": "https://www.target.com/sl/clarkstown/1083",
+    "slug": "clarkstown",
+    "store_id": "1083"
+  },
+  {
+    "url": "https://www.target.com/sl/union/1084",
+    "slug": "union",
+    "store_id": "1084"
+  },
+  {
+    "url": "https://www.target.com/sl/cherry-hill/1085",
+    "slug": "cherry-hill",
+    "store_id": "1085"
+  },
+  {
+    "url": "https://www.target.com/sl/winston-salem-hanes-mall/1086",
+    "slug": "winston-salem-hanes-mall",
+    "store_id": "1086"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-stonecrest/1087",
+    "slug": "charlotte-stonecrest",
+    "store_id": "1087"
+  },
+  {
+    "url": "https://www.target.com/sl/reston/1088",
+    "slug": "reston",
+    "store_id": "1088"
+  },
+  {
+    "url": "https://www.target.com/sl/augusta/1090",
+    "slug": "augusta",
+    "store_id": "1090"
+  },
+  {
+    "url": "https://www.target.com/sl/fields-ertel/1091",
+    "slug": "fields-ertel",
+    "store_id": "1091"
+  },
+  {
+    "url": "https://www.target.com/sl/beechmont-area/1092",
+    "slug": "beechmont-area",
+    "store_id": "1092"
+  },
+  {
+    "url": "https://www.target.com/sl/lexington-se/1094",
+    "slug": "lexington-se",
+    "store_id": "1094"
+  },
+  {
+    "url": "https://www.target.com/sl/minneapolis-ne/1095",
+    "slug": "minneapolis-ne",
+    "store_id": "1095"
+  },
+  {
+    "url": "https://www.target.com/sl/winona/1096",
+    "slug": "winona",
+    "store_id": "1096"
+  },
+  {
+    "url": "https://www.target.com/sl/auburn/1097",
+    "slug": "auburn",
+    "store_id": "1097"
+  },
+  {
+    "url": "https://www.target.com/sl/folsom/1098",
+    "slug": "folsom",
+    "store_id": "1098"
+  },
+  {
+    "url": "https://www.target.com/sl/thousand-oaks/1100",
+    "slug": "thousand-oaks",
+    "store_id": "1100"
+  },
+  {
+    "url": "https://www.target.com/sl/florissant/1101",
+    "slug": "florissant",
+    "store_id": "1101"
+  },
+  {
+    "url": "https://www.target.com/sl/brentwood/1102",
+    "slug": "brentwood",
+    "store_id": "1102"
+  },
+  {
+    "url": "https://www.target.com/sl/newport-news/1103",
+    "slug": "newport-news",
+    "store_id": "1103"
+  },
+  {
+    "url": "https://www.target.com/sl/garner/1104",
+    "slug": "garner",
+    "store_id": "1104"
+  },
+  {
+    "url": "https://www.target.com/sl/princess-anne/1105",
+    "slug": "princess-anne",
+    "store_id": "1105"
+  },
+  {
+    "url": "https://www.target.com/sl/cobb-ne/1106",
+    "slug": "cobb-ne",
+    "store_id": "1106"
+  },
+  {
+    "url": "https://www.target.com/sl/wilmington/1107",
+    "slug": "wilmington",
+    "store_id": "1107"
+  },
+  {
+    "url": "https://www.target.com/sl/commack/1108",
+    "slug": "commack",
+    "store_id": "1108"
+  },
+  {
+    "url": "https://www.target.com/sl/mays-landing/1109",
+    "slug": "mays-landing",
+    "store_id": "1109"
+  },
+  {
+    "url": "https://www.target.com/sl/greenacres/1110",
+    "slug": "greenacres",
+    "store_id": "1110"
+  },
+  {
+    "url": "https://www.target.com/sl/willoughby/1112",
+    "slug": "willoughby",
+    "store_id": "1112"
+  },
+  {
+    "url": "https://www.target.com/sl/coralville/1113",
+    "slug": "coralville",
+    "store_id": "1113"
+  },
+  {
+    "url": "https://www.target.com/sl/little-rock-west/1114",
+    "slug": "little-rock-west",
+    "store_id": "1114"
+  },
+  {
+    "url": "https://www.target.com/sl/conroe/1115",
+    "slug": "conroe",
+    "store_id": "1115"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-prairie/1116",
+    "slug": "grand-prairie",
+    "store_id": "1116"
+  },
+  {
+    "url": "https://www.target.com/sl/rio-rancho/1117",
+    "slug": "rio-rancho",
+    "store_id": "1117"
+  },
+  {
+    "url": "https://www.target.com/sl/woodinville/1118",
+    "slug": "woodinville",
+    "store_id": "1118"
+  },
+  {
+    "url": "https://www.target.com/sl/paso-robles/1120",
+    "slug": "paso-robles",
+    "store_id": "1120"
+  },
+  {
+    "url": "https://www.target.com/sl/birdcage-citrus-heights/1121",
+    "slug": "birdcage-citrus-heights",
+    "store_id": "1121"
+  },
+  {
+    "url": "https://www.target.com/sl/san-mateo-fashion-island/1122",
+    "slug": "san-mateo-fashion-island",
+    "store_id": "1122"
+  },
+  {
+    "url": "https://www.target.com/sl/tomball-parkway/1124",
+    "slug": "tomball-parkway",
+    "store_id": "1124"
+  },
+  {
+    "url": "https://www.target.com/sl/golf-mill/1125",
+    "slug": "golf-mill",
+    "store_id": "1125"
+  },
+  {
+    "url": "https://www.target.com/sl/murfreesboro/1126",
+    "slug": "murfreesboro",
+    "store_id": "1126"
+  },
+  {
+    "url": "https://www.target.com/sl/beavercreek/1128",
+    "slug": "beavercreek",
+    "store_id": "1128"
+  },
+  {
+    "url": "https://www.target.com/sl/huber-heights/1129",
+    "slug": "huber-heights",
+    "store_id": "1129"
+  },
+  {
+    "url": "https://www.target.com/sl/st-petersburg-gateway/1131",
+    "slug": "st-petersburg-gateway",
+    "store_id": "1131"
+  },
+  {
+    "url": "https://www.target.com/sl/turnersville/1132",
+    "slug": "turnersville",
+    "store_id": "1132"
+  },
+  {
+    "url": "https://www.target.com/sl/voorhees/1133",
+    "slug": "voorhees",
+    "store_id": "1133"
+  },
+  {
+    "url": "https://www.target.com/sl/exton/1134",
+    "slug": "exton",
+    "store_id": "1134"
+  },
+  {
+    "url": "https://www.target.com/sl/oxford-valley/1135",
+    "slug": "oxford-valley",
+    "store_id": "1135"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield/1136",
+    "slug": "springfield",
+    "store_id": "1136"
+  },
+  {
+    "url": "https://www.target.com/sl/frederick/1137",
+    "slug": "frederick",
+    "store_id": "1137"
+  },
+  {
+    "url": "https://www.target.com/sl/silver-spring/1138",
+    "slug": "silver-spring",
+    "store_id": "1138"
+  },
+  {
+    "url": "https://www.target.com/sl/westbury/1139",
+    "slug": "westbury",
+    "store_id": "1139"
+  },
+  {
+    "url": "https://www.target.com/sl/rancho-san-diego/1140",
+    "slug": "rancho-san-diego",
+    "store_id": "1140"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-i17-and-sr101/1141",
+    "slug": "phoenix-i17-and-sr101",
+    "store_id": "1141"
+  },
+  {
+    "url": "https://www.target.com/sl/towson/1142",
+    "slug": "towson",
+    "store_id": "1142"
+  },
+  {
+    "url": "https://www.target.com/sl/watsonville/1143",
+    "slug": "watsonville",
+    "store_id": "1143"
+  },
+  {
+    "url": "https://www.target.com/sl/coon-rapids/1144",
+    "slug": "coon-rapids",
+    "store_id": "1144"
+  },
+  {
+    "url": "https://www.target.com/sl/brandywine/1146",
+    "slug": "brandywine",
+    "store_id": "1146"
+  },
+  {
+    "url": "https://www.target.com/sl/copiague/1147",
+    "slug": "copiague",
+    "store_id": "1147"
+  },
+  {
+    "url": "https://www.target.com/sl/bay-shore/1148",
+    "slug": "bay-shore",
+    "store_id": "1148"
+  },
+  {
+    "url": "https://www.target.com/sl/college-point/1150",
+    "slug": "college-point",
+    "store_id": "1150"
+  },
+  {
+    "url": "https://www.target.com/sl/princeton/1151",
+    "slug": "princeton",
+    "store_id": "1151"
+  },
+  {
+    "url": "https://www.target.com/sl/milltown/1152",
+    "slug": "milltown",
+    "store_id": "1152"
+  },
+  {
+    "url": "https://www.target.com/sl/brick/1153",
+    "slug": "brick",
+    "store_id": "1153"
+  },
+  {
+    "url": "https://www.target.com/sl/toms-river/1154",
+    "slug": "toms-river",
+    "store_id": "1154"
+  },
+  {
+    "url": "https://www.target.com/sl/watchung/1155",
+    "slug": "watchung",
+    "store_id": "1155"
+  },
+  {
+    "url": "https://www.target.com/sl/victor/1156",
+    "slug": "victor",
+    "store_id": "1156"
+  },
+  {
+    "url": "https://www.target.com/sl/henrietta/1157",
+    "slug": "henrietta",
+    "store_id": "1157"
+  },
+  {
+    "url": "https://www.target.com/sl/burlington/1158",
+    "slug": "burlington",
+    "store_id": "1158"
+  },
+  {
+    "url": "https://www.target.com/sl/montgomeryville/1159",
+    "slug": "montgomeryville",
+    "store_id": "1159"
+  },
+  {
+    "url": "https://www.target.com/sl/altoona/1160",
+    "slug": "altoona",
+    "store_id": "1160"
+  },
+  {
+    "url": "https://www.target.com/sl/williamsburg/1161",
+    "slug": "williamsburg",
+    "store_id": "1161"
+  },
+  {
+    "url": "https://www.target.com/sl/roanoke/1162",
+    "slug": "roanoke",
+    "store_id": "1162"
+  },
+  {
+    "url": "https://www.target.com/sl/ft-lauderdale/1163",
+    "slug": "ft-lauderdale",
+    "store_id": "1163"
+  },
+  {
+    "url": "https://www.target.com/sl/austell/1164",
+    "slug": "austell",
+    "store_id": "1164"
+  },
+  {
+    "url": "https://www.target.com/sl/west-marietta/1165",
+    "slug": "west-marietta",
+    "store_id": "1165"
+  },
+  {
+    "url": "https://www.target.com/sl/crystal-lake/1166",
+    "slug": "crystal-lake",
+    "store_id": "1166"
+  },
+  {
+    "url": "https://www.target.com/sl/glenview/1167",
+    "slug": "glenview",
+    "store_id": "1167"
+  },
+  {
+    "url": "https://www.target.com/sl/highland-park/1168",
+    "slug": "highland-park",
+    "store_id": "1168"
+  },
+  {
+    "url": "https://www.target.com/sl/horn-lake/1169",
+    "slug": "horn-lake",
+    "store_id": "1169"
+  },
+  {
+    "url": "https://www.target.com/sl/ames/1170",
+    "slug": "ames",
+    "store_id": "1170"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-silverado-ranch/1171",
+    "slug": "las-vegas-silverado-ranch",
+    "store_id": "1171"
+  },
+  {
+    "url": "https://www.target.com/sl/douglasville/1172",
+    "slug": "douglasville",
+    "store_id": "1172"
+  },
+  {
+    "url": "https://www.target.com/sl/fairfield/1175",
+    "slug": "fairfield",
+    "store_id": "1175"
+  },
+  {
+    "url": "https://www.target.com/sl/arlington-heights/1176",
+    "slug": "arlington-heights",
+    "store_id": "1176"
+  },
+  {
+    "url": "https://www.target.com/sl/kansas-city-north/1177",
+    "slug": "kansas-city-north",
+    "store_id": "1177"
+  },
+  {
+    "url": "https://www.target.com/sl/loveland/1178",
+    "slug": "loveland",
+    "store_id": "1178"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus/1179",
+    "slug": "columbus",
+    "store_id": "1179"
+  },
+  {
+    "url": "https://www.target.com/sl/greensboro-lawndale/1180",
+    "slug": "greensboro-lawndale",
+    "store_id": "1180"
+  },
+  {
+    "url": "https://www.target.com/sl/hickory/1181",
+    "slug": "hickory",
+    "store_id": "1181"
+  },
+  {
+    "url": "https://www.target.com/sl/greenville/1182",
+    "slug": "greenville",
+    "store_id": "1182"
+  },
+  {
+    "url": "https://www.target.com/sl/neshaminy/1183",
+    "slug": "neshaminy",
+    "store_id": "1183"
+  },
+  {
+    "url": "https://www.target.com/sl/manalapan/1184",
+    "slug": "manalapan",
+    "store_id": "1184"
+  },
+  {
+    "url": "https://www.target.com/sl/north-st-paul/1185",
+    "slug": "north-st-paul",
+    "store_id": "1185"
+  },
+  {
+    "url": "https://www.target.com/sl/salem-broadway/1186",
+    "slug": "salem-broadway",
+    "store_id": "1186"
+  },
+  {
+    "url": "https://www.target.com/sl/danvers/1187",
+    "slug": "danvers",
+    "store_id": "1187"
+  },
+  {
+    "url": "https://www.target.com/sl/warwick-route-2/1188",
+    "slug": "warwick-route-2",
+    "store_id": "1188"
+  },
+  {
+    "url": "https://www.target.com/sl/taunton/1189",
+    "slug": "taunton",
+    "store_id": "1189"
+  },
+  {
+    "url": "https://www.target.com/sl/north-attleborough/1190",
+    "slug": "north-attleborough",
+    "store_id": "1190"
+  },
+  {
+    "url": "https://www.target.com/sl/south-setauket/1191",
+    "slug": "south-setauket",
+    "store_id": "1191"
+  },
+  {
+    "url": "https://www.target.com/sl/middletown/1192",
+    "slug": "middletown",
+    "store_id": "1192"
+  },
+  {
+    "url": "https://www.target.com/sl/gaithersburg/1193",
+    "slug": "gaithersburg",
+    "store_id": "1193"
+  },
+  {
+    "url": "https://www.target.com/sl/greece/1194",
+    "slug": "greece",
+    "store_id": "1194"
+  },
+  {
+    "url": "https://www.target.com/sl/penfield/1195",
+    "slug": "penfield",
+    "store_id": "1195"
+  },
+  {
+    "url": "https://www.target.com/sl/warrington/1196",
+    "slug": "warrington",
+    "store_id": "1196"
+  },
+  {
+    "url": "https://www.target.com/sl/buckhead/1197",
+    "slug": "buckhead",
+    "store_id": "1197"
+  },
+  {
+    "url": "https://www.target.com/sl/anderson/1198",
+    "slug": "anderson",
+    "store_id": "1198"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia-harbison-blvd/1199",
+    "slug": "columbia-harbison-blvd",
+    "store_id": "1199"
+  },
+  {
+    "url": "https://www.target.com/sl/florence/1200",
+    "slug": "florence",
+    "store_id": "1200"
+  },
+  {
+    "url": "https://www.target.com/sl/independence/1201",
+    "slug": "independence",
+    "store_id": "1201"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-ne/1204",
+    "slug": "san-antonio-ne",
+    "store_id": "1204"
+  },
+  {
+    "url": "https://www.target.com/sl/gig-harbor/1205",
+    "slug": "gig-harbor",
+    "store_id": "1205"
+  },
+  {
+    "url": "https://www.target.com/sl/buford/1206",
+    "slug": "buford",
+    "store_id": "1206"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-boca-park/1207",
+    "slug": "las-vegas-boca-park",
+    "store_id": "1207"
+  },
+  {
+    "url": "https://www.target.com/sl/walnut-creek/1208",
+    "slug": "walnut-creek",
+    "store_id": "1208"
+  },
+  {
+    "url": "https://www.target.com/sl/gilbert-val-vista/1209",
+    "slug": "gilbert-val-vista",
+    "store_id": "1209"
+  },
+  {
+    "url": "https://www.target.com/sl/hutchinson/1210",
+    "slug": "hutchinson",
+    "store_id": "1210"
+  },
+  {
+    "url": "https://www.target.com/sl/northfield/1211",
+    "slug": "northfield",
+    "store_id": "1211"
+  },
+  {
+    "url": "https://www.target.com/sl/grafton/1212",
+    "slug": "grafton",
+    "store_id": "1212"
+  },
+  {
+    "url": "https://www.target.com/sl/lemont/1213",
+    "slug": "lemont",
+    "store_id": "1213"
+  },
+  {
+    "url": "https://www.target.com/sl/washington-square/1214",
+    "slug": "washington-square",
+    "store_id": "1214"
+  },
+  {
+    "url": "https://www.target.com/sl/elyria/1215",
+    "slug": "elyria",
+    "store_id": "1215"
+  },
+  {
+    "url": "https://www.target.com/sl/washington/1216",
+    "slug": "washington",
+    "store_id": "1216"
+  },
+  {
+    "url": "https://www.target.com/sl/north-fayette/1217",
+    "slug": "north-fayette",
+    "store_id": "1217"
+  },
+  {
+    "url": "https://www.target.com/sl/mccandless/1218",
+    "slug": "mccandless",
+    "store_id": "1218"
+  },
+  {
+    "url": "https://www.target.com/sl/monroeville/1219",
+    "slug": "monroeville",
+    "store_id": "1219"
+  },
+  {
+    "url": "https://www.target.com/sl/greensburg/1220",
+    "slug": "greensburg",
+    "store_id": "1220"
+  },
+  {
+    "url": "https://www.target.com/sl/york-galleria/1221",
+    "slug": "york-galleria",
+    "store_id": "1221"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-township/1222",
+    "slug": "spring-township",
+    "store_id": "1222"
+  },
+  {
+    "url": "https://www.target.com/sl/newnan/1223",
+    "slug": "newnan",
+    "store_id": "1223"
+  },
+  {
+    "url": "https://www.target.com/sl/bridgewater/1224",
+    "slug": "bridgewater",
+    "store_id": "1224"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond-brandermill/1225",
+    "slug": "richmond-brandermill",
+    "store_id": "1225"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville/1226",
+    "slug": "jacksonville",
+    "store_id": "1226"
+  },
+  {
+    "url": "https://www.target.com/sl/concord/1227",
+    "slug": "concord",
+    "store_id": "1227"
+  },
+  {
+    "url": "https://www.target.com/sl/nashua/1228",
+    "slug": "nashua",
+    "store_id": "1228"
+  },
+  {
+    "url": "https://www.target.com/sl/everett/1229",
+    "slug": "everett",
+    "store_id": "1229"
+  },
+  {
+    "url": "https://www.target.com/sl/boise-eagle-road/1230",
+    "slug": "boise-eagle-road",
+    "store_id": "1230"
+  },
+  {
+    "url": "https://www.target.com/sl/allen/1231",
+    "slug": "allen",
+    "store_id": "1231"
+  },
+  {
+    "url": "https://www.target.com/sl/holyoke/1232",
+    "slug": "holyoke",
+    "store_id": "1232"
+  },
+  {
+    "url": "https://www.target.com/sl/salisbury/1233",
+    "slug": "salisbury",
+    "store_id": "1233"
+  },
+  {
+    "url": "https://www.target.com/sl/winchester/1234",
+    "slug": "winchester",
+    "store_id": "1234"
+  },
+  {
+    "url": "https://www.target.com/sl/hudson/1235",
+    "slug": "hudson",
+    "store_id": "1235"
+  },
+  {
+    "url": "https://www.target.com/sl/polaris/1236",
+    "slug": "polaris",
+    "store_id": "1236"
+  },
+  {
+    "url": "https://www.target.com/sl/bozeman/1237",
+    "slug": "bozeman",
+    "store_id": "1237"
+  },
+  {
+    "url": "https://www.target.com/sl/irvine-north/1238",
+    "slug": "irvine-north",
+    "store_id": "1238"
+  },
+  {
+    "url": "https://www.target.com/sl/carson-city/1239",
+    "slug": "carson-city",
+    "store_id": "1239"
+  },
+  {
+    "url": "https://www.target.com/sl/o'fallon/1241",
+    "slug": "o'fallon",
+    "store_id": "1241"
+  },
+  {
+    "url": "https://www.target.com/sl/goodyear/1242",
+    "slug": "goodyear",
+    "store_id": "1242"
+  },
+  {
+    "url": "https://www.target.com/sl/forest-lake/1244",
+    "slug": "forest-lake",
+    "store_id": "1244"
+  },
+  {
+    "url": "https://www.target.com/sl/sturgeon-bay/1246",
+    "slug": "sturgeon-bay",
+    "store_id": "1246"
+  },
+  {
+    "url": "https://www.target.com/sl/green-bay-west/1247",
+    "slug": "green-bay-west",
+    "store_id": "1247"
+  },
+  {
+    "url": "https://www.target.com/sl/appleton-east/1248",
+    "slug": "appleton-east",
+    "store_id": "1248"
+  },
+  {
+    "url": "https://www.target.com/sl/south-windsor/1249",
+    "slug": "south-windsor",
+    "store_id": "1249"
+  },
+  {
+    "url": "https://www.target.com/sl/maryville/1250",
+    "slug": "maryville",
+    "store_id": "1250"
+  },
+  {
+    "url": "https://www.target.com/sl/auburn-hills/1251",
+    "slug": "auburn-hills",
+    "store_id": "1251"
+  },
+  {
+    "url": "https://www.target.com/sl/dayton-south/1252",
+    "slug": "dayton-south",
+    "store_id": "1252"
+  },
+  {
+    "url": "https://www.target.com/sl/waterfront/1253",
+    "slug": "waterfront",
+    "store_id": "1253"
+  },
+  {
+    "url": "https://www.target.com/sl/harrisburg-north/1254",
+    "slug": "harrisburg-north",
+    "store_id": "1254"
+  },
+  {
+    "url": "https://www.target.com/sl/enfield/1255",
+    "slug": "enfield",
+    "store_id": "1255"
+  },
+  {
+    "url": "https://www.target.com/sl/abington-township/1256",
+    "slug": "abington-township",
+    "store_id": "1256"
+  },
+  {
+    "url": "https://www.target.com/sl/hagerstown/1257",
+    "slug": "hagerstown",
+    "store_id": "1257"
+  },
+  {
+    "url": "https://www.target.com/sl/lexington-park/1258",
+    "slug": "lexington-park",
+    "store_id": "1258"
+  },
+  {
+    "url": "https://www.target.com/sl/cranberry/1259",
+    "slug": "cranberry",
+    "store_id": "1259"
+  },
+  {
+    "url": "https://www.target.com/sl/stroudsburg/1260",
+    "slug": "stroudsburg",
+    "store_id": "1260"
+  },
+  {
+    "url": "https://www.target.com/sl/charleston/1261",
+    "slug": "charleston",
+    "store_id": "1261"
+  },
+  {
+    "url": "https://www.target.com/sl/edgewater/1263",
+    "slug": "edgewater",
+    "store_id": "1263"
+  },
+  {
+    "url": "https://www.target.com/sl/levittown/1264",
+    "slug": "levittown",
+    "store_id": "1264"
+  },
+  {
+    "url": "https://www.target.com/sl/timonium/1265",
+    "slug": "timonium",
+    "store_id": "1265"
+  },
+  {
+    "url": "https://www.target.com/sl/woburn/1266",
+    "slug": "woburn",
+    "store_id": "1266"
+  },
+  {
+    "url": "https://www.target.com/sl/waterford/1267",
+    "slug": "waterford",
+    "store_id": "1267"
+  },
+  {
+    "url": "https://www.target.com/sl/colonie-northway/1268",
+    "slug": "colonie-northway",
+    "store_id": "1268"
+  },
+  {
+    "url": "https://www.target.com/sl/plymouth-meeting/1269",
+    "slug": "plymouth-meeting",
+    "store_id": "1269"
+  },
+  {
+    "url": "https://www.target.com/sl/west-mifflin/1270",
+    "slug": "west-mifflin",
+    "store_id": "1270"
+  },
+  {
+    "url": "https://www.target.com/sl/saratoga-springs/1271",
+    "slug": "saratoga-springs",
+    "store_id": "1271"
+  },
+  {
+    "url": "https://www.target.com/sl/shakopee/1272",
+    "slug": "shakopee",
+    "store_id": "1272"
+  },
+  {
+    "url": "https://www.target.com/sl/pensacola-ne/1273",
+    "slug": "pensacola-ne",
+    "store_id": "1273"
+  },
+  {
+    "url": "https://www.target.com/sl/daphne/1274",
+    "slug": "daphne",
+    "store_id": "1274"
+  },
+  {
+    "url": "https://www.target.com/sl/lynchburg/1275",
+    "slug": "lynchburg",
+    "store_id": "1275"
+  },
+  {
+    "url": "https://www.target.com/sl/arnold/1278",
+    "slug": "arnold",
+    "store_id": "1278"
+  },
+  {
+    "url": "https://www.target.com/sl/kirkwood/1279",
+    "slug": "kirkwood",
+    "store_id": "1279"
+  },
+  {
+    "url": "https://www.target.com/sl/st-charles/1280",
+    "slug": "st-charles",
+    "store_id": "1280"
+  },
+  {
+    "url": "https://www.target.com/sl/milford/1281",
+    "slug": "milford",
+    "store_id": "1281"
+  },
+  {
+    "url": "https://www.target.com/sl/helena/1282",
+    "slug": "helena",
+    "store_id": "1282"
+  },
+  {
+    "url": "https://www.target.com/sl/murrieta/1283",
+    "slug": "murrieta",
+    "store_id": "1283"
+  },
+  {
+    "url": "https://www.target.com/sl/northgate/1284",
+    "slug": "northgate",
+    "store_id": "1284"
+  },
+  {
+    "url": "https://www.target.com/sl/ypsilanti-carpenter-road/1285",
+    "slug": "ypsilanti-carpenter-road",
+    "store_id": "1285"
+  },
+  {
+    "url": "https://www.target.com/sl/valparaiso/1286",
+    "slug": "valparaiso",
+    "store_id": "1286"
+  },
+  {
+    "url": "https://www.target.com/sl/erie/1287",
+    "slug": "erie",
+    "store_id": "1287"
+  },
+  {
+    "url": "https://www.target.com/sl/state-college/1288",
+    "slug": "state-college",
+    "store_id": "1288"
+  },
+  {
+    "url": "https://www.target.com/sl/new-britain/1289",
+    "slug": "new-britain",
+    "store_id": "1289"
+  },
+  {
+    "url": "https://www.target.com/sl/saugus/1290",
+    "slug": "saugus",
+    "store_id": "1290"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenixville/1291",
+    "slug": "phoenixville",
+    "store_id": "1291"
+  },
+  {
+    "url": "https://www.target.com/sl/christiansburg/1292",
+    "slug": "christiansburg",
+    "store_id": "1292"
+  },
+  {
+    "url": "https://www.target.com/sl/costa-mesa/1293",
+    "slug": "costa-mesa",
+    "store_id": "1293"
+  },
+  {
+    "url": "https://www.target.com/sl/st-augustine/1294",
+    "slug": "st-augustine",
+    "store_id": "1294"
+  },
+  {
+    "url": "https://www.target.com/sl/greenbelt/1295",
+    "slug": "greenbelt",
+    "store_id": "1295"
+  },
+  {
+    "url": "https://www.target.com/sl/middletown/1296",
+    "slug": "middletown",
+    "store_id": "1296"
+  },
+  {
+    "url": "https://www.target.com/sl/hilton-head/1298",
+    "slug": "hilton-head",
+    "store_id": "1298"
+  },
+  {
+    "url": "https://www.target.com/sl/lakeland-south/1299",
+    "slug": "lakeland-south",
+    "store_id": "1299"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville-mandarin/1300",
+    "slug": "jacksonville-mandarin",
+    "store_id": "1300"
+  },
+  {
+    "url": "https://www.target.com/sl/niles/1301",
+    "slug": "niles",
+    "store_id": "1301"
+  },
+  {
+    "url": "https://www.target.com/sl/chattanooga-east/1302",
+    "slug": "chattanooga-east",
+    "store_id": "1302"
+  },
+  {
+    "url": "https://www.target.com/sl/cambridge/1303",
+    "slug": "cambridge",
+    "store_id": "1303"
+  },
+  {
+    "url": "https://www.target.com/sl/turlock/1304",
+    "slug": "turlock",
+    "store_id": "1304"
+  },
+  {
+    "url": "https://www.target.com/sl/cerritos-south-street/1305",
+    "slug": "cerritos-south-street",
+    "store_id": "1305"
+  },
+  {
+    "url": "https://www.target.com/sl/los-angeles/1306",
+    "slug": "los-angeles",
+    "store_id": "1306"
+  },
+  {
+    "url": "https://www.target.com/sl/sherman-oaks/1307",
+    "slug": "sherman-oaks",
+    "store_id": "1307"
+  },
+  {
+    "url": "https://www.target.com/sl/framingham/1308",
+    "slug": "framingham",
+    "store_id": "1308"
+  },
+  {
+    "url": "https://www.target.com/sl/van-nuys-raymer-st/1309",
+    "slug": "van-nuys-raymer-st",
+    "store_id": "1309"
+  },
+  {
+    "url": "https://www.target.com/sl/aiken/1310",
+    "slug": "aiken",
+    "store_id": "1310"
+  },
+  {
+    "url": "https://www.target.com/sl/new-berlin/1311",
+    "slug": "new-berlin",
+    "store_id": "1311"
+  },
+  {
+    "url": "https://www.target.com/sl/dover/1312",
+    "slug": "dover",
+    "store_id": "1312"
+  },
+  {
+    "url": "https://www.target.com/sl/troy/1313",
+    "slug": "troy",
+    "store_id": "1313"
+  },
+  {
+    "url": "https://www.target.com/sl/fenton/1314",
+    "slug": "fenton",
+    "store_id": "1314"
+  },
+  {
+    "url": "https://www.target.com/sl/linden/1315",
+    "slug": "linden",
+    "store_id": "1315"
+  },
+  {
+    "url": "https://www.target.com/sl/tucson-sw/1316",
+    "slug": "tucson-sw",
+    "store_id": "1316"
+  },
+  {
+    "url": "https://www.target.com/sl/rossford/1317",
+    "slug": "rossford",
+    "store_id": "1317"
+  },
+  {
+    "url": "https://www.target.com/sl/kingston/1318",
+    "slug": "kingston",
+    "store_id": "1318"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia-two-notch-rd/1319",
+    "slug": "columbia-two-notch-rd",
+    "store_id": "1319"
+  },
+  {
+    "url": "https://www.target.com/sl/florence/1322",
+    "slug": "florence",
+    "store_id": "1322"
+  },
+  {
+    "url": "https://www.target.com/sl/st-charles/1323",
+    "slug": "st-charles",
+    "store_id": "1323"
+  },
+  {
+    "url": "https://www.target.com/sl/mayfield-heights/1324",
+    "slug": "mayfield-heights",
+    "store_id": "1324"
+  },
+  {
+    "url": "https://www.target.com/sl/avon-oh/1325",
+    "slug": "avon-oh",
+    "store_id": "1325"
+  },
+  {
+    "url": "https://www.target.com/sl/castle-rock/1326",
+    "slug": "castle-rock",
+    "store_id": "1326"
+  },
+  {
+    "url": "https://www.target.com/sl/scottsdale-road/1327",
+    "slug": "scottsdale-road",
+    "store_id": "1327"
+  },
+  {
+    "url": "https://www.target.com/sl/seal-beach/1328",
+    "slug": "seal-beach",
+    "store_id": "1328"
+  },
+  {
+    "url": "https://www.target.com/sl/inglewood/1329",
+    "slug": "inglewood",
+    "store_id": "1329"
+  },
+  {
+    "url": "https://www.target.com/sl/hackensack/1330",
+    "slug": "hackensack",
+    "store_id": "1330"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-stevens/1331",
+    "slug": "lake-stevens",
+    "store_id": "1331"
+  },
+  {
+    "url": "https://www.target.com/sl/pasadena-east/1332",
+    "slug": "pasadena-east",
+    "store_id": "1332"
+  },
+  {
+    "url": "https://www.target.com/sl/billings-heights/1333",
+    "slug": "billings-heights",
+    "store_id": "1333"
+  },
+  {
+    "url": "https://www.target.com/sl/marquette/1334",
+    "slug": "marquette",
+    "store_id": "1334"
+  },
+  {
+    "url": "https://www.target.com/sl/surprise/1335",
+    "slug": "surprise",
+    "store_id": "1335"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-south-main/1336",
+    "slug": "houston-south-main",
+    "store_id": "1336"
+  },
+  {
+    "url": "https://www.target.com/sl/deerfield-beach/1337",
+    "slug": "deerfield-beach",
+    "store_id": "1337"
+  },
+  {
+    "url": "https://www.target.com/sl/south-portland/1338",
+    "slug": "south-portland",
+    "store_id": "1338"
+  },
+  {
+    "url": "https://www.target.com/sl/arlington-south/1339",
+    "slug": "arlington-south",
+    "store_id": "1339"
+  },
+  {
+    "url": "https://www.target.com/sl/norwalk/1340",
+    "slug": "norwalk",
+    "store_id": "1340"
+  },
+  {
+    "url": "https://www.target.com/sl/fair-lakes/1341",
+    "slug": "fair-lakes",
+    "store_id": "1341"
+  },
+  {
+    "url": "https://www.target.com/sl/rosemont/1342",
+    "slug": "rosemont",
+    "store_id": "1342"
+  },
+  {
+    "url": "https://www.target.com/sl/queens-place/1344",
+    "slug": "queens-place",
+    "store_id": "1344"
+  },
+  {
+    "url": "https://www.target.com/sl/east-windsor/1345",
+    "slug": "east-windsor",
+    "store_id": "1345"
+  },
+  {
+    "url": "https://www.target.com/sl/huntsville-west/1346",
+    "slug": "huntsville-west",
+    "store_id": "1346"
+  },
+  {
+    "url": "https://www.target.com/sl/shreveport/1347",
+    "slug": "shreveport",
+    "store_id": "1347"
+  },
+  {
+    "url": "https://www.target.com/sl/worcester/1348",
+    "slug": "worcester",
+    "store_id": "1348"
+  },
+  {
+    "url": "https://www.target.com/sl/spartanburg/1349",
+    "slug": "spartanburg",
+    "store_id": "1349"
+  },
+  {
+    "url": "https://www.target.com/sl/fishers/1350",
+    "slug": "fishers",
+    "store_id": "1350"
+  },
+  {
+    "url": "https://www.target.com/sl/rochester/1351",
+    "slug": "rochester",
+    "store_id": "1351"
+  },
+  {
+    "url": "https://www.target.com/sl/chaska/1352",
+    "slug": "chaska",
+    "store_id": "1352"
+  },
+  {
+    "url": "https://www.target.com/sl/chesterfield/1353",
+    "slug": "chesterfield",
+    "store_id": "1353"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-north/1354",
+    "slug": "san-antonio-north",
+    "store_id": "1354"
+  },
+  {
+    "url": "https://www.target.com/sl/lacey/1355",
+    "slug": "lacey",
+    "store_id": "1355"
+  },
+  {
+    "url": "https://www.target.com/sl/minnetonka/1356",
+    "slug": "minnetonka",
+    "store_id": "1356"
+  },
+  {
+    "url": "https://www.target.com/sl/st-george/1357",
+    "slug": "st-george",
+    "store_id": "1357"
+  },
+  {
+    "url": "https://www.target.com/sl/white-plains/1358",
+    "slug": "white-plains",
+    "store_id": "1358"
+  },
+  {
+    "url": "https://www.target.com/sl/missouri-city/1359",
+    "slug": "missouri-city",
+    "store_id": "1359"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-ne/1360",
+    "slug": "phoenix-ne",
+    "store_id": "1360"
+  },
+  {
+    "url": "https://www.target.com/sl/peoria-sw/1361",
+    "slug": "peoria-sw",
+    "store_id": "1361"
+  },
+  {
+    "url": "https://www.target.com/sl/burbank/1362",
+    "slug": "burbank",
+    "store_id": "1362"
+  },
+  {
+    "url": "https://www.target.com/sl/reno-south/1363",
+    "slug": "reno-south",
+    "store_id": "1363"
+  },
+  {
+    "url": "https://www.target.com/sl/greenwood-south/1364",
+    "slug": "greenwood-south",
+    "store_id": "1364"
+  },
+  {
+    "url": "https://www.target.com/sl/marlton/1365",
+    "slug": "marlton",
+    "store_id": "1365"
+  },
+  {
+    "url": "https://www.target.com/sl/carmel-west/1366",
+    "slug": "carmel-west",
+    "store_id": "1366"
+  },
+  {
+    "url": "https://www.target.com/sl/huntsville-south/1367",
+    "slug": "huntsville-south",
+    "store_id": "1367"
+  },
+  {
+    "url": "https://www.target.com/sl/euless/1368",
+    "slug": "euless",
+    "store_id": "1368"
+  },
+  {
+    "url": "https://www.target.com/sl/baton-rouge-siegen/1369",
+    "slug": "baton-rouge-siegen",
+    "store_id": "1369"
+  },
+  {
+    "url": "https://www.target.com/sl/farragut/1370",
+    "slug": "farragut",
+    "store_id": "1370"
+  },
+  {
+    "url": "https://www.target.com/sl/rock-hill/1371",
+    "slug": "rock-hill",
+    "store_id": "1371"
+  },
+  {
+    "url": "https://www.target.com/sl/thornton/1372",
+    "slug": "thornton",
+    "store_id": "1372"
+  },
+  {
+    "url": "https://www.target.com/sl/meriden/1373",
+    "slug": "meriden",
+    "store_id": "1373"
+  },
+  {
+    "url": "https://www.target.com/sl/seekonk/1374",
+    "slug": "seekonk",
+    "store_id": "1374"
+  },
+  {
+    "url": "https://www.target.com/sl/mpls-nicollet-mall/1375",
+    "slug": "mpls-nicollet-mall",
+    "store_id": "1375"
+  },
+  {
+    "url": "https://www.target.com/sl/mobile-west/1376",
+    "slug": "mobile-west",
+    "store_id": "1376"
+  },
+  {
+    "url": "https://www.target.com/sl/clear-lake-shores/1377",
+    "slug": "clear-lake-shores",
+    "store_id": "1377"
+  },
+  {
+    "url": "https://www.target.com/sl/ocean-township/1378",
+    "slug": "ocean-township",
+    "store_id": "1378"
+  },
+  {
+    "url": "https://www.target.com/sl/warner-robins/1380",
+    "slug": "warner-robins",
+    "store_id": "1380"
+  },
+  {
+    "url": "https://www.target.com/sl/mansfield/1381",
+    "slug": "mansfield",
+    "store_id": "1381"
+  },
+  {
+    "url": "https://www.target.com/sl/new-tampa/1382",
+    "slug": "new-tampa",
+    "store_id": "1382"
+  },
+  {
+    "url": "https://www.target.com/sl/west-fullerton/1383",
+    "slug": "west-fullerton",
+    "store_id": "1383"
+  },
+  {
+    "url": "https://www.target.com/sl/bakersfield-nw/1384",
+    "slug": "bakersfield-nw",
+    "store_id": "1384"
+  },
+  {
+    "url": "https://www.target.com/sl/wheeling/1385",
+    "slug": "wheeling",
+    "store_id": "1385"
+  },
+  {
+    "url": "https://www.target.com/sl/mesa-red-mountain/1386",
+    "slug": "mesa-red-mountain",
+    "store_id": "1386"
+  },
+  {
+    "url": "https://www.target.com/sl/kansas-city-chouteau/1388",
+    "slug": "kansas-city-chouteau",
+    "store_id": "1388"
+  },
+  {
+    "url": "https://www.target.com/sl/deptford/1389",
+    "slug": "deptford",
+    "store_id": "1389"
+  },
+  {
+    "url": "https://www.target.com/sl/northlake/1390",
+    "slug": "northlake",
+    "store_id": "1390"
+  },
+  {
+    "url": "https://www.target.com/sl/charleston-south/1391",
+    "slug": "charleston-south",
+    "store_id": "1391"
+  },
+  {
+    "url": "https://www.target.com/sl/lees-summit/1392",
+    "slug": "lees-summit",
+    "store_id": "1392"
+  },
+  {
+    "url": "https://www.target.com/sl/milford/1393",
+    "slug": "milford",
+    "store_id": "1393"
+  },
+  {
+    "url": "https://www.target.com/sl/cumming/1394",
+    "slug": "cumming",
+    "store_id": "1394"
+  },
+  {
+    "url": "https://www.target.com/sl/vista-ridge/1395",
+    "slug": "vista-ridge",
+    "store_id": "1395"
+  },
+  {
+    "url": "https://www.target.com/sl/pasadena/1396",
+    "slug": "pasadena",
+    "store_id": "1396"
+  },
+  {
+    "url": "https://www.target.com/sl/quail-springs/1397",
+    "slug": "quail-springs",
+    "store_id": "1397"
+  },
+  {
+    "url": "https://www.target.com/sl/edmond/1398",
+    "slug": "edmond",
+    "store_id": "1398"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-charles/1399",
+    "slug": "lake-charles",
+    "store_id": "1399"
+  },
+  {
+    "url": "https://www.target.com/sl/hiram/1400",
+    "slug": "hiram",
+    "store_id": "1400"
+  },
+  {
+    "url": "https://www.target.com/sl/gateway/1401",
+    "slug": "gateway",
+    "store_id": "1401"
+  },
+  {
+    "url": "https://www.target.com/sl/oswego/1402",
+    "slug": "oswego",
+    "store_id": "1402"
+  },
+  {
+    "url": "https://www.target.com/sl/plainfield/1403",
+    "slug": "plainfield",
+    "store_id": "1403"
+  },
+  {
+    "url": "https://www.target.com/sl/smithfield/1404",
+    "slug": "smithfield",
+    "store_id": "1404"
+  },
+  {
+    "url": "https://www.target.com/sl/eugene/1405",
+    "slug": "eugene",
+    "store_id": "1405"
+  },
+  {
+    "url": "https://www.target.com/sl/fairview/1406",
+    "slug": "fairview",
+    "store_id": "1406"
+  },
+  {
+    "url": "https://www.target.com/sl/daly-city-serramonte/1407",
+    "slug": "daly-city-serramonte",
+    "store_id": "1407"
+  },
+  {
+    "url": "https://www.target.com/sl/los-angeles-eagle-rock/1408",
+    "slug": "los-angeles-eagle-rock",
+    "store_id": "1408"
+  },
+  {
+    "url": "https://www.target.com/sl/lakewood-center-mall/1409",
+    "slug": "lakewood-center-mall",
+    "store_id": "1409"
+  },
+  {
+    "url": "https://www.target.com/sl/san-diego-mission-valley/1410",
+    "slug": "san-diego-mission-valley",
+    "store_id": "1410"
+  },
+  {
+    "url": "https://www.target.com/sl/rosemead/1411",
+    "slug": "rosemead",
+    "store_id": "1411"
+  },
+  {
+    "url": "https://www.target.com/sl/aurora-west/1413",
+    "slug": "aurora-west",
+    "store_id": "1413"
+  },
+  {
+    "url": "https://www.target.com/sl/butler/1414",
+    "slug": "butler",
+    "store_id": "1414"
+  },
+  {
+    "url": "https://www.target.com/sl/wheaton/1415",
+    "slug": "wheaton",
+    "store_id": "1415"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield/1416",
+    "slug": "springfield",
+    "store_id": "1416"
+  },
+  {
+    "url": "https://www.target.com/sl/blackstone-and-bullard/1417",
+    "slug": "blackstone-and-bullard",
+    "store_id": "1417"
+  },
+  {
+    "url": "https://www.target.com/sl/fullerton-south/1418",
+    "slug": "fullerton-south",
+    "store_id": "1418"
+  },
+  {
+    "url": "https://www.target.com/sl/portland-east-washington-street/1419",
+    "slug": "portland-east-washington-street",
+    "store_id": "1419"
+  },
+  {
+    "url": "https://www.target.com/sl/chesapeake-sq-mall/1420",
+    "slug": "chesapeake-sq-mall",
+    "store_id": "1420"
+  },
+  {
+    "url": "https://www.target.com/sl/eureka/1421",
+    "slug": "eureka",
+    "store_id": "1421"
+  },
+  {
+    "url": "https://www.target.com/sl/fremont-hub/1422",
+    "slug": "fremont-hub",
+    "store_id": "1422"
+  },
+  {
+    "url": "https://www.target.com/sl/montclair/1423",
+    "slug": "montclair",
+    "store_id": "1423"
+  },
+  {
+    "url": "https://www.target.com/sl/norwalk-east/1424",
+    "slug": "norwalk-east",
+    "store_id": "1424"
+  },
+  {
+    "url": "https://www.target.com/sl/pico-rivera/1425",
+    "slug": "pico-rivera",
+    "store_id": "1425"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-capitol/1426",
+    "slug": "san-jose-capitol",
+    "store_id": "1426"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-westgate/1427",
+    "slug": "san-jose-westgate",
+    "store_id": "1427"
+  },
+  {
+    "url": "https://www.target.com/sl/san-leandro-bayfair/1428",
+    "slug": "san-leandro-bayfair",
+    "store_id": "1428"
+  },
+  {
+    "url": "https://www.target.com/sl/mesa-west/1429",
+    "slug": "mesa-west",
+    "store_id": "1429"
+  },
+  {
+    "url": "https://www.target.com/sl/richardson-sq-mall/1430",
+    "slug": "richardson-sq-mall",
+    "store_id": "1430"
+  },
+  {
+    "url": "https://www.target.com/sl/falls-church/1431",
+    "slug": "falls-church",
+    "store_id": "1431"
+  },
+  {
+    "url": "https://www.target.com/sl/fountain-hills/1432",
+    "slug": "fountain-hills",
+    "store_id": "1432"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-memorial/1435",
+    "slug": "houston-memorial",
+    "store_id": "1435"
+  },
+  {
+    "url": "https://www.target.com/sl/ward-parkway/1436",
+    "slug": "ward-parkway",
+    "store_id": "1436"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-mid-north/1437",
+    "slug": "chicago-mid-north",
+    "store_id": "1437"
+  },
+  {
+    "url": "https://www.target.com/sl/napa-north/1438",
+    "slug": "napa-north",
+    "store_id": "1438"
+  },
+  {
+    "url": "https://www.target.com/sl/tucson-el-con-mall/1439",
+    "slug": "tucson-el-con-mall",
+    "store_id": "1439"
+  },
+  {
+    "url": "https://www.target.com/sl/somerville/1441",
+    "slug": "somerville",
+    "store_id": "1441"
+  },
+  {
+    "url": "https://www.target.com/sl/watertown/1442",
+    "slug": "watertown",
+    "store_id": "1442"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-snyder-ave/1443",
+    "slug": "philadelphia-snyder-ave",
+    "store_id": "1443"
+  },
+  {
+    "url": "https://www.target.com/sl/vancouver-mill-plain-blvd/1444",
+    "slug": "vancouver-mill-plain-blvd",
+    "store_id": "1444"
+  },
+  {
+    "url": "https://www.target.com/sl/mishawaka/1445",
+    "slug": "mishawaka",
+    "store_id": "1445"
+  },
+  {
+    "url": "https://www.target.com/sl/goshen/1446",
+    "slug": "goshen",
+    "store_id": "1446"
+  },
+  {
+    "url": "https://www.target.com/sl/cincinnati-central/1447",
+    "slug": "cincinnati-central",
+    "store_id": "1447"
+  },
+  {
+    "url": "https://www.target.com/sl/lino-lakes/1448",
+    "slug": "lino-lakes",
+    "store_id": "1448"
+  },
+  {
+    "url": "https://www.target.com/sl/metairie/1449",
+    "slug": "metairie",
+    "store_id": "1449"
+  },
+  {
+    "url": "https://www.target.com/sl/houma/1450",
+    "slug": "houma",
+    "store_id": "1450"
+  },
+  {
+    "url": "https://www.target.com/sl/harvey/1451",
+    "slug": "harvey",
+    "store_id": "1451"
+  },
+  {
+    "url": "https://www.target.com/sl/florence/1452",
+    "slug": "florence",
+    "store_id": "1452"
+  },
+  {
+    "url": "https://www.target.com/sl/athens/1453",
+    "slug": "athens",
+    "store_id": "1453"
+  },
+  {
+    "url": "https://www.target.com/sl/cape-coral/1454",
+    "slug": "cape-coral",
+    "store_id": "1454"
+  },
+  {
+    "url": "https://www.target.com/sl/liberty/1455",
+    "slug": "liberty",
+    "store_id": "1455"
+  },
+  {
+    "url": "https://www.target.com/sl/rogers-diamond-lake-road/1456",
+    "slug": "rogers-diamond-lake-road",
+    "store_id": "1456"
+  },
+  {
+    "url": "https://www.target.com/sl/humble/1457",
+    "slug": "humble",
+    "store_id": "1457"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-north-central/1458",
+    "slug": "houston-north-central",
+    "store_id": "1458"
+  },
+  {
+    "url": "https://www.target.com/sl/pearland/1459",
+    "slug": "pearland",
+    "store_id": "1459"
+  },
+  {
+    "url": "https://www.target.com/sl/homewood/1460",
+    "slug": "homewood",
+    "store_id": "1460"
+  },
+  {
+    "url": "https://www.target.com/sl/mcdonough/1461",
+    "slug": "mcdonough",
+    "store_id": "1461"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-centennial-hills/1462",
+    "slug": "las-vegas-centennial-hills",
+    "store_id": "1462"
+  },
+  {
+    "url": "https://www.target.com/sl/boardman/1463",
+    "slug": "boardman",
+    "store_id": "1463"
+  },
+  {
+    "url": "https://www.target.com/sl/greenwich-township/1464",
+    "slug": "greenwich-township",
+    "store_id": "1464"
+  },
+  {
+    "url": "https://www.target.com/sl/novi/1465",
+    "slug": "novi",
+    "store_id": "1465"
+  },
+  {
+    "url": "https://www.target.com/sl/shelby-township/1466",
+    "slug": "shelby-township",
+    "store_id": "1466"
+  },
+  {
+    "url": "https://www.target.com/sl/clark/1467",
+    "slug": "clark",
+    "store_id": "1467"
+  },
+  {
+    "url": "https://www.target.com/sl/dothan/1468",
+    "slug": "dothan",
+    "store_id": "1468"
+  },
+  {
+    "url": "https://www.target.com/sl/monroe/1469",
+    "slug": "monroe",
+    "store_id": "1469"
+  },
+  {
+    "url": "https://www.target.com/sl/fayetteville/1470",
+    "slug": "fayetteville",
+    "store_id": "1470"
+  },
+  {
+    "url": "https://www.target.com/sl/aurora/1471",
+    "slug": "aurora",
+    "store_id": "1471"
+  },
+  {
+    "url": "https://www.target.com/sl/hayward/1472",
+    "slug": "hayward",
+    "store_id": "1472"
+  },
+  {
+    "url": "https://www.target.com/sl/lafayette/1473",
+    "slug": "lafayette",
+    "store_id": "1473"
+  },
+  {
+    "url": "https://www.target.com/sl/dickson-city/1474",
+    "slug": "dickson-city",
+    "store_id": "1474"
+  },
+  {
+    "url": "https://www.target.com/sl/clay/1475",
+    "slug": "clay",
+    "store_id": "1475"
+  },
+  {
+    "url": "https://www.target.com/sl/fayetteville/1476",
+    "slug": "fayetteville",
+    "store_id": "1476"
+  },
+  {
+    "url": "https://www.target.com/sl/clifton-park/1477",
+    "slug": "clifton-park",
+    "store_id": "1477"
+  },
+  {
+    "url": "https://www.target.com/sl/barboursville/1478",
+    "slug": "barboursville",
+    "store_id": "1478"
+  },
+  {
+    "url": "https://www.target.com/sl/bashford-manor/1479",
+    "slug": "bashford-manor",
+    "store_id": "1479"
+  },
+  {
+    "url": "https://www.target.com/sl/plantation/1480",
+    "slug": "plantation",
+    "store_id": "1480"
+  },
+  {
+    "url": "https://www.target.com/sl/evansville-lloyd-expressway/1481",
+    "slug": "evansville-lloyd-expressway",
+    "store_id": "1481"
+  },
+  {
+    "url": "https://www.target.com/sl/holland/1482",
+    "slug": "holland",
+    "store_id": "1482"
+  },
+  {
+    "url": "https://www.target.com/sl/bellevue/1483",
+    "slug": "bellevue",
+    "store_id": "1483"
+  },
+  {
+    "url": "https://www.target.com/sl/lakeville/1484",
+    "slug": "lakeville",
+    "store_id": "1484"
+  },
+  {
+    "url": "https://www.target.com/sl/santee/1485",
+    "slug": "santee",
+    "store_id": "1485"
+  },
+  {
+    "url": "https://www.target.com/sl/north-druid-hills/1486",
+    "slug": "north-druid-hills",
+    "store_id": "1486"
+  },
+  {
+    "url": "https://www.target.com/sl/mission/1487",
+    "slug": "mission",
+    "store_id": "1487"
+  },
+  {
+    "url": "https://www.target.com/sl/garland-east/1489",
+    "slug": "garland-east",
+    "store_id": "1489"
+  },
+  {
+    "url": "https://www.target.com/sl/mcallen-north/1490",
+    "slug": "mcallen-north",
+    "store_id": "1490"
+  },
+  {
+    "url": "https://www.target.com/sl/east-hanover/1491",
+    "slug": "east-hanover",
+    "store_id": "1491"
+  },
+  {
+    "url": "https://www.target.com/sl/new-hartford/1492",
+    "slug": "new-hartford",
+    "store_id": "1492"
+  },
+  {
+    "url": "https://www.target.com/sl/summerville/1493",
+    "slug": "summerville",
+    "store_id": "1493"
+  },
+  {
+    "url": "https://www.target.com/sl/kingston/1495",
+    "slug": "kingston",
+    "store_id": "1495"
+  },
+  {
+    "url": "https://www.target.com/sl/westborough/1496",
+    "slug": "westborough",
+    "store_id": "1496"
+  },
+  {
+    "url": "https://www.target.com/sl/fleming-island/1497",
+    "slug": "fleming-island",
+    "store_id": "1497"
+  },
+  {
+    "url": "https://www.target.com/sl/opelika/1499",
+    "slug": "opelika",
+    "store_id": "1499"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-west/1500",
+    "slug": "denver-west",
+    "store_id": "1500"
+  },
+  {
+    "url": "https://www.target.com/sl/colorado-springs-east/1501",
+    "slug": "colorado-springs-east",
+    "store_id": "1501"
+  },
+  {
+    "url": "https://www.target.com/sl/roseville-fairway-drive/1502",
+    "slug": "roseville-fairway-drive",
+    "store_id": "1502"
+  },
+  {
+    "url": "https://www.target.com/sl/wake-forest/1504",
+    "slug": "wake-forest",
+    "store_id": "1504"
+  },
+  {
+    "url": "https://www.target.com/sl/mooresville/1505",
+    "slug": "mooresville",
+    "store_id": "1505"
+  },
+  {
+    "url": "https://www.target.com/sl/odessa/1506",
+    "slug": "odessa",
+    "store_id": "1506"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond/1507",
+    "slug": "richmond",
+    "store_id": "1507"
+  },
+  {
+    "url": "https://www.target.com/sl/lansing/1508",
+    "slug": "lansing",
+    "store_id": "1508"
+  },
+  {
+    "url": "https://www.target.com/sl/south-county/1509",
+    "slug": "south-county",
+    "store_id": "1509"
+  },
+  {
+    "url": "https://www.target.com/sl/allentown/1510",
+    "slug": "allentown",
+    "store_id": "1510"
+  },
+  {
+    "url": "https://www.target.com/sl/hendersonville/1511",
+    "slug": "hendersonville",
+    "store_id": "1511"
+  },
+  {
+    "url": "https://www.target.com/sl/miramar/1512",
+    "slug": "miramar",
+    "store_id": "1512"
+  },
+  {
+    "url": "https://www.target.com/sl/louisville-jefferson-pavilion/1513",
+    "slug": "louisville-jefferson-pavilion",
+    "store_id": "1513"
+  },
+  {
+    "url": "https://www.target.com/sl/north-richland-hills/1514",
+    "slug": "north-richland-hills",
+    "store_id": "1514"
+  },
+  {
+    "url": "https://www.target.com/sl/hampton-village/1515",
+    "slug": "hampton-village",
+    "store_id": "1515"
+  },
+  {
+    "url": "https://www.target.com/sl/marlborough/1516",
+    "slug": "marlborough",
+    "store_id": "1516"
+  },
+  {
+    "url": "https://www.target.com/sl/flower-mound/1517",
+    "slug": "flower-mound",
+    "store_id": "1517"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando-millenia/1518",
+    "slug": "orlando-millenia",
+    "store_id": "1518"
+  },
+  {
+    "url": "https://www.target.com/sl/clermont/1519",
+    "slug": "clermont",
+    "store_id": "1519"
+  },
+  {
+    "url": "https://www.target.com/sl/hooksett/1520",
+    "slug": "hooksett",
+    "store_id": "1520"
+  },
+  {
+    "url": "https://www.target.com/sl/niskayuna/1521",
+    "slug": "niskayuna",
+    "store_id": "1521"
+  },
+  {
+    "url": "https://www.target.com/sl/red-wing/1522",
+    "slug": "red-wing",
+    "store_id": "1522"
+  },
+  {
+    "url": "https://www.target.com/sl/balcones-heights-crossroads/1523",
+    "slug": "balcones-heights-crossroads",
+    "store_id": "1523"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-summerlin-south/1524",
+    "slug": "las-vegas-summerlin-south",
+    "store_id": "1524"
+  },
+  {
+    "url": "https://www.target.com/sl/silverthorne/1525",
+    "slug": "silverthorne",
+    "store_id": "1525"
+  },
+  {
+    "url": "https://www.target.com/sl/manteca/1526",
+    "slug": "manteca",
+    "store_id": "1526"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-sw/1527",
+    "slug": "sacramento-sw",
+    "store_id": "1527"
+  },
+  {
+    "url": "https://www.target.com/sl/bethel/1528",
+    "slug": "bethel",
+    "store_id": "1528"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-pleasant/1529",
+    "slug": "mt-pleasant",
+    "store_id": "1529"
+  },
+  {
+    "url": "https://www.target.com/sl/muncie/1530",
+    "slug": "muncie",
+    "store_id": "1530"
+  },
+  {
+    "url": "https://www.target.com/sl/waco/1531",
+    "slug": "waco",
+    "store_id": "1531"
+  },
+  {
+    "url": "https://www.target.com/sl/nashua-nw/1532",
+    "slug": "nashua-nw",
+    "store_id": "1532"
+  },
+  {
+    "url": "https://www.target.com/sl/alexandria-hybla-valley/1533",
+    "slug": "alexandria-hybla-valley",
+    "store_id": "1533"
+  },
+  {
+    "url": "https://www.target.com/sl/west-chester-township/1534",
+    "slug": "west-chester-township",
+    "store_id": "1534"
+  },
+  {
+    "url": "https://www.target.com/sl/galveston/1535",
+    "slug": "galveston",
+    "store_id": "1535"
+  },
+  {
+    "url": "https://www.target.com/sl/mansfield/1536",
+    "slug": "mansfield",
+    "store_id": "1536"
+  },
+  {
+    "url": "https://www.target.com/sl/bellevue/1537",
+    "slug": "bellevue",
+    "store_id": "1537"
+  },
+  {
+    "url": "https://www.target.com/sl/belton/1538",
+    "slug": "belton",
+    "store_id": "1538"
+  },
+  {
+    "url": "https://www.target.com/sl/shiloh/1539",
+    "slug": "shiloh",
+    "store_id": "1539"
+  },
+  {
+    "url": "https://www.target.com/sl/kalispell/1540",
+    "slug": "kalispell",
+    "store_id": "1540"
+  },
+  {
+    "url": "https://www.target.com/sl/pikesville/1541",
+    "slug": "pikesville",
+    "store_id": "1541"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-east/1542",
+    "slug": "austin-east",
+    "store_id": "1542"
+  },
+  {
+    "url": "https://www.target.com/sl/olathe-south/1543",
+    "slug": "olathe-south",
+    "store_id": "1543"
+  },
+  {
+    "url": "https://www.target.com/sl/stamford/1544",
+    "slug": "stamford",
+    "store_id": "1544"
+  },
+  {
+    "url": "https://www.target.com/sl/colerain/1545",
+    "slug": "colerain",
+    "store_id": "1545"
+  },
+  {
+    "url": "https://www.target.com/sl/east-point/1546",
+    "slug": "east-point",
+    "store_id": "1546"
+  },
+  {
+    "url": "https://www.target.com/sl/moorpark/1547",
+    "slug": "moorpark",
+    "store_id": "1547"
+  },
+  {
+    "url": "https://www.target.com/sl/corona/1548",
+    "slug": "corona",
+    "store_id": "1548"
+  },
+  {
+    "url": "https://www.target.com/sl/centerville/1750",
+    "slug": "centerville",
+    "store_id": "1750"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-union/1751",
+    "slug": "fort-union",
+    "store_id": "1751"
+  },
+  {
+    "url": "https://www.target.com/sl/sandy-south-towne/1752",
+    "slug": "sandy-south-towne",
+    "store_id": "1752"
+  },
+  {
+    "url": "https://www.target.com/sl/riverdale/1753",
+    "slug": "riverdale",
+    "store_id": "1753"
+  },
+  {
+    "url": "https://www.target.com/sl/orem-state-street/1754",
+    "slug": "orem-state-street",
+    "store_id": "1754"
+  },
+  {
+    "url": "https://www.target.com/sl/layton/1755",
+    "slug": "layton",
+    "store_id": "1755"
+  },
+  {
+    "url": "https://www.target.com/sl/olathe/1756",
+    "slug": "olathe",
+    "store_id": "1756"
+  },
+  {
+    "url": "https://www.target.com/sl/overland-park/1757",
+    "slug": "overland-park",
+    "store_id": "1757"
+  },
+  {
+    "url": "https://www.target.com/sl/shawnee/1759",
+    "slug": "shawnee",
+    "store_id": "1759"
+  },
+  {
+    "url": "https://www.target.com/sl/waterford-lakes/1760",
+    "slug": "waterford-lakes",
+    "store_id": "1760"
+  },
+  {
+    "url": "https://www.target.com/sl/roswell/1761",
+    "slug": "roswell",
+    "store_id": "1761"
+  },
+  {
+    "url": "https://www.target.com/sl/lafayette/1762",
+    "slug": "lafayette",
+    "store_id": "1762"
+  },
+  {
+    "url": "https://www.target.com/sl/frisco/1763",
+    "slug": "frisco",
+    "store_id": "1763"
+  },
+  {
+    "url": "https://www.target.com/sl/plano-west/1764",
+    "slug": "plano-west",
+    "store_id": "1764"
+  },
+  {
+    "url": "https://www.target.com/sl/watauga/1765",
+    "slug": "watauga",
+    "store_id": "1765"
+  },
+  {
+    "url": "https://www.target.com/sl/hurst/1766",
+    "slug": "hurst",
+    "store_id": "1766"
+  },
+  {
+    "url": "https://www.target.com/sl/ankeny/1767",
+    "slug": "ankeny",
+    "store_id": "1767"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-rapids-north/1768",
+    "slug": "cedar-rapids-north",
+    "store_id": "1768"
+  },
+  {
+    "url": "https://www.target.com/sl/superior/1769",
+    "slug": "superior",
+    "store_id": "1769"
+  },
+  {
+    "url": "https://www.target.com/sl/cityview/1770",
+    "slug": "cityview",
+    "store_id": "1770"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-rapids-south/1771",
+    "slug": "cedar-rapids-south",
+    "store_id": "1771"
+  },
+  {
+    "url": "https://www.target.com/sl/birmingham-280-corridor/1772",
+    "slug": "birmingham-280-corridor",
+    "store_id": "1772"
+  },
+  {
+    "url": "https://www.target.com/sl/trussville/1773",
+    "slug": "trussville",
+    "store_id": "1773"
+  },
+  {
+    "url": "https://www.target.com/sl/eau-claire/1774",
+    "slug": "eau-claire",
+    "store_id": "1774"
+  },
+  {
+    "url": "https://www.target.com/sl/north-dallas-coit-road/1775",
+    "slug": "north-dallas-coit-road",
+    "store_id": "1775"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-sw/1776",
+    "slug": "denver-sw",
+    "store_id": "1776"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha-west/1777",
+    "slug": "omaha-west",
+    "store_id": "1777"
+  },
+  {
+    "url": "https://www.target.com/sl/woodstock/1780",
+    "slug": "woodstock",
+    "store_id": "1780"
+  },
+  {
+    "url": "https://www.target.com/sl/tulsa-se/1782",
+    "slug": "tulsa-se",
+    "store_id": "1782"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-forks/1783",
+    "slug": "grand-forks",
+    "store_id": "1783"
+  },
+  {
+    "url": "https://www.target.com/sl/northeast-dallas-skillman/1784",
+    "slug": "northeast-dallas-skillman",
+    "store_id": "1784"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-west/1785",
+    "slug": "san-antonio-west",
+    "store_id": "1785"
+  },
+  {
+    "url": "https://www.target.com/sl/sugar-land/1786",
+    "slug": "sugar-land",
+    "store_id": "1786"
+  },
+  {
+    "url": "https://www.target.com/sl/tuscaloosa/1787",
+    "slug": "tuscaloosa",
+    "store_id": "1787"
+  },
+  {
+    "url": "https://www.target.com/sl/avon/1788",
+    "slug": "avon",
+    "store_id": "1788"
+  },
+  {
+    "url": "https://www.target.com/sl/southport/1789",
+    "slug": "southport",
+    "store_id": "1789"
+  },
+  {
+    "url": "https://www.target.com/sl/hunters-creek/1790",
+    "slug": "hunters-creek",
+    "store_id": "1790"
+  },
+  {
+    "url": "https://www.target.com/sl/urbandale/1791",
+    "slug": "urbandale",
+    "store_id": "1791"
+  },
+  {
+    "url": "https://www.target.com/sl/waterloo/1792",
+    "slug": "waterloo",
+    "store_id": "1792"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-east/1793",
+    "slug": "charlotte-east",
+    "store_id": "1793"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-brier-creek/1794",
+    "slug": "raleigh-brier-creek",
+    "store_id": "1794"
+  },
+  {
+    "url": "https://www.target.com/sl/port-orange/1795",
+    "slug": "port-orange",
+    "store_id": "1795"
+  },
+  {
+    "url": "https://www.target.com/sl/east-greenbush/1796",
+    "slug": "east-greenbush",
+    "store_id": "1796"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-lakeline-mall-dr/1797",
+    "slug": "austin-lakeline-mall-dr",
+    "store_id": "1797"
+  },
+  {
+    "url": "https://www.target.com/sl/bronx-riverdale/1798",
+    "slug": "bronx-riverdale",
+    "store_id": "1798"
+  },
+  {
+    "url": "https://www.target.com/sl/machesney-park/1799",
+    "slug": "machesney-park",
+    "store_id": "1799"
+  },
+  {
+    "url": "https://www.target.com/sl/sioux-city/1800",
+    "slug": "sioux-city",
+    "store_id": "1800"
+  },
+  {
+    "url": "https://www.target.com/sl/algonquin/1801",
+    "slug": "algonquin",
+    "store_id": "1801"
+  },
+  {
+    "url": "https://www.target.com/sl/newington/1802",
+    "slug": "newington",
+    "store_id": "1802"
+  },
+  {
+    "url": "https://www.target.com/sl/salem-highland-ave/1803",
+    "slug": "salem-highland-ave",
+    "store_id": "1803"
+  },
+  {
+    "url": "https://www.target.com/sl/university-heights/1804",
+    "slug": "university-heights",
+    "store_id": "1804"
+  },
+  {
+    "url": "https://www.target.com/sl/visalia/1805",
+    "slug": "visalia",
+    "store_id": "1805"
+  },
+  {
+    "url": "https://www.target.com/sl/glendale/1806",
+    "slug": "glendale",
+    "store_id": "1806"
+  },
+  {
+    "url": "https://www.target.com/sl/asheville/1807",
+    "slug": "asheville",
+    "store_id": "1807"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-valley/1808",
+    "slug": "spring-valley",
+    "store_id": "1808"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-roosevelt-blvd/1809",
+    "slug": "philadelphia-roosevelt-blvd",
+    "store_id": "1809"
+  },
+  {
+    "url": "https://www.target.com/sl/texarkana/1811",
+    "slug": "texarkana",
+    "store_id": "1811"
+  },
+  {
+    "url": "https://www.target.com/sl/bee-cave/1812",
+    "slug": "bee-cave",
+    "store_id": "1812"
+  },
+  {
+    "url": "https://www.target.com/sl/greeley/1813",
+    "slug": "greeley",
+    "store_id": "1813"
+  },
+  {
+    "url": "https://www.target.com/sl/american-fork/1814",
+    "slug": "american-fork",
+    "store_id": "1814"
+  },
+  {
+    "url": "https://www.target.com/sl/chula-vista-east/1815",
+    "slug": "chula-vista-east",
+    "store_id": "1815"
+  },
+  {
+    "url": "https://www.target.com/sl/el-centro/1816",
+    "slug": "el-centro",
+    "store_id": "1816"
+  },
+  {
+    "url": "https://www.target.com/sl/riverhead/1818",
+    "slug": "riverhead",
+    "store_id": "1818"
+  },
+  {
+    "url": "https://www.target.com/sl/antioch-slatten-ranch/1819",
+    "slug": "antioch-slatten-ranch",
+    "store_id": "1819"
+  },
+  {
+    "url": "https://www.target.com/sl/clearwater/1820",
+    "slug": "clearwater",
+    "store_id": "1820"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan/1821",
+    "slug": "manhattan",
+    "store_id": "1821"
+  },
+  {
+    "url": "https://www.target.com/sl/clifton/1822",
+    "slug": "clifton",
+    "store_id": "1822"
+  },
+  {
+    "url": "https://www.target.com/sl/howell-township/1823",
+    "slug": "howell-township",
+    "store_id": "1823"
+  },
+  {
+    "url": "https://www.target.com/sl/white-oak-garner/1824",
+    "slug": "white-oak-garner",
+    "store_id": "1824"
+  },
+  {
+    "url": "https://www.target.com/sl/montgomery/1825",
+    "slug": "montgomery",
+    "store_id": "1825"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-capital-blvd/1826",
+    "slug": "raleigh-capital-blvd",
+    "store_id": "1826"
+  },
+  {
+    "url": "https://www.target.com/sl/chantilly/1827",
+    "slug": "chantilly",
+    "store_id": "1827"
+  },
+  {
+    "url": "https://www.target.com/sl/bridgeport/1828",
+    "slug": "bridgeport",
+    "store_id": "1828"
+  },
+  {
+    "url": "https://www.target.com/sl/north-charleston/1829",
+    "slug": "north-charleston",
+    "store_id": "1829"
+  },
+  {
+    "url": "https://www.target.com/sl/queensbury/1830",
+    "slug": "queensbury",
+    "store_id": "1830"
+  },
+  {
+    "url": "https://www.target.com/sl/champlin/1831",
+    "slug": "champlin",
+    "store_id": "1831"
+  },
+  {
+    "url": "https://www.target.com/sl/blaine/1832",
+    "slug": "blaine",
+    "store_id": "1832"
+  },
+  {
+    "url": "https://www.target.com/sl/savage/1833",
+    "slug": "savage",
+    "store_id": "1833"
+  },
+  {
+    "url": "https://www.target.com/sl/upland/1834",
+    "slug": "upland",
+    "store_id": "1834"
+  },
+  {
+    "url": "https://www.target.com/sl/millbury/1835",
+    "slug": "millbury",
+    "store_id": "1835"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-hill/1836",
+    "slug": "cedar-hill",
+    "store_id": "1836"
+  },
+  {
+    "url": "https://www.target.com/sl/baybrook/1837",
+    "slug": "baybrook",
+    "store_id": "1837"
+  },
+  {
+    "url": "https://www.target.com/sl/chandler-fashion-center/1838",
+    "slug": "chandler-fashion-center",
+    "store_id": "1838"
+  },
+  {
+    "url": "https://www.target.com/sl/hadley/1839",
+    "slug": "hadley",
+    "store_id": "1839"
+  },
+  {
+    "url": "https://www.target.com/sl/stateline/1840",
+    "slug": "stateline",
+    "store_id": "1840"
+  },
+  {
+    "url": "https://www.target.com/sl/macedonia/1841",
+    "slug": "macedonia",
+    "store_id": "1841"
+  },
+  {
+    "url": "https://www.target.com/sl/overland-park-south/1842",
+    "slug": "overland-park-south",
+    "store_id": "1842"
+  },
+  {
+    "url": "https://www.target.com/sl/riverside-se/1843",
+    "slug": "riverside-se",
+    "store_id": "1843"
+  },
+  {
+    "url": "https://www.target.com/sl/wilkes-barre/1845",
+    "slug": "wilkes-barre",
+    "store_id": "1845"
+  },
+  {
+    "url": "https://www.target.com/sl/lemon-grove/1846",
+    "slug": "lemon-grove",
+    "store_id": "1846"
+  },
+  {
+    "url": "https://www.target.com/sl/wilsonville/1847",
+    "slug": "wilsonville",
+    "store_id": "1847"
+  },
+  {
+    "url": "https://www.target.com/sl/nora-plaza/1848",
+    "slug": "nora-plaza",
+    "store_id": "1848"
+  },
+  {
+    "url": "https://www.target.com/sl/atlantic-terminal/1849",
+    "slug": "atlantic-terminal",
+    "store_id": "1849"
+  },
+  {
+    "url": "https://www.target.com/sl/addison/1850",
+    "slug": "addison",
+    "store_id": "1850"
+  },
+  {
+    "url": "https://www.target.com/sl/gilroy/1851",
+    "slug": "gilroy",
+    "store_id": "1851"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-se/1852",
+    "slug": "san-antonio-se",
+    "store_id": "1852"
+  },
+  {
+    "url": "https://www.target.com/sl/ortega/1853",
+    "slug": "ortega",
+    "store_id": "1853"
+  },
+  {
+    "url": "https://www.target.com/sl/rockville/1854",
+    "slug": "rockville",
+    "store_id": "1854"
+  },
+  {
+    "url": "https://www.target.com/sl/bangor/1855",
+    "slug": "bangor",
+    "store_id": "1855"
+  },
+  {
+    "url": "https://www.target.com/sl/poughkeepsie/1856",
+    "slug": "poughkeepsie",
+    "store_id": "1856"
+  },
+  {
+    "url": "https://www.target.com/sl/stafford/1857",
+    "slug": "stafford",
+    "store_id": "1857"
+  },
+  {
+    "url": "https://www.target.com/sl/charlottesville/1858",
+    "slug": "charlottesville",
+    "store_id": "1858"
+  },
+  {
+    "url": "https://www.target.com/sl/lakeland-north/1859",
+    "slug": "lakeland-north",
+    "store_id": "1859"
+  },
+  {
+    "url": "https://www.target.com/sl/oklahoma-city-nw/1860",
+    "slug": "oklahoma-city-nw",
+    "store_id": "1860"
+  },
+  {
+    "url": "https://www.target.com/sl/sherman/1861",
+    "slug": "sherman",
+    "store_id": "1861"
+  },
+  {
+    "url": "https://www.target.com/sl/stockton-north/1862",
+    "slug": "stockton-north",
+    "store_id": "1862"
+  },
+  {
+    "url": "https://www.target.com/sl/tucson-se/1863",
+    "slug": "tucson-se",
+    "store_id": "1863"
+  },
+  {
+    "url": "https://www.target.com/sl/rockaway/1864",
+    "slug": "rockaway",
+    "store_id": "1864"
+  },
+  {
+    "url": "https://www.target.com/sl/north-bergen-commons/1865",
+    "slug": "north-bergen-commons",
+    "store_id": "1865"
+  },
+  {
+    "url": "https://www.target.com/sl/farmingdale/1866",
+    "slug": "farmingdale",
+    "store_id": "1866"
+  },
+  {
+    "url": "https://www.target.com/sl/la-quinta/1867",
+    "slug": "la-quinta",
+    "store_id": "1867"
+  },
+  {
+    "url": "https://www.target.com/sl/sherwood/1868",
+    "slug": "sherwood",
+    "store_id": "1868"
+  },
+  {
+    "url": "https://www.target.com/sl/redlands/1869",
+    "slug": "redlands",
+    "store_id": "1869"
+  },
+  {
+    "url": "https://www.target.com/sl/simpsonville/1870",
+    "slug": "simpsonville",
+    "store_id": "1870"
+  },
+  {
+    "url": "https://www.target.com/sl/abingdon/1871",
+    "slug": "abingdon",
+    "store_id": "1871"
+  },
+  {
+    "url": "https://www.target.com/sl/durham/1872",
+    "slug": "durham",
+    "store_id": "1872"
+  },
+  {
+    "url": "https://www.target.com/sl/gainesville/1873",
+    "slug": "gainesville",
+    "store_id": "1873"
+  },
+  {
+    "url": "https://www.target.com/sl/leesburg/1874",
+    "slug": "leesburg",
+    "store_id": "1874"
+  },
+  {
+    "url": "https://www.target.com/sl/york-west/1875",
+    "slug": "york-west",
+    "store_id": "1875"
+  },
+  {
+    "url": "https://www.target.com/sl/covington/1876",
+    "slug": "covington",
+    "store_id": "1876"
+  },
+  {
+    "url": "https://www.target.com/sl/port-arthur/1877",
+    "slug": "port-arthur",
+    "store_id": "1877"
+  },
+  {
+    "url": "https://www.target.com/sl/bloomington/1878",
+    "slug": "bloomington",
+    "store_id": "1878"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-south-pulaski/1879",
+    "slug": "chicago-south-pulaski",
+    "store_id": "1879"
+  },
+  {
+    "url": "https://www.target.com/sl/kohler/1880",
+    "slug": "kohler",
+    "store_id": "1880"
+  },
+  {
+    "url": "https://www.target.com/sl/shorewood/1881",
+    "slug": "shorewood",
+    "store_id": "1881"
+  },
+  {
+    "url": "https://www.target.com/sl/willowbrook/1882",
+    "slug": "willowbrook",
+    "store_id": "1882"
+  },
+  {
+    "url": "https://www.target.com/sl/vancouver-hazel-dell-ave/1883",
+    "slug": "vancouver-hazel-dell-ave",
+    "store_id": "1883"
+  },
+  {
+    "url": "https://www.target.com/sl/west-hollywood/1884",
+    "slug": "west-hollywood",
+    "store_id": "1884"
+  },
+  {
+    "url": "https://www.target.com/sl/hicksville/1885",
+    "slug": "hicksville",
+    "store_id": "1885"
+  },
+  {
+    "url": "https://www.target.com/sl/jersey-city/1886",
+    "slug": "jersey-city",
+    "store_id": "1886"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-vernon/1887",
+    "slug": "mt-vernon",
+    "store_id": "1887"
+  },
+  {
+    "url": "https://www.target.com/sl/norridge/1888",
+    "slug": "norridge",
+    "store_id": "1888"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-south-loop/1889",
+    "slug": "chicago-south-loop",
+    "store_id": "1889"
+  },
+  {
+    "url": "https://www.target.com/sl/prince-georges-plaza/1890",
+    "slug": "prince-georges-plaza",
+    "store_id": "1890"
+  },
+  {
+    "url": "https://www.target.com/sl/conway/1891",
+    "slug": "conway",
+    "store_id": "1891"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-north-hills/1892",
+    "slug": "raleigh-north-hills",
+    "store_id": "1892"
+  },
+  {
+    "url": "https://www.target.com/sl/skyline/1893",
+    "slug": "skyline",
+    "store_id": "1893"
+  },
+  {
+    "url": "https://www.target.com/sl/cypress/1894",
+    "slug": "cypress",
+    "store_id": "1894"
+  },
+  {
+    "url": "https://www.target.com/sl/west-milwaukee/1895",
+    "slug": "west-milwaukee",
+    "store_id": "1895"
+  },
+  {
+    "url": "https://www.target.com/sl/south-elgin/1896",
+    "slug": "south-elgin",
+    "store_id": "1896"
+  },
+  {
+    "url": "https://www.target.com/sl/forestville/1897",
+    "slug": "forestville",
+    "store_id": "1897"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-south-bay/1898",
+    "slug": "boston-south-bay",
+    "store_id": "1898"
+  },
+  {
+    "url": "https://www.target.com/sl/west-des-moines-sw/1901",
+    "slug": "west-des-moines-sw",
+    "store_id": "1901"
+  },
+  {
+    "url": "https://www.target.com/sl/south-bend/1902",
+    "slug": "south-bend",
+    "store_id": "1902"
+  },
+  {
+    "url": "https://www.target.com/sl/warrenville/1903",
+    "slug": "warrenville",
+    "store_id": "1903"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-tomball-north/1904",
+    "slug": "houston-tomball-north",
+    "store_id": "1904"
+  },
+  {
+    "url": "https://www.target.com/sl/south-mountain/1905",
+    "slug": "south-mountain",
+    "store_id": "1905"
+  },
+  {
+    "url": "https://www.target.com/sl/hanford/1906",
+    "slug": "hanford",
+    "store_id": "1906"
+  },
+  {
+    "url": "https://www.target.com/sl/collierville/1907",
+    "slug": "collierville",
+    "store_id": "1907"
+  },
+  {
+    "url": "https://www.target.com/sl/katy-cinco-ranch/1908",
+    "slug": "katy-cinco-ranch",
+    "store_id": "1908"
+  },
+  {
+    "url": "https://www.target.com/sl/savannah/1910",
+    "slug": "savannah",
+    "store_id": "1910"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus/1911",
+    "slug": "columbus",
+    "store_id": "1911"
+  },
+  {
+    "url": "https://www.target.com/sl/mundelein/1912",
+    "slug": "mundelein",
+    "store_id": "1912"
+  },
+  {
+    "url": "https://www.target.com/sl/munster/1913",
+    "slug": "munster",
+    "store_id": "1913"
+  },
+  {
+    "url": "https://www.target.com/sl/osage-beach/1914",
+    "slug": "osage-beach",
+    "store_id": "1914"
+  },
+  {
+    "url": "https://www.target.com/sl/latham/1915",
+    "slug": "latham",
+    "store_id": "1915"
+  },
+  {
+    "url": "https://www.target.com/sl/north-haven/1916",
+    "slug": "north-haven",
+    "store_id": "1916"
+  },
+  {
+    "url": "https://www.target.com/sl/mount-laurel/1917",
+    "slug": "mount-laurel",
+    "store_id": "1917"
+  },
+  {
+    "url": "https://www.target.com/sl/kissimmee-west/1918",
+    "slug": "kissimmee-west",
+    "store_id": "1918"
+  },
+  {
+    "url": "https://www.target.com/sl/jonesboro/1919",
+    "slug": "jonesboro",
+    "store_id": "1919"
+  },
+  {
+    "url": "https://www.target.com/sl/flowood/1920",
+    "slug": "flowood",
+    "store_id": "1920"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville-east/1921",
+    "slug": "jacksonville-east",
+    "store_id": "1921"
+  },
+  {
+    "url": "https://www.target.com/sl/burleson/1922",
+    "slug": "burleson",
+    "store_id": "1922"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia-garners-ferry/1923",
+    "slug": "columbia-garners-ferry",
+    "store_id": "1923"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-brickyard/1924",
+    "slug": "chicago-brickyard",
+    "store_id": "1924"
+  },
+  {
+    "url": "https://www.target.com/sl/oak-creek/1925",
+    "slug": "oak-creek",
+    "store_id": "1925"
+  },
+  {
+    "url": "https://www.target.com/sl/albany/1926",
+    "slug": "albany",
+    "store_id": "1926"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-oakridge/1927",
+    "slug": "san-jose-oakridge",
+    "store_id": "1927"
+  },
+  {
+    "url": "https://www.target.com/sl/westminster/1928",
+    "slug": "westminster",
+    "store_id": "1928"
+  },
+  {
+    "url": "https://www.target.com/sl/south-plainfield/1929",
+    "slug": "south-plainfield",
+    "store_id": "1929"
+  },
+  {
+    "url": "https://www.target.com/sl/plainville/1930",
+    "slug": "plainville",
+    "store_id": "1930"
+  },
+  {
+    "url": "https://www.target.com/sl/forest-hill/1931",
+    "slug": "forest-hill",
+    "store_id": "1931"
+  },
+  {
+    "url": "https://www.target.com/sl/apex/1932",
+    "slug": "apex",
+    "store_id": "1932"
+  },
+  {
+    "url": "https://www.target.com/sl/ft-wayne-ne/1933",
+    "slug": "ft-wayne-ne",
+    "store_id": "1933"
+  },
+  {
+    "url": "https://www.target.com/sl/viera/1934",
+    "slug": "viera",
+    "store_id": "1934"
+  },
+  {
+    "url": "https://www.target.com/sl/royal-palm-beach/1935",
+    "slug": "royal-palm-beach",
+    "store_id": "1935"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-ana-nw/1936",
+    "slug": "santa-ana-nw",
+    "store_id": "1936"
+  },
+  {
+    "url": "https://www.target.com/sl/greer/1937",
+    "slug": "greer",
+    "store_id": "1937"
+  },
+  {
+    "url": "https://www.target.com/sl/glen-burnie-north/1938",
+    "slug": "glen-burnie-north",
+    "store_id": "1938"
+  },
+  {
+    "url": "https://www.target.com/sl/altoona/1939",
+    "slug": "altoona",
+    "store_id": "1939"
+  },
+  {
+    "url": "https://www.target.com/sl/sugarcreek-township/1940",
+    "slug": "sugarcreek-township",
+    "store_id": "1940"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-park/palm-beach-gardens/1941",
+    "slug": "palm-beach-gardens",
+    "store_id": "1941"
+  },
+  {
+    "url": "https://www.target.com/sl/revere/1942",
+    "slug": "revere",
+    "store_id": "1942"
+  },
+  {
+    "url": "https://www.target.com/sl/wichita-maple/1943",
+    "slug": "wichita-maple",
+    "store_id": "1943"
+  },
+  {
+    "url": "https://www.target.com/sl/wichita-ne/1944",
+    "slug": "wichita-ne",
+    "store_id": "1944"
+  },
+  {
+    "url": "https://www.target.com/sl/wichita-nw/1945",
+    "slug": "wichita-nw",
+    "store_id": "1945"
+  },
+  {
+    "url": "https://www.target.com/sl/fairfield-township/1946",
+    "slug": "fairfield-township",
+    "store_id": "1946"
+  },
+  {
+    "url": "https://www.target.com/sl/federal-way/1947",
+    "slug": "federal-way",
+    "store_id": "1947"
+  },
+  {
+    "url": "https://www.target.com/sl/medford/1948",
+    "slug": "medford",
+    "store_id": "1948"
+  },
+  {
+    "url": "https://www.target.com/sl/morgantown/1949",
+    "slug": "morgantown",
+    "store_id": "1949"
+  },
+  {
+    "url": "https://www.target.com/sl/streamwood/1950",
+    "slug": "streamwood",
+    "store_id": "1950"
+  },
+  {
+    "url": "https://www.target.com/sl/decatur/1951",
+    "slug": "decatur",
+    "store_id": "1951"
+  },
+  {
+    "url": "https://www.target.com/sl/town-and-country/1952",
+    "slug": "town-and-country",
+    "store_id": "1952"
+  },
+  {
+    "url": "https://www.target.com/sl/four-points/1953",
+    "slug": "four-points",
+    "store_id": "1953"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-kisco/1954",
+    "slug": "mt-kisco",
+    "store_id": "1954"
+  },
+  {
+    "url": "https://www.target.com/sl/orange/1955",
+    "slug": "orange",
+    "store_id": "1955"
+  },
+  {
+    "url": "https://www.target.com/sl/trumbull/1956",
+    "slug": "trumbull",
+    "store_id": "1956"
+  },
+  {
+    "url": "https://www.target.com/sl/bonney-lake/1957",
+    "slug": "bonney-lake",
+    "store_id": "1957"
+  },
+  {
+    "url": "https://www.target.com/sl/fontana-north/1958",
+    "slug": "fontana-north",
+    "store_id": "1958"
+  },
+  {
+    "url": "https://www.target.com/sl/gilbert-gateway/1959",
+    "slug": "gilbert-gateway",
+    "store_id": "1959"
+  },
+  {
+    "url": "https://www.target.com/sl/gilbert-sw/1960",
+    "slug": "gilbert-sw",
+    "store_id": "1960"
+  },
+  {
+    "url": "https://www.target.com/sl/eastvale/1961",
+    "slug": "eastvale",
+    "store_id": "1961"
+  },
+  {
+    "url": "https://www.target.com/sl/waxahachie/1962",
+    "slug": "waxahachie",
+    "store_id": "1962"
+  },
+  {
+    "url": "https://www.target.com/sl/franklin/1963",
+    "slug": "franklin",
+    "store_id": "1963"
+  },
+  {
+    "url": "https://www.target.com/sl/atlanta-edgewood/1964",
+    "slug": "atlanta-edgewood",
+    "store_id": "1964"
+  },
+  {
+    "url": "https://www.target.com/sl/leominster/1965",
+    "slug": "leominster",
+    "store_id": "1965"
+  },
+  {
+    "url": "https://www.target.com/sl/sanford/1966",
+    "slug": "sanford",
+    "store_id": "1966"
+  },
+  {
+    "url": "https://www.target.com/sl/seven-springs/1967",
+    "slug": "seven-springs",
+    "store_id": "1967"
+  },
+  {
+    "url": "https://www.target.com/sl/mechanicsville/1968",
+    "slug": "mechanicsville",
+    "store_id": "1968"
+  },
+  {
+    "url": "https://www.target.com/sl/hilliard-trueman/1969",
+    "slug": "hilliard-trueman",
+    "store_id": "1969"
+  },
+  {
+    "url": "https://www.target.com/sl/middle-river/1970",
+    "slug": "middle-river",
+    "store_id": "1970"
+  },
+  {
+    "url": "https://www.target.com/sl/hartland-township/1971",
+    "slug": "hartland-township",
+    "store_id": "1971"
+  },
+  {
+    "url": "https://www.target.com/sl/whitehall/1972",
+    "slug": "whitehall",
+    "store_id": "1972"
+  },
+  {
+    "url": "https://www.target.com/sl/tallahassee-north/1973",
+    "slug": "tallahassee-north",
+    "store_id": "1973"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville-st-johns/1974",
+    "slug": "jacksonville-st-johns",
+    "store_id": "1974"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-meyerland/1975",
+    "slug": "houston-meyerland",
+    "store_id": "1975"
+  },
+  {
+    "url": "https://www.target.com/sl/aurora-saddle-rock/1976",
+    "slug": "aurora-saddle-rock",
+    "store_id": "1976"
+  },
+  {
+    "url": "https://www.target.com/sl/st-joseph/1977",
+    "slug": "st-joseph",
+    "store_id": "1977"
+  },
+  {
+    "url": "https://www.target.com/sl/graceland/1978",
+    "slug": "graceland",
+    "store_id": "1978"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-westover/1979",
+    "slug": "san-antonio-westover",
+    "store_id": "1979"
+  },
+  {
+    "url": "https://www.target.com/sl/redondo-beach/1980",
+    "slug": "redondo-beach",
+    "store_id": "1980"
+  },
+  {
+    "url": "https://www.target.com/sl/weatherford/1981",
+    "slug": "weatherford",
+    "store_id": "1981"
+  },
+  {
+    "url": "https://www.target.com/sl/georgetown/1982",
+    "slug": "georgetown",
+    "store_id": "1982"
+  },
+  {
+    "url": "https://www.target.com/sl/brentwood/1983",
+    "slug": "brentwood",
+    "store_id": "1983"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-story-road/1984",
+    "slug": "san-jose-story-road",
+    "store_id": "1984"
+  },
+  {
+    "url": "https://www.target.com/sl/staten-island/2006",
+    "slug": "staten-island",
+    "store_id": "2006"
+  },
+  {
+    "url": "https://www.target.com/sl/lanham/2007",
+    "slug": "lanham",
+    "store_id": "2007"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-worth/2008",
+    "slug": "lake-worth",
+    "store_id": "2008"
+  },
+  {
+    "url": "https://www.target.com/sl/bedford/2009",
+    "slug": "bedford",
+    "store_id": "2009"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha-north/2010",
+    "slug": "omaha-north",
+    "store_id": "2010"
+  },
+  {
+    "url": "https://www.target.com/sl/asheville-south/2011",
+    "slug": "asheville-south",
+    "store_id": "2011"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-rapids-east/2014",
+    "slug": "grand-rapids-east",
+    "store_id": "2014"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-rapids-south/2015",
+    "slug": "grand-rapids-south",
+    "store_id": "2015"
+  },
+  {
+    "url": "https://www.target.com/sl/north-olmsted/2016",
+    "slug": "north-olmsted",
+    "store_id": "2016"
+  },
+  {
+    "url": "https://www.target.com/sl/dumfries/2017",
+    "slug": "dumfries",
+    "store_id": "2017"
+  },
+  {
+    "url": "https://www.target.com/sl/clovis-nw/2018",
+    "slug": "clovis-nw",
+    "store_id": "2018"
+  },
+  {
+    "url": "https://www.target.com/sl/whittier/2019",
+    "slug": "whittier",
+    "store_id": "2019"
+  },
+  {
+    "url": "https://www.target.com/sl/sherwood-forest/2020",
+    "slug": "sherwood-forest",
+    "store_id": "2020"
+  },
+  {
+    "url": "https://www.target.com/sl/wheat-ridge/2021",
+    "slug": "wheat-ridge",
+    "store_id": "2021"
+  },
+  {
+    "url": "https://www.target.com/sl/davie/2022",
+    "slug": "davie",
+    "store_id": "2022"
+  },
+  {
+    "url": "https://www.target.com/sl/lone-tree/2023",
+    "slug": "lone-tree",
+    "store_id": "2023"
+  },
+  {
+    "url": "https://www.target.com/sl/monroe/2024",
+    "slug": "monroe",
+    "store_id": "2024"
+  },
+  {
+    "url": "https://www.target.com/sl/andover/2025",
+    "slug": "andover",
+    "store_id": "2025"
+  },
+  {
+    "url": "https://www.target.com/sl/carson-north/2026",
+    "slug": "carson-north",
+    "store_id": "2026"
+  },
+  {
+    "url": "https://www.target.com/sl/evans/2027",
+    "slug": "evans",
+    "store_id": "2027"
+  },
+  {
+    "url": "https://www.target.com/sl/new-lenox/2028",
+    "slug": "new-lenox",
+    "store_id": "2028"
+  },
+  {
+    "url": "https://www.target.com/sl/glenwood-springs/2029",
+    "slug": "glenwood-springs",
+    "store_id": "2029"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-clarita-east/2030",
+    "slug": "santa-clarita-east",
+    "store_id": "2030"
+  },
+  {
+    "url": "https://www.target.com/sl/paseo/2031",
+    "slug": "paseo",
+    "store_id": "2031"
+  },
+  {
+    "url": "https://www.target.com/sl/winter-park/2032",
+    "slug": "winter-park",
+    "store_id": "2032"
+  },
+  {
+    "url": "https://www.target.com/sl/allen-park/2033",
+    "slug": "allen-park",
+    "store_id": "2033"
+  },
+  {
+    "url": "https://www.target.com/sl/university-parkway/2034",
+    "slug": "university-parkway",
+    "store_id": "2034"
+  },
+  {
+    "url": "https://www.target.com/sl/tinley-park/2035",
+    "slug": "tinley-park",
+    "store_id": "2035"
+  },
+  {
+    "url": "https://www.target.com/sl/atlanta-perimeter/2036",
+    "slug": "atlanta-perimeter",
+    "store_id": "2036"
+  },
+  {
+    "url": "https://www.target.com/sl/burlington/2037",
+    "slug": "burlington",
+    "store_id": "2037"
+  },
+  {
+    "url": "https://www.target.com/sl/webster/2038",
+    "slug": "webster",
+    "store_id": "2038"
+  },
+  {
+    "url": "https://www.target.com/sl/tampa-central-walter's-crossing/2040",
+    "slug": "tampa-central-walter's-crossing",
+    "store_id": "2040"
+  },
+  {
+    "url": "https://www.target.com/sl/des-moines-north/2041",
+    "slug": "des-moines-north",
+    "store_id": "2041"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-worth-central/2042",
+    "slug": "fort-worth-central",
+    "store_id": "2042"
+  },
+  {
+    "url": "https://www.target.com/sl/overland-park-west/2043",
+    "slug": "overland-park-west",
+    "store_id": "2043"
+  },
+  {
+    "url": "https://www.target.com/sl/massillon/2044",
+    "slug": "massillon",
+    "store_id": "2044"
+  },
+  {
+    "url": "https://www.target.com/sl/milford/2045",
+    "slug": "milford",
+    "store_id": "2045"
+  },
+  {
+    "url": "https://www.target.com/sl/west-st-paul/2046",
+    "slug": "west-st-paul",
+    "store_id": "2046"
+  },
+  {
+    "url": "https://www.target.com/sl/st-john/2048",
+    "slug": "st-john",
+    "store_id": "2048"
+  },
+  {
+    "url": "https://www.target.com/sl/huntington-beach-east/2051",
+    "slug": "huntington-beach-east",
+    "store_id": "2051"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-northfield-blvd/2052",
+    "slug": "denver-northfield-blvd",
+    "store_id": "2052"
+  },
+  {
+    "url": "https://www.target.com/sl/chattanooga-north/2053",
+    "slug": "chattanooga-north",
+    "store_id": "2053"
+  },
+  {
+    "url": "https://www.target.com/sl/hattiesburg/2055",
+    "slug": "hattiesburg",
+    "store_id": "2055"
+  },
+  {
+    "url": "https://www.target.com/sl/suwanee-peachtree-pkwy/2056",
+    "slug": "suwanee-peachtree-pkwy",
+    "store_id": "2056"
+  },
+  {
+    "url": "https://www.target.com/sl/knoxville-north/2057",
+    "slug": "knoxville-north",
+    "store_id": "2057"
+  },
+  {
+    "url": "https://www.target.com/sl/lady-lake/2058",
+    "slug": "lady-lake",
+    "store_id": "2058"
+  },
+  {
+    "url": "https://www.target.com/sl/lee-county/2059",
+    "slug": "lee-county",
+    "store_id": "2059"
+  },
+  {
+    "url": "https://www.target.com/sl/midwest-city/2061",
+    "slug": "midwest-city",
+    "store_id": "2061"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-dora/2062",
+    "slug": "mt-dora",
+    "store_id": "2062"
+  },
+  {
+    "url": "https://www.target.com/sl/naples-north/2063",
+    "slug": "naples-north",
+    "store_id": "2063"
+  },
+  {
+    "url": "https://www.target.com/sl/pinellas-park/2064",
+    "slug": "pinellas-park",
+    "store_id": "2064"
+  },
+  {
+    "url": "https://www.target.com/sl/wellington-south/2065",
+    "slug": "wellington-south",
+    "store_id": "2065"
+  },
+  {
+    "url": "https://www.target.com/sl/willowbrook/2066",
+    "slug": "willowbrook",
+    "store_id": "2066"
+  },
+  {
+    "url": "https://www.target.com/sl/boynton-beach-west/2067",
+    "slug": "boynton-beach-west",
+    "store_id": "2067"
+  },
+  {
+    "url": "https://www.target.com/sl/waterford-park/2068",
+    "slug": "waterford-park",
+    "store_id": "2068"
+  },
+  {
+    "url": "https://www.target.com/sl/durham-renaissance-pkwy/2069",
+    "slug": "durham-renaissance-pkwy",
+    "store_id": "2069"
+  },
+  {
+    "url": "https://www.target.com/sl/grove-city/2070",
+    "slug": "grove-city",
+    "store_id": "2070"
+  },
+  {
+    "url": "https://www.target.com/sl/harrisonburg/2071",
+    "slug": "harrisonburg",
+    "store_id": "2071"
+  },
+  {
+    "url": "https://www.target.com/sl/lancaster-east/2072",
+    "slug": "lancaster-east",
+    "store_id": "2072"
+  },
+  {
+    "url": "https://www.target.com/sl/lincoln/2073",
+    "slug": "lincoln",
+    "store_id": "2073"
+  },
+  {
+    "url": "https://www.target.com/sl/monroe/2074",
+    "slug": "monroe",
+    "store_id": "2074"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-bridesburg/2075",
+    "slug": "philadelphia-bridesburg",
+    "store_id": "2075"
+  },
+  {
+    "url": "https://www.target.com/sl/newburgh/2076",
+    "slug": "newburgh",
+    "store_id": "2076"
+  },
+  {
+    "url": "https://www.target.com/sl/mount-nebo/2077",
+    "slug": "mount-nebo",
+    "store_id": "2077"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-mckinley-park/2078",
+    "slug": "chicago-mckinley-park",
+    "store_id": "2078"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-peterson-ave/2079",
+    "slug": "chicago-peterson-ave",
+    "store_id": "2079"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-north/2080",
+    "slug": "charlotte-north",
+    "store_id": "2080"
+  },
+  {
+    "url": "https://www.target.com/sl/broadview/2081",
+    "slug": "broadview",
+    "store_id": "2081"
+  },
+  {
+    "url": "https://www.target.com/sl/buena-park/2082",
+    "slug": "buena-park",
+    "store_id": "2082"
+  },
+  {
+    "url": "https://www.target.com/sl/yuma/2083",
+    "slug": "yuma",
+    "store_id": "2083"
+  },
+  {
+    "url": "https://www.target.com/sl/decatur/2084",
+    "slug": "decatur",
+    "store_id": "2084"
+  },
+  {
+    "url": "https://www.target.com/sl/destin/2085",
+    "slug": "destin",
+    "store_id": "2085"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-east-broad-street/2086",
+    "slug": "columbus-east-broad-street",
+    "store_id": "2086"
+  },
+  {
+    "url": "https://www.target.com/sl/oak-lawn/2087",
+    "slug": "oak-lawn",
+    "store_id": "2087"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-college-park/2088",
+    "slug": "san-jose-college-park",
+    "store_id": "2088"
+  },
+  {
+    "url": "https://www.target.com/sl/baton-rouge-east/2089",
+    "slug": "baton-rouge-east",
+    "store_id": "2089"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-blakeney/2090",
+    "slug": "charlotte-blakeney",
+    "store_id": "2090"
+  },
+  {
+    "url": "https://www.target.com/sl/acworth/2091",
+    "slug": "acworth",
+    "store_id": "2091"
+  },
+  {
+    "url": "https://www.target.com/sl/deerfield-beach-hillsboro-blvd/2092",
+    "slug": "deerfield-beach-hillsboro-blvd",
+    "store_id": "2092"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-central/2093",
+    "slug": "houston-central",
+    "store_id": "2093"
+  },
+  {
+    "url": "https://www.target.com/sl/owasso/2095",
+    "slug": "owasso",
+    "store_id": "2095"
+  },
+  {
+    "url": "https://www.target.com/sl/riverbank/2096",
+    "slug": "riverbank",
+    "store_id": "2096"
+  },
+  {
+    "url": "https://www.target.com/sl/branson/2098",
+    "slug": "branson",
+    "store_id": "2098"
+  },
+  {
+    "url": "https://www.target.com/sl/carlisle/2099",
+    "slug": "carlisle",
+    "store_id": "2099"
+  },
+  {
+    "url": "https://www.target.com/sl/center-township/2100",
+    "slug": "center-township",
+    "store_id": "2100"
+  },
+  {
+    "url": "https://www.target.com/sl/roseville-t1/2101",
+    "slug": "roseville-t1",
+    "store_id": "2101"
+  },
+  {
+    "url": "https://www.target.com/sl/central-islip/2102",
+    "slug": "central-islip",
+    "store_id": "2102"
+  },
+  {
+    "url": "https://www.target.com/sl/dardenne-prairie/2103",
+    "slug": "dardenne-prairie",
+    "store_id": "2103"
+  },
+  {
+    "url": "https://www.target.com/sl/delran/2104",
+    "slug": "delran",
+    "store_id": "2104"
+  },
+  {
+    "url": "https://www.target.com/sl/fenton/2105",
+    "slug": "fenton",
+    "store_id": "2105"
+  },
+  {
+    "url": "https://www.target.com/sl/fitchburg/2106",
+    "slug": "fitchburg",
+    "store_id": "2106"
+  },
+  {
+    "url": "https://www.target.com/sl/greensboro-new-garden/2108",
+    "slug": "greensboro-new-garden",
+    "store_id": "2108"
+  },
+  {
+    "url": "https://www.target.com/sl/hialeah/2109",
+    "slug": "hialeah",
+    "store_id": "2109"
+  },
+  {
+    "url": "https://www.target.com/sl/keizer/2110",
+    "slug": "keizer",
+    "store_id": "2110"
+  },
+  {
+    "url": "https://www.target.com/sl/knightdale/2111",
+    "slug": "knightdale",
+    "store_id": "2111"
+  },
+  {
+    "url": "https://www.target.com/sl/laredo-east/2112",
+    "slug": "laredo-east",
+    "store_id": "2112"
+  },
+  {
+    "url": "https://www.target.com/sl/macomb-twp/2113",
+    "slug": "macomb-twp",
+    "store_id": "2113"
+  },
+  {
+    "url": "https://www.target.com/sl/north-huntingdon/2114",
+    "slug": "north-huntingdon",
+    "store_id": "2114"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-natomas/2115",
+    "slug": "sacramento-natomas",
+    "store_id": "2115"
+  },
+  {
+    "url": "https://www.target.com/sl/lutz-dale-mabry-highway/2118",
+    "slug": "lutz-dale-mabry-highway",
+    "store_id": "2118"
+  },
+  {
+    "url": "https://www.target.com/sl/wadsworth/2119",
+    "slug": "wadsworth",
+    "store_id": "2119"
+  },
+  {
+    "url": "https://www.target.com/sl/keene/2120",
+    "slug": "keene",
+    "store_id": "2120"
+  },
+  {
+    "url": "https://www.target.com/sl/marietta-east/2121",
+    "slug": "marietta-east",
+    "store_id": "2121"
+  },
+  {
+    "url": "https://www.target.com/sl/hoffman-estates/2122",
+    "slug": "hoffman-estates",
+    "store_id": "2122"
+  },
+  {
+    "url": "https://www.target.com/sl/south-jordan/2123",
+    "slug": "south-jordan",
+    "store_id": "2123"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-city-ave/2124",
+    "slug": "philadelphia-city-ave",
+    "store_id": "2124"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha/2125",
+    "slug": "omaha",
+    "store_id": "2125"
+  },
+  {
+    "url": "https://www.target.com/sl/mt-juliet/2126",
+    "slug": "mt-juliet",
+    "store_id": "2126"
+  },
+  {
+    "url": "https://www.target.com/sl/lanesborough/2127",
+    "slug": "lanesborough",
+    "store_id": "2127"
+  },
+  {
+    "url": "https://www.target.com/sl/irvine-spectrum/2128",
+    "slug": "irvine-spectrum",
+    "store_id": "2128"
+  },
+  {
+    "url": "https://www.target.com/sl/peachtree-city/2129",
+    "slug": "peachtree-city",
+    "store_id": "2129"
+  },
+  {
+    "url": "https://www.target.com/sl/topsham/2130",
+    "slug": "topsham",
+    "store_id": "2130"
+  },
+  {
+    "url": "https://www.target.com/sl/royersford/2131",
+    "slug": "royersford",
+    "store_id": "2131"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-sw/2132",
+    "slug": "charlotte-sw",
+    "store_id": "2132"
+  },
+  {
+    "url": "https://www.target.com/sl/laplata/2133",
+    "slug": "laplata",
+    "store_id": "2133"
+  },
+  {
+    "url": "https://www.target.com/sl/kernersville/2134",
+    "slug": "kernersville",
+    "store_id": "2134"
+  },
+  {
+    "url": "https://www.target.com/sl/oakdale/2135",
+    "slug": "oakdale",
+    "store_id": "2135"
+  },
+  {
+    "url": "https://www.target.com/sl/puyallup-south/2136",
+    "slug": "puyallup-south",
+    "store_id": "2136"
+  },
+  {
+    "url": "https://www.target.com/sl/atlanta-midtown/2137",
+    "slug": "atlanta-midtown",
+    "store_id": "2137"
+  },
+  {
+    "url": "https://www.target.com/sl/massaponax/2138",
+    "slug": "massaponax",
+    "store_id": "2138"
+  },
+  {
+    "url": "https://www.target.com/sl/westheimer/2139",
+    "slug": "westheimer",
+    "store_id": "2139"
+  },
+  {
+    "url": "https://www.target.com/sl/tucson-north/2140",
+    "slug": "tucson-north",
+    "store_id": "2140"
+  },
+  {
+    "url": "https://www.target.com/sl/union-north/2141",
+    "slug": "union-north",
+    "store_id": "2141"
+  },
+  {
+    "url": "https://www.target.com/sl/mckinney-sw/2142",
+    "slug": "mckinney-sw",
+    "store_id": "2142"
+  },
+  {
+    "url": "https://www.target.com/sl/los-angeles-topanga/2143",
+    "slug": "los-angeles-topanga",
+    "store_id": "2143"
+  },
+  {
+    "url": "https://www.target.com/sl/steeplechase/2144",
+    "slug": "steeplechase",
+    "store_id": "2144"
+  },
+  {
+    "url": "https://www.target.com/sl/denton/2145",
+    "slug": "denton",
+    "store_id": "2145"
+  },
+  {
+    "url": "https://www.target.com/sl/coral-springs/2146",
+    "slug": "coral-springs",
+    "store_id": "2146"
+  },
+  {
+    "url": "https://www.target.com/sl/west-covina-south/2147",
+    "slug": "west-covina-south",
+    "store_id": "2147"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-sw/2149",
+    "slug": "phoenix-sw",
+    "store_id": "2149"
+  },
+  {
+    "url": "https://www.target.com/sl/west-jordan-sw/2150",
+    "slug": "west-jordan-sw",
+    "store_id": "2150"
+  },
+  {
+    "url": "https://www.target.com/sl/tustin/2151",
+    "slug": "tustin",
+    "store_id": "2151"
+  },
+  {
+    "url": "https://www.target.com/sl/brownsville-north/2152",
+    "slug": "brownsville-north",
+    "store_id": "2152"
+  },
+  {
+    "url": "https://www.target.com/sl/oxford/2153",
+    "slug": "oxford",
+    "store_id": "2153"
+  },
+  {
+    "url": "https://www.target.com/sl/gulf-shores/2154",
+    "slug": "gulf-shores",
+    "store_id": "2154"
+  },
+  {
+    "url": "https://www.target.com/sl/yulee/2155",
+    "slug": "yulee",
+    "store_id": "2155"
+  },
+  {
+    "url": "https://www.target.com/sl/waterbury/2156",
+    "slug": "waterbury",
+    "store_id": "2156"
+  },
+  {
+    "url": "https://www.target.com/sl/streetsboro/2157",
+    "slug": "streetsboro",
+    "store_id": "2157"
+  },
+  {
+    "url": "https://www.target.com/sl/big-flats/2158",
+    "slug": "big-flats",
+    "store_id": "2158"
+  },
+  {
+    "url": "https://www.target.com/sl/sandusky/2159",
+    "slug": "sandusky",
+    "store_id": "2159"
+  },
+  {
+    "url": "https://www.target.com/sl/bainbridge/2161",
+    "slug": "bainbridge",
+    "store_id": "2161"
+  },
+  {
+    "url": "https://www.target.com/sl/mission-viejo-n/2163",
+    "slug": "mission-viejo-n",
+    "store_id": "2163"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-blue-diamond/2164",
+    "slug": "las-vegas-blue-diamond",
+    "store_id": "2164"
+  },
+  {
+    "url": "https://www.target.com/sl/vista-south-business-park-drive/2165",
+    "slug": "vista-south-business-park-drive",
+    "store_id": "2165"
+  },
+  {
+    "url": "https://www.target.com/sl/biddeford/2166",
+    "slug": "biddeford",
+    "store_id": "2166"
+  },
+  {
+    "url": "https://www.target.com/sl/north-dartmouth/2167",
+    "slug": "north-dartmouth",
+    "store_id": "2167"
+  },
+  {
+    "url": "https://www.target.com/sl/wilson/2168",
+    "slug": "wilson",
+    "store_id": "2168"
+  },
+  {
+    "url": "https://www.target.com/sl/kannapolis/2169",
+    "slug": "kannapolis",
+    "store_id": "2169"
+  },
+  {
+    "url": "https://www.target.com/sl/millville/2170",
+    "slug": "millville",
+    "store_id": "2170"
+  },
+  {
+    "url": "https://www.target.com/sl/buckhead-south/2171",
+    "slug": "buckhead-south",
+    "store_id": "2171"
+  },
+  {
+    "url": "https://www.target.com/sl/concord-township/2172",
+    "slug": "concord-township",
+    "store_id": "2172"
+  },
+  {
+    "url": "https://www.target.com/sl/abington/2173",
+    "slug": "abington",
+    "store_id": "2173"
+  },
+  {
+    "url": "https://www.target.com/sl/conyers/2174",
+    "slug": "conyers",
+    "store_id": "2174"
+  },
+  {
+    "url": "https://www.target.com/sl/stafford-south/2175",
+    "slug": "stafford-south",
+    "store_id": "2175"
+  },
+  {
+    "url": "https://www.target.com/sl/tempe-rio-salado/2176",
+    "slug": "tempe-rio-salado",
+    "store_id": "2176"
+  },
+  {
+    "url": "https://www.target.com/sl/north-aurora/2177",
+    "slug": "north-aurora",
+    "store_id": "2177"
+  },
+  {
+    "url": "https://www.target.com/sl/bloomfield-township/2178",
+    "slug": "bloomfield-township",
+    "store_id": "2178"
+  },
+  {
+    "url": "https://www.target.com/sl/diamond-bar/2179",
+    "slug": "diamond-bar",
+    "store_id": "2179"
+  },
+  {
+    "url": "https://www.target.com/sl/monticello/2180",
+    "slug": "monticello",
+    "store_id": "2180"
+  },
+  {
+    "url": "https://www.target.com/sl/gloucester-township/2181",
+    "slug": "gloucester-township",
+    "store_id": "2181"
+  },
+  {
+    "url": "https://www.target.com/sl/somersworth/2182",
+    "slug": "somersworth",
+    "store_id": "2182"
+  },
+  {
+    "url": "https://www.target.com/sl/brighton/2183",
+    "slug": "brighton",
+    "store_id": "2183"
+  },
+  {
+    "url": "https://www.target.com/sl/south-union-twp/2184",
+    "slug": "south-union-twp",
+    "store_id": "2184"
+  },
+  {
+    "url": "https://www.target.com/sl/hayward-north/2185",
+    "slug": "hayward-north",
+    "store_id": "2185"
+  },
+  {
+    "url": "https://www.target.com/sl/harrisburg-east/2186",
+    "slug": "harrisburg-east",
+    "store_id": "2186"
+  },
+  {
+    "url": "https://www.target.com/sl/la-cantera/2187",
+    "slug": "la-cantera",
+    "store_id": "2187"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-central/2188",
+    "slug": "miami-central",
+    "store_id": "2188"
+  },
+  {
+    "url": "https://www.target.com/sl/knollwood-hwy-7/2189",
+    "slug": "knollwood-hwy-7",
+    "store_id": "2189"
+  },
+  {
+    "url": "https://www.target.com/sl/lubbock-marsha-sharp/2190",
+    "slug": "lubbock-marsha-sharp",
+    "store_id": "2190"
+  },
+  {
+    "url": "https://www.target.com/sl/losson-road/2191",
+    "slug": "losson-road",
+    "store_id": "2191"
+  },
+  {
+    "url": "https://www.target.com/sl/marysville/2192",
+    "slug": "marysville",
+    "store_id": "2192"
+  },
+  {
+    "url": "https://www.target.com/sl/maple-grove-north/2193",
+    "slug": "maple-grove-north",
+    "store_id": "2193"
+  },
+  {
+    "url": "https://www.target.com/sl/bismarck/2194",
+    "slug": "bismarck",
+    "store_id": "2194"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-elsinore/2195",
+    "slug": "lake-elsinore",
+    "store_id": "2195"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-lakes/2196",
+    "slug": "miami-lakes",
+    "store_id": "2196"
+  },
+  {
+    "url": "https://www.target.com/sl/westminster-orchard-parkway/2197",
+    "slug": "westminster-orchard-parkway",
+    "store_id": "2197"
+  },
+  {
+    "url": "https://www.target.com/sl/west-allis/2199",
+    "slug": "west-allis",
+    "store_id": "2199"
+  },
+  {
+    "url": "https://www.target.com/sl/fridley/2200",
+    "slug": "fridley",
+    "store_id": "2200"
+  },
+  {
+    "url": "https://www.target.com/sl/ross-township/2201",
+    "slug": "ross-township",
+    "store_id": "2201"
+  },
+  {
+    "url": "https://www.target.com/sl/mechanicsburg/2202",
+    "slug": "mechanicsburg",
+    "store_id": "2202"
+  },
+  {
+    "url": "https://www.target.com/sl/hillcrest/2203",
+    "slug": "hillcrest",
+    "store_id": "2203"
+  },
+  {
+    "url": "https://www.target.com/sl/bryant/2204",
+    "slug": "bryant",
+    "store_id": "2204"
+  },
+  {
+    "url": "https://www.target.com/sl/rosenberg/2205",
+    "slug": "rosenberg",
+    "store_id": "2205"
+  },
+  {
+    "url": "https://www.target.com/sl/nampa/2206",
+    "slug": "nampa",
+    "store_id": "2206"
+  },
+  {
+    "url": "https://www.target.com/sl/southfield/2207",
+    "slug": "southfield",
+    "store_id": "2207"
+  },
+  {
+    "url": "https://www.target.com/sl/pier-park/2208",
+    "slug": "pier-park",
+    "store_id": "2208"
+  },
+  {
+    "url": "https://www.target.com/sl/boynton-beach-se/2210",
+    "slug": "boynton-beach-se",
+    "store_id": "2210"
+  },
+  {
+    "url": "https://www.target.com/sl/irondequoit/2211",
+    "slug": "irondequoit",
+    "store_id": "2211"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-junction/2212",
+    "slug": "brooklyn-junction",
+    "store_id": "2212"
+  },
+  {
+    "url": "https://www.target.com/sl/windsor/2213",
+    "slug": "windsor",
+    "store_id": "2213"
+  },
+  {
+    "url": "https://www.target.com/sl/lincoln/2214",
+    "slug": "lincoln",
+    "store_id": "2214"
+  },
+  {
+    "url": "https://www.target.com/sl/el-paso-joe-battle-blvd/2216",
+    "slug": "el-paso-joe-battle-blvd",
+    "store_id": "2216"
+  },
+  {
+    "url": "https://www.target.com/sl/ft-wayne-glenbrook/2217",
+    "slug": "ft-wayne-glenbrook",
+    "store_id": "2217"
+  },
+  {
+    "url": "https://www.target.com/sl/longmont/2218",
+    "slug": "longmont",
+    "store_id": "2218"
+  },
+  {
+    "url": "https://www.target.com/sl/parker/2219",
+    "slug": "parker",
+    "store_id": "2219"
+  },
+  {
+    "url": "https://www.target.com/sl/norman/2220",
+    "slug": "norman",
+    "store_id": "2220"
+  },
+  {
+    "url": "https://www.target.com/sl/colorado-springs-ne/2221",
+    "slug": "colorado-springs-ne",
+    "store_id": "2221"
+  },
+  {
+    "url": "https://www.target.com/sl/kc-speedway/2222",
+    "slug": "kc-speedway",
+    "store_id": "2222"
+  },
+  {
+    "url": "https://www.target.com/sl/medina/2223",
+    "slug": "medina",
+    "store_id": "2223"
+  },
+  {
+    "url": "https://www.target.com/sl/mcallen-northwest/2224",
+    "slug": "mcallen-northwest",
+    "store_id": "2224"
+  },
+  {
+    "url": "https://www.target.com/sl/edgewater/2225",
+    "slug": "edgewater",
+    "store_id": "2225"
+  },
+  {
+    "url": "https://www.target.com/sl/cleveland-west/2226",
+    "slug": "cleveland-west",
+    "store_id": "2226"
+  },
+  {
+    "url": "https://www.target.com/sl/peoria-lake-pleasant-pkwy/2227",
+    "slug": "peoria-lake-pleasant-pkwy",
+    "store_id": "2227"
+  },
+  {
+    "url": "https://www.target.com/sl/cleveland-south/2228",
+    "slug": "cleveland-south",
+    "store_id": "2228"
+  },
+  {
+    "url": "https://www.target.com/sl/st-paul-midway/2229",
+    "slug": "st-paul-midway",
+    "store_id": "2229"
+  },
+  {
+    "url": "https://www.target.com/sl/livonia/2230",
+    "slug": "livonia",
+    "store_id": "2230"
+  },
+  {
+    "url": "https://www.target.com/sl/wheeling/2231",
+    "slug": "wheeling",
+    "store_id": "2231"
+  },
+  {
+    "url": "https://www.target.com/sl/natl-cty-pl-bonita/2232",
+    "slug": "natl-cty-pl-bonita",
+    "store_id": "2232"
+  },
+  {
+    "url": "https://www.target.com/sl/jacksonville-west/2233",
+    "slug": "jacksonville-west",
+    "store_id": "2233"
+  },
+  {
+    "url": "https://www.target.com/sl/rowlett/2234",
+    "slug": "rowlett",
+    "store_id": "2234"
+  },
+  {
+    "url": "https://www.target.com/sl/riverview/2235",
+    "slug": "riverview",
+    "store_id": "2235"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-7th-street-and-bell/2236",
+    "slug": "phoenix-7th-street-and-bell",
+    "store_id": "2236"
+  },
+  {
+    "url": "https://www.target.com/sl/mission/2237",
+    "slug": "mission",
+    "store_id": "2237"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-east/2238",
+    "slug": "san-jose-east",
+    "store_id": "2238"
+  },
+  {
+    "url": "https://www.target.com/sl/stone-oak/2239",
+    "slug": "stone-oak",
+    "store_id": "2239"
+  },
+  {
+    "url": "https://www.target.com/sl/nashville-west/2240",
+    "slug": "nashville-west",
+    "store_id": "2240"
+  },
+  {
+    "url": "https://www.target.com/sl/chambersburg/2241",
+    "slug": "chambersburg",
+    "store_id": "2241"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-prairie-s/2243",
+    "slug": "grand-prairie-s",
+    "store_id": "2243"
+  },
+  {
+    "url": "https://www.target.com/sl/charlotte-midtown/2244",
+    "slug": "charlotte-midtown",
+    "store_id": "2244"
+  },
+  {
+    "url": "https://www.target.com/sl/ontario/2245",
+    "slug": "ontario",
+    "store_id": "2245"
+  },
+  {
+    "url": "https://www.target.com/sl/richland-twp/2246",
+    "slug": "richland-twp",
+    "store_id": "2246"
+  },
+  {
+    "url": "https://www.target.com/sl/riverdale-rt-23-and-falston/2247",
+    "slug": "riverdale-rt-23-and-falston",
+    "store_id": "2247"
+  },
+  {
+    "url": "https://www.target.com/sl/port-st-lucie/2248",
+    "slug": "port-st-lucie",
+    "store_id": "2248"
+  },
+  {
+    "url": "https://www.target.com/sl/ansonia/2249",
+    "slug": "ansonia",
+    "store_id": "2249"
+  },
+  {
+    "url": "https://www.target.com/sl/culpeper/2250",
+    "slug": "culpeper",
+    "store_id": "2250"
+  },
+  {
+    "url": "https://www.target.com/sl/pleasant-prairie/2251",
+    "slug": "pleasant-prairie",
+    "store_id": "2251"
+  },
+  {
+    "url": "https://www.target.com/sl/morgan-hill/2252",
+    "slug": "morgan-hill",
+    "store_id": "2252"
+  },
+  {
+    "url": "https://www.target.com/sl/watertown/2253",
+    "slug": "watertown",
+    "store_id": "2253"
+  },
+  {
+    "url": "https://www.target.com/sl/sterling-heights-w/2254",
+    "slug": "sterling-heights-w",
+    "store_id": "2254"
+  },
+  {
+    "url": "https://www.target.com/sl/washington/2255",
+    "slug": "washington",
+    "store_id": "2255"
+  },
+  {
+    "url": "https://www.target.com/sl/south-brunswick/2256",
+    "slug": "south-brunswick",
+    "store_id": "2256"
+  },
+  {
+    "url": "https://www.target.com/sl/stoughton/2258",
+    "slug": "stoughton",
+    "store_id": "2258"
+  },
+  {
+    "url": "https://www.target.com/sl/columbia-heights/2259",
+    "slug": "columbia-heights",
+    "store_id": "2259"
+  },
+  {
+    "url": "https://www.target.com/sl/apple-valley-north/2260",
+    "slug": "apple-valley-north",
+    "store_id": "2260"
+  },
+  {
+    "url": "https://www.target.com/sl/sheridan/2261",
+    "slug": "sheridan",
+    "store_id": "2261"
+  },
+  {
+    "url": "https://www.target.com/sl/richland-twp-north/2262",
+    "slug": "richland-twp-north",
+    "store_id": "2262"
+  },
+  {
+    "url": "https://www.target.com/sl/winter-garden/2264",
+    "slug": "winter-garden",
+    "store_id": "2264"
+  },
+  {
+    "url": "https://www.target.com/sl/coral-springs-nw/2265",
+    "slug": "coral-springs-nw",
+    "store_id": "2265"
+  },
+  {
+    "url": "https://www.target.com/sl/fairview-park/2266",
+    "slug": "fairview-park",
+    "store_id": "2266"
+  },
+  {
+    "url": "https://www.target.com/sl/easton/2267",
+    "slug": "easton",
+    "store_id": "2267"
+  },
+  {
+    "url": "https://www.target.com/sl/west-sacramento/2268",
+    "slug": "west-sacramento",
+    "store_id": "2268"
+  },
+  {
+    "url": "https://www.target.com/sl/titusville/2269",
+    "slug": "titusville",
+    "store_id": "2269"
+  },
+  {
+    "url": "https://www.target.com/sl/el-dorado-hills/2270",
+    "slug": "el-dorado-hills",
+    "store_id": "2270"
+  },
+  {
+    "url": "https://www.target.com/sl/annapolis/2271",
+    "slug": "annapolis",
+    "store_id": "2271"
+  },
+  {
+    "url": "https://www.target.com/sl/dulles/2272",
+    "slug": "dulles",
+    "store_id": "2272"
+  },
+  {
+    "url": "https://www.target.com/sl/bossier-city/2273",
+    "slug": "bossier-city",
+    "store_id": "2273"
+  },
+  {
+    "url": "https://www.target.com/sl/prattville/2274",
+    "slug": "prattville",
+    "store_id": "2274"
+  },
+  {
+    "url": "https://www.target.com/sl/compton-rancho-dom/2275",
+    "slug": "compton-rancho-dom",
+    "store_id": "2275"
+  },
+  {
+    "url": "https://www.target.com/sl/alabaster/2276",
+    "slug": "alabaster",
+    "store_id": "2276"
+  },
+  {
+    "url": "https://www.target.com/sl/lexington/2277",
+    "slug": "lexington",
+    "store_id": "2277"
+  },
+  {
+    "url": "https://www.target.com/sl/temple/2278",
+    "slug": "temple",
+    "store_id": "2278"
+  },
+  {
+    "url": "https://www.target.com/sl/pace/2279",
+    "slug": "pace",
+    "store_id": "2279"
+  },
+  {
+    "url": "https://www.target.com/sl/hawthorne/2280",
+    "slug": "hawthorne",
+    "store_id": "2280"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-central/2281",
+    "slug": "san-jose-central",
+    "store_id": "2281"
+  },
+  {
+    "url": "https://www.target.com/sl/longview/2283",
+    "slug": "longview",
+    "store_id": "2283"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-smith/2284",
+    "slug": "fort-smith",
+    "store_id": "2284"
+  },
+  {
+    "url": "https://www.target.com/sl/methuen/2287",
+    "slug": "methuen",
+    "store_id": "2287"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-southpark/2288",
+    "slug": "austin-southpark",
+    "store_id": "2288"
+  },
+  {
+    "url": "https://www.target.com/sl/tampa-west/2289",
+    "slug": "tampa-west",
+    "store_id": "2289"
+  },
+  {
+    "url": "https://www.target.com/sl/renton/2290",
+    "slug": "renton",
+    "store_id": "2290"
+  },
+  {
+    "url": "https://www.target.com/sl/wareham/2292",
+    "slug": "wareham",
+    "store_id": "2292"
+  },
+  {
+    "url": "https://www.target.com/sl/waynesboro/2294",
+    "slug": "waynesboro",
+    "store_id": "2294"
+  },
+  {
+    "url": "https://www.target.com/sl/cicero/2295",
+    "slug": "cicero",
+    "store_id": "2295"
+  },
+  {
+    "url": "https://www.target.com/sl/williamsburg-east/2296",
+    "slug": "williamsburg-east",
+    "store_id": "2296"
+  },
+  {
+    "url": "https://www.target.com/sl/front-royal/2297",
+    "slug": "front-royal",
+    "store_id": "2297"
+  },
+  {
+    "url": "https://www.target.com/sl/richfield/2300",
+    "slug": "richfield",
+    "store_id": "2300"
+  },
+  {
+    "url": "https://www.target.com/sl/brunswick/2301",
+    "slug": "brunswick",
+    "store_id": "2301"
+  },
+  {
+    "url": "https://www.target.com/sl/muhlenberg-township/2302",
+    "slug": "muhlenberg-township",
+    "store_id": "2302"
+  },
+  {
+    "url": "https://www.target.com/sl/lincoln-sw/2303",
+    "slug": "lincoln-sw",
+    "store_id": "2303"
+  },
+  {
+    "url": "https://www.target.com/sl/westminster-mall/2304",
+    "slug": "westminster-mall",
+    "store_id": "2304"
+  },
+  {
+    "url": "https://www.target.com/sl/torrington/2305",
+    "slug": "torrington",
+    "store_id": "2305"
+  },
+  {
+    "url": "https://www.target.com/sl/marina/2306",
+    "slug": "marina",
+    "store_id": "2306"
+  },
+  {
+    "url": "https://www.target.com/sl/glendale/2307",
+    "slug": "glendale",
+    "store_id": "2307"
+  },
+  {
+    "url": "https://www.target.com/sl/bristol/2308",
+    "slug": "bristol",
+    "store_id": "2308"
+  },
+  {
+    "url": "https://www.target.com/sl/moreno-valley-east/2309",
+    "slug": "moreno-valley-east",
+    "store_id": "2309"
+  },
+  {
+    "url": "https://www.target.com/sl/easton/2310",
+    "slug": "easton",
+    "store_id": "2310"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield-west/2312",
+    "slug": "springfield-west",
+    "store_id": "2312"
+  },
+  {
+    "url": "https://www.target.com/sl/edina/2313",
+    "slug": "edina",
+    "store_id": "2313"
+  },
+  {
+    "url": "https://www.target.com/sl/richland/2314",
+    "slug": "richland",
+    "store_id": "2314"
+  },
+  {
+    "url": "https://www.target.com/sl/augusta/2315",
+    "slug": "augusta",
+    "store_id": "2315"
+  },
+  {
+    "url": "https://www.target.com/sl/cape-coral-north/2316",
+    "slug": "cape-coral-north",
+    "store_id": "2316"
+  },
+  {
+    "url": "https://www.target.com/sl/coconut-point/2317",
+    "slug": "coconut-point",
+    "store_id": "2317"
+  },
+  {
+    "url": "https://www.target.com/sl/signal-hill/2319",
+    "slug": "signal-hill",
+    "store_id": "2319"
+  },
+  {
+    "url": "https://www.target.com/sl/league-city/2320",
+    "slug": "league-city",
+    "store_id": "2320"
+  },
+  {
+    "url": "https://www.target.com/sl/rochester-south/2321",
+    "slug": "rochester-south",
+    "store_id": "2321"
+  },
+  {
+    "url": "https://www.target.com/sl/mentor/2322",
+    "slug": "mentor",
+    "store_id": "2322"
+  },
+  {
+    "url": "https://www.target.com/sl/manassas-west/2323",
+    "slug": "manassas-west",
+    "store_id": "2323"
+  },
+  {
+    "url": "https://www.target.com/sl/camillus/2324",
+    "slug": "camillus",
+    "store_id": "2324"
+  },
+  {
+    "url": "https://www.target.com/sl/haverhill/2325",
+    "slug": "haverhill",
+    "store_id": "2325"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha-far-nw/2326",
+    "slug": "omaha-far-nw",
+    "store_id": "2326"
+  },
+  {
+    "url": "https://www.target.com/sl/norton-shores/2327",
+    "slug": "norton-shores",
+    "store_id": "2327"
+  },
+  {
+    "url": "https://www.target.com/sl/carson/2328",
+    "slug": "carson",
+    "store_id": "2328"
+  },
+  {
+    "url": "https://www.target.com/sl/granada-hills/2329",
+    "slug": "granada-hills",
+    "store_id": "2329"
+  },
+  {
+    "url": "https://www.target.com/sl/belleville/2330",
+    "slug": "belleville",
+    "store_id": "2330"
+  },
+  {
+    "url": "https://www.target.com/sl/savannah-east/2331",
+    "slug": "savannah-east",
+    "store_id": "2331"
+  },
+  {
+    "url": "https://www.target.com/sl/kingsport/2332",
+    "slug": "kingsport",
+    "store_id": "2332"
+  },
+  {
+    "url": "https://www.target.com/sl/sandy-springs-prado/2333",
+    "slug": "sandy-springs-prado",
+    "store_id": "2333"
+  },
+  {
+    "url": "https://www.target.com/sl/dallas-south/2334",
+    "slug": "dallas-south",
+    "store_id": "2334"
+  },
+  {
+    "url": "https://www.target.com/sl/mckinney/2335",
+    "slug": "mckinney",
+    "store_id": "2335"
+  },
+  {
+    "url": "https://www.target.com/sl/henrico-staples-mill-rd/2337",
+    "slug": "henrico-staples-mill-rd",
+    "store_id": "2337"
+  },
+  {
+    "url": "https://www.target.com/sl/frisco-north/2338",
+    "slug": "frisco-north",
+    "store_id": "2338"
+  },
+  {
+    "url": "https://www.target.com/sl/wasilla/2339",
+    "slug": "wasilla",
+    "store_id": "2339"
+  },
+  {
+    "url": "https://www.target.com/sl/burnsville/2340",
+    "slug": "burnsville",
+    "store_id": "2340"
+  },
+  {
+    "url": "https://www.target.com/sl/glendale/2341",
+    "slug": "glendale",
+    "store_id": "2341"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-park/2342",
+    "slug": "cedar-park",
+    "store_id": "2342"
+  },
+  {
+    "url": "https://www.target.com/sl/montrose/2343",
+    "slug": "montrose",
+    "store_id": "2343"
+  },
+  {
+    "url": "https://www.target.com/sl/wentzville/2345",
+    "slug": "wentzville",
+    "store_id": "2345"
+  },
+  {
+    "url": "https://www.target.com/sl/green/2346",
+    "slug": "green",
+    "store_id": "2346"
+  },
+  {
+    "url": "https://www.target.com/sl/lathrop/2347",
+    "slug": "lathrop",
+    "store_id": "2347"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-geneva/2348",
+    "slug": "lake-geneva",
+    "store_id": "2348"
+  },
+  {
+    "url": "https://www.target.com/sl/tulare/2349",
+    "slug": "tulare",
+    "store_id": "2349"
+  },
+  {
+    "url": "https://www.target.com/sl/palmdale-east/2350",
+    "slug": "palmdale-east",
+    "store_id": "2350"
+  },
+  {
+    "url": "https://www.target.com/sl/amherst/2351",
+    "slug": "amherst",
+    "store_id": "2351"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-spectrum/2354",
+    "slug": "phoenix-spectrum",
+    "store_id": "2354"
+  },
+  {
+    "url": "https://www.target.com/sl/fultondale/2355",
+    "slug": "fultondale",
+    "store_id": "2355"
+  },
+  {
+    "url": "https://www.target.com/sl/westwood-village/2356",
+    "slug": "westwood-village",
+    "store_id": "2356"
+  },
+  {
+    "url": "https://www.target.com/sl/tulsa-hills/2357",
+    "slug": "tulsa-hills",
+    "store_id": "2357"
+  },
+  {
+    "url": "https://www.target.com/sl/hilliard-rome/2358",
+    "slug": "hilliard-rome",
+    "store_id": "2358"
+  },
+  {
+    "url": "https://www.target.com/sl/los-banos/2359",
+    "slug": "los-banos",
+    "store_id": "2359"
+  },
+  {
+    "url": "https://www.target.com/sl/smyrna/2360",
+    "slug": "smyrna",
+    "store_id": "2360"
+  },
+  {
+    "url": "https://www.target.com/sl/trumbull-west/2361",
+    "slug": "trumbull-west",
+    "store_id": "2361"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-hill/2362",
+    "slug": "spring-hill",
+    "store_id": "2362"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-myers-sw/2363",
+    "slug": "fort-myers-sw",
+    "store_id": "2363"
+  },
+  {
+    "url": "https://www.target.com/sl/palm-coast/2364",
+    "slug": "palm-coast",
+    "store_id": "2364"
+  },
+  {
+    "url": "https://www.target.com/sl/queen-creek/2365",
+    "slug": "queen-creek",
+    "store_id": "2365"
+  },
+  {
+    "url": "https://www.target.com/sl/ne-polk-county/2366",
+    "slug": "ne-polk-county",
+    "store_id": "2366"
+  },
+  {
+    "url": "https://www.target.com/sl/cleveland/2367",
+    "slug": "cleveland",
+    "store_id": "2367"
+  },
+  {
+    "url": "https://www.target.com/sl/bullhead-city/2368",
+    "slug": "bullhead-city",
+    "store_id": "2368"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-myers-north/2369",
+    "slug": "fort-myers-north",
+    "store_id": "2369"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando-sw/2370",
+    "slug": "orlando-sw",
+    "store_id": "2370"
+  },
+  {
+    "url": "https://www.target.com/sl/anchorage-ne/2371",
+    "slug": "anchorage-ne",
+    "store_id": "2371"
+  },
+  {
+    "url": "https://www.target.com/sl/anchorage-south/2372",
+    "slug": "anchorage-south",
+    "store_id": "2372"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-wilson-yard/2373",
+    "slug": "chicago-wilson-yard",
+    "store_id": "2373"
+  },
+  {
+    "url": "https://www.target.com/sl/harker-heights/2374",
+    "slug": "harker-heights",
+    "store_id": "2374"
+  },
+  {
+    "url": "https://www.target.com/sl/bessemer/2375",
+    "slug": "bessemer",
+    "store_id": "2375"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando---sodo/2376",
+    "slug": "orlando---sodo",
+    "store_id": "2376"
+  },
+  {
+    "url": "https://www.target.com/sl/lafayette-n/2377",
+    "slug": "lafayette-n",
+    "store_id": "2377"
+  },
+  {
+    "url": "https://www.target.com/sl/yorkville/2378",
+    "slug": "yorkville",
+    "store_id": "2378"
+  },
+  {
+    "url": "https://www.target.com/sl/winchester-north/2379",
+    "slug": "winchester-north",
+    "store_id": "2379"
+  },
+  {
+    "url": "https://www.target.com/sl/paramus/2381",
+    "slug": "paramus",
+    "store_id": "2381"
+  },
+  {
+    "url": "https://www.target.com/sl/batavia/2382",
+    "slug": "batavia",
+    "store_id": "2382"
+  },
+  {
+    "url": "https://www.target.com/sl/omaha-far-sw/2383",
+    "slug": "omaha-far-sw",
+    "store_id": "2383"
+  },
+  {
+    "url": "https://www.target.com/sl/mantua/2384",
+    "slug": "mantua",
+    "store_id": "2384"
+  },
+  {
+    "url": "https://www.target.com/sl/harmar/2385",
+    "slug": "harmar",
+    "store_id": "2385"
+  },
+  {
+    "url": "https://www.target.com/sl/atwater/2386",
+    "slug": "atwater",
+    "store_id": "2386"
+  },
+  {
+    "url": "https://www.target.com/sl/flowery-branch/2387",
+    "slug": "flowery-branch",
+    "store_id": "2387"
+  },
+  {
+    "url": "https://www.target.com/sl/franklin/2388",
+    "slug": "franklin",
+    "store_id": "2388"
+  },
+  {
+    "url": "https://www.target.com/sl/atascocita/2389",
+    "slug": "atascocita",
+    "store_id": "2389"
+  },
+  {
+    "url": "https://www.target.com/sl/apple-valley-south/2390",
+    "slug": "apple-valley-south",
+    "store_id": "2390"
+  },
+  {
+    "url": "https://www.target.com/sl/indy-glendale/2391",
+    "slug": "indy-glendale",
+    "store_id": "2391"
+  },
+  {
+    "url": "https://www.target.com/sl/stafford-township/2392",
+    "slug": "stafford-township",
+    "store_id": "2392"
+  },
+  {
+    "url": "https://www.target.com/sl/brandywine/2394",
+    "slug": "brandywine",
+    "store_id": "2394"
+  },
+  {
+    "url": "https://www.target.com/sl/wesley-chapel/2395",
+    "slug": "wesley-chapel",
+    "store_id": "2395"
+  },
+  {
+    "url": "https://www.target.com/sl/red-mill/2396",
+    "slug": "red-mill",
+    "store_id": "2396"
+  },
+  {
+    "url": "https://www.target.com/sl/la-habra/2397",
+    "slug": "la-habra",
+    "store_id": "2397"
+  },
+  {
+    "url": "https://www.target.com/sl/ventura-mall/2398",
+    "slug": "ventura-mall",
+    "store_id": "2398"
+  },
+  {
+    "url": "https://www.target.com/sl/hanover-township/2399",
+    "slug": "hanover-township",
+    "store_id": "2399"
+  },
+  {
+    "url": "https://www.target.com/sl/goodyear-west/2400",
+    "slug": "goodyear-west",
+    "store_id": "2400"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-collins-east/2403",
+    "slug": "fort-collins-east",
+    "store_id": "2403"
+  },
+  {
+    "url": "https://www.target.com/sl/henderson-lake-mead-pkwy/2404",
+    "slug": "henderson-lake-mead-pkwy",
+    "store_id": "2404"
+  },
+  {
+    "url": "https://www.target.com/sl/woodbury-commerce-drive/2406",
+    "slug": "woodbury-commerce-drive",
+    "store_id": "2406"
+  },
+  {
+    "url": "https://www.target.com/sl/danville/2407",
+    "slug": "danville",
+    "store_id": "2407"
+  },
+  {
+    "url": "https://www.target.com/sl/woodland/2408",
+    "slug": "woodland",
+    "store_id": "2408"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-arboretum/2409",
+    "slug": "austin-arboretum",
+    "store_id": "2409"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-honolulu-salt-lake/2410",
+    "slug": "oahu-honolulu-salt-lake",
+    "store_id": "2410"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-kapolei/2411",
+    "slug": "oahu-kapolei",
+    "store_id": "2411"
+  },
+  {
+    "url": "https://www.target.com/sl/hawaii-kona/2412",
+    "slug": "hawaii-kona",
+    "store_id": "2412"
+  },
+  {
+    "url": "https://www.target.com/sl/fairview-heights/2414",
+    "slug": "fairview-heights",
+    "store_id": "2414"
+  },
+  {
+    "url": "https://www.target.com/sl/canton-michigan-avenue/2415",
+    "slug": "canton-michigan-avenue",
+    "store_id": "2415"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-cottman/2418",
+    "slug": "philadelphia-cottman",
+    "store_id": "2418"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-eldridge-pkwy/2419",
+    "slug": "houston-eldridge-pkwy",
+    "store_id": "2419"
+  },
+  {
+    "url": "https://www.target.com/sl/porterville/2420",
+    "slug": "porterville",
+    "store_id": "2420"
+  },
+  {
+    "url": "https://www.target.com/sl/anaheim/2421",
+    "slug": "anaheim",
+    "store_id": "2421"
+  },
+  {
+    "url": "https://www.target.com/sl/broken-arrow/2422",
+    "slug": "broken-arrow",
+    "store_id": "2422"
+  },
+  {
+    "url": "https://www.target.com/sl/kansas-city-skyview-ave/2423",
+    "slug": "kansas-city-skyview-ave",
+    "store_id": "2423"
+  },
+  {
+    "url": "https://www.target.com/sl/long-beach-nw/2424",
+    "slug": "long-beach-nw",
+    "store_id": "2424"
+  },
+  {
+    "url": "https://www.target.com/sl/ridgmar/2425",
+    "slug": "ridgmar",
+    "store_id": "2425"
+  },
+  {
+    "url": "https://www.target.com/sl/san-antonio-culebra/2426",
+    "slug": "san-antonio-culebra",
+    "store_id": "2426"
+  },
+  {
+    "url": "https://www.target.com/sl/west-palm-beach/2427",
+    "slug": "west-palm-beach",
+    "store_id": "2427"
+  },
+  {
+    "url": "https://www.target.com/sl/bryan/2428",
+    "slug": "bryan",
+    "store_id": "2428"
+  },
+  {
+    "url": "https://www.target.com/sl/new-braunfels/2429",
+    "slug": "new-braunfels",
+    "store_id": "2429"
+  },
+  {
+    "url": "https://www.target.com/sl/warwick-north/2430",
+    "slug": "warwick-north",
+    "store_id": "2430"
+  },
+  {
+    "url": "https://www.target.com/sl/milton/2431",
+    "slug": "milton",
+    "store_id": "2431"
+  },
+  {
+    "url": "https://www.target.com/sl/killingly/2432",
+    "slug": "killingly",
+    "store_id": "2432"
+  },
+  {
+    "url": "https://www.target.com/sl/lisbon/2433",
+    "slug": "lisbon",
+    "store_id": "2433"
+  },
+  {
+    "url": "https://www.target.com/sl/southington/2434",
+    "slug": "southington",
+    "store_id": "2434"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond-east/2436",
+    "slug": "richmond-east",
+    "store_id": "2436"
+  },
+  {
+    "url": "https://www.target.com/sl/williamsport/2437",
+    "slug": "williamsport",
+    "store_id": "2437"
+  },
+  {
+    "url": "https://www.target.com/sl/san-marcos/2438",
+    "slug": "san-marcos",
+    "store_id": "2438"
+  },
+  {
+    "url": "https://www.target.com/sl/selinsgrove/2439",
+    "slug": "selinsgrove",
+    "store_id": "2439"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-wayne-sw/2440",
+    "slug": "fort-wayne-sw",
+    "store_id": "2440"
+  },
+  {
+    "url": "https://www.target.com/sl/olive-branch-west/2442",
+    "slug": "olive-branch-west",
+    "store_id": "2442"
+  },
+  {
+    "url": "https://www.target.com/sl/pensacola-west/2445",
+    "slug": "pensacola-west",
+    "store_id": "2445"
+  },
+  {
+    "url": "https://www.target.com/sl/washington-twp/2446",
+    "slug": "washington-twp",
+    "store_id": "2446"
+  },
+  {
+    "url": "https://www.target.com/sl/derby/2448",
+    "slug": "derby",
+    "store_id": "2448"
+  },
+  {
+    "url": "https://www.target.com/sl/waconia/2449",
+    "slug": "waconia",
+    "store_id": "2449"
+  },
+  {
+    "url": "https://www.target.com/sl/reynoldsburg/2450",
+    "slug": "reynoldsburg",
+    "store_id": "2450"
+  },
+  {
+    "url": "https://www.target.com/sl/flushing/2451",
+    "slug": "flushing",
+    "store_id": "2451"
+  },
+  {
+    "url": "https://www.target.com/sl/council-bluffs/2454",
+    "slug": "council-bluffs",
+    "store_id": "2454"
+  },
+  {
+    "url": "https://www.target.com/sl/davis/2455",
+    "slug": "davis",
+    "store_id": "2455"
+  },
+  {
+    "url": "https://www.target.com/sl/otsego/2456",
+    "slug": "otsego",
+    "store_id": "2456"
+  },
+  {
+    "url": "https://www.target.com/sl/rapid-city/2457",
+    "slug": "rapid-city",
+    "store_id": "2457"
+  },
+  {
+    "url": "https://www.target.com/sl/aurora-south/2458",
+    "slug": "aurora-south",
+    "store_id": "2458"
+  },
+  {
+    "url": "https://www.target.com/sl/plattsburgh/2459",
+    "slug": "plattsburgh",
+    "store_id": "2459"
+  },
+  {
+    "url": "https://www.target.com/sl/yukon/2460",
+    "slug": "yukon",
+    "store_id": "2460"
+  },
+  {
+    "url": "https://www.target.com/sl/amsterdam/2461",
+    "slug": "amsterdam",
+    "store_id": "2461"
+  },
+  {
+    "url": "https://www.target.com/sl/simi-valley-tierra-rejada-road/2462",
+    "slug": "simi-valley-tierra-rejada-road",
+    "store_id": "2462"
+  },
+  {
+    "url": "https://www.target.com/sl/rancho-cordova/2463",
+    "slug": "rancho-cordova",
+    "store_id": "2463"
+  },
+  {
+    "url": "https://www.target.com/sl/balboa/2465",
+    "slug": "balboa",
+    "store_id": "2465"
+  },
+  {
+    "url": "https://www.target.com/sl/park-north/2467",
+    "slug": "park-north",
+    "store_id": "2467"
+  },
+  {
+    "url": "https://www.target.com/sl/hesperia/2468",
+    "slug": "hesperia",
+    "store_id": "2468"
+  },
+  {
+    "url": "https://www.target.com/sl/visalia-north/2469",
+    "slug": "visalia-north",
+    "store_id": "2469"
+  },
+  {
+    "url": "https://www.target.com/sl/san-pedro/2470",
+    "slug": "san-pedro",
+    "store_id": "2470"
+  },
+  {
+    "url": "https://www.target.com/sl/menifee/2471",
+    "slug": "menifee",
+    "store_id": "2471"
+  },
+  {
+    "url": "https://www.target.com/sl/sparks-south/2472",
+    "slug": "sparks-south",
+    "store_id": "2472"
+  },
+  {
+    "url": "https://www.target.com/sl/st-matthews/2473",
+    "slug": "st-matthews",
+    "store_id": "2473"
+  },
+  {
+    "url": "https://www.target.com/sl/memphis-east/2474",
+    "slug": "memphis-east",
+    "store_id": "2474"
+  },
+  {
+    "url": "https://www.target.com/sl/bronx-terminal/2475",
+    "slug": "bronx-terminal",
+    "store_id": "2475"
+  },
+  {
+    "url": "https://www.target.com/sl/canton/2476",
+    "slug": "canton",
+    "store_id": "2476"
+  },
+  {
+    "url": "https://www.target.com/sl/midlothian-perimeter-dr/2478",
+    "slug": "midlothian-perimeter-dr",
+    "store_id": "2478"
+  },
+  {
+    "url": "https://www.target.com/sl/la-sunset/2479",
+    "slug": "la-sunset",
+    "store_id": "2479"
+  },
+  {
+    "url": "https://www.target.com/sl/lowell/2480",
+    "slug": "lowell",
+    "store_id": "2480"
+  },
+  {
+    "url": "https://www.target.com/sl/brea/2482",
+    "slug": "brea",
+    "store_id": "2482"
+  },
+  {
+    "url": "https://www.target.com/sl/newport/2483",
+    "slug": "newport",
+    "store_id": "2483"
+  },
+  {
+    "url": "https://www.target.com/sl/d'iberville/2485",
+    "slug": "d'iberville",
+    "store_id": "2485"
+  },
+  {
+    "url": "https://www.target.com/sl/south-lebanon/2486",
+    "slug": "south-lebanon",
+    "store_id": "2486"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-new-albany/2487",
+    "slug": "columbus-new-albany",
+    "store_id": "2487"
+  },
+  {
+    "url": "https://www.target.com/sl/western-hills/2488",
+    "slug": "western-hills",
+    "store_id": "2488"
+  },
+  {
+    "url": "https://www.target.com/sl/brooksville/2489",
+    "slug": "brooksville",
+    "store_id": "2489"
+  },
+  {
+    "url": "https://www.target.com/sl/hillside/2490",
+    "slug": "hillside",
+    "store_id": "2490"
+  },
+  {
+    "url": "https://www.target.com/sl/sun-prairie/2491",
+    "slug": "sun-prairie",
+    "store_id": "2491"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-east/2492",
+    "slug": "sacramento-east",
+    "store_id": "2492"
+  },
+  {
+    "url": "https://www.target.com/sl/winder/2493",
+    "slug": "winder",
+    "store_id": "2493"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-south/2494",
+    "slug": "houston-south",
+    "store_id": "2494"
+  },
+  {
+    "url": "https://www.target.com/sl/pflugerville/2495",
+    "slug": "pflugerville",
+    "store_id": "2495"
+  },
+  {
+    "url": "https://www.target.com/sl/uwchlan-township/2496",
+    "slug": "uwchlan-township",
+    "store_id": "2496"
+  },
+  {
+    "url": "https://www.target.com/sl/n-las-vegas-deer-sp/2497",
+    "slug": "n-las-vegas-deer-sp",
+    "store_id": "2497"
+  },
+  {
+    "url": "https://www.target.com/sl/rogers/2498",
+    "slug": "rogers",
+    "store_id": "2498"
+  },
+  {
+    "url": "https://www.target.com/sl/murrieta-north/2499",
+    "slug": "murrieta-north",
+    "store_id": "2499"
+  },
+  {
+    "url": "https://www.target.com/sl/hampton/2501",
+    "slug": "hampton",
+    "store_id": "2501"
+  },
+  {
+    "url": "https://www.target.com/sl/hoover-west/2503",
+    "slug": "hoover-west",
+    "store_id": "2503"
+  },
+  {
+    "url": "https://www.target.com/sl/allen-north/2516",
+    "slug": "allen-north",
+    "store_id": "2516"
+  },
+  {
+    "url": "https://www.target.com/sl/inver-grove-heights/2519",
+    "slug": "inver-grove-heights",
+    "store_id": "2519"
+  },
+  {
+    "url": "https://www.target.com/sl/lewisville-state-highway-121/2520",
+    "slug": "lewisville-state-highway-121",
+    "store_id": "2520"
+  },
+  {
+    "url": "https://www.target.com/sl/portland-cascade-station/2523",
+    "slug": "portland-cascade-station",
+    "store_id": "2523"
+  },
+  {
+    "url": "https://www.target.com/sl/bakersfield-central/2524",
+    "slug": "bakersfield-central",
+    "store_id": "2524"
+  },
+  {
+    "url": "https://www.target.com/sl/blue-springs/2525",
+    "slug": "blue-springs",
+    "store_id": "2525"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-falls/2526",
+    "slug": "cedar-falls",
+    "store_id": "2526"
+  },
+  {
+    "url": "https://www.target.com/sl/cheltenham/2527",
+    "slug": "cheltenham",
+    "store_id": "2527"
+  },
+  {
+    "url": "https://www.target.com/sl/chili/2528",
+    "slug": "chili",
+    "store_id": "2528"
+  },
+  {
+    "url": "https://www.target.com/sl/exeter-township/2529",
+    "slug": "exeter-township",
+    "store_id": "2529"
+  },
+  {
+    "url": "https://www.target.com/sl/greenland/2530",
+    "slug": "greenland",
+    "store_id": "2530"
+  },
+  {
+    "url": "https://www.target.com/sl/hammond/2531",
+    "slug": "hammond",
+    "store_id": "2531"
+  },
+  {
+    "url": "https://www.target.com/sl/hanover/2532",
+    "slug": "hanover",
+    "store_id": "2532"
+  },
+  {
+    "url": "https://www.target.com/sl/huntsville/2533",
+    "slug": "huntsville",
+    "store_id": "2533"
+  },
+  {
+    "url": "https://www.target.com/sl/kenner/2534",
+    "slug": "kenner",
+    "store_id": "2534"
+  },
+  {
+    "url": "https://www.target.com/sl/lower-nazareth/2536",
+    "slug": "lower-nazareth",
+    "store_id": "2536"
+  },
+  {
+    "url": "https://www.target.com/sl/malvern/2537",
+    "slug": "malvern",
+    "store_id": "2537"
+  },
+  {
+    "url": "https://www.target.com/sl/martinsburg/2538",
+    "slug": "martinsburg",
+    "store_id": "2538"
+  },
+  {
+    "url": "https://www.target.com/sl/sioux-falls-east/2540",
+    "slug": "sioux-falls-east",
+    "store_id": "2540"
+  },
+  {
+    "url": "https://www.target.com/sl/tulsa-south/2542",
+    "slug": "tulsa-south",
+    "store_id": "2542"
+  },
+  {
+    "url": "https://www.target.com/sl/warren/2544",
+    "slug": "warren",
+    "store_id": "2544"
+  },
+  {
+    "url": "https://www.target.com/sl/warwick-township/2545",
+    "slug": "warwick-township",
+    "store_id": "2545"
+  },
+  {
+    "url": "https://www.target.com/sl/waukesha-south/2546",
+    "slug": "waukesha-south",
+    "store_id": "2546"
+  },
+  {
+    "url": "https://www.target.com/sl/palm-bay/2547",
+    "slug": "palm-bay",
+    "store_id": "2547"
+  },
+  {
+    "url": "https://www.target.com/sl/west-pottsgrove-twp/2548",
+    "slug": "west-pottsgrove-twp",
+    "store_id": "2548"
+  },
+  {
+    "url": "https://www.target.com/sl/wylie/2550",
+    "slug": "wylie",
+    "store_id": "2550"
+  },
+  {
+    "url": "https://www.target.com/sl/blue-ash/2557",
+    "slug": "blue-ash",
+    "store_id": "2557"
+  },
+  {
+    "url": "https://www.target.com/sl/dekalb/2559",
+    "slug": "dekalb",
+    "store_id": "2559"
+  },
+  {
+    "url": "https://www.target.com/sl/gastonia/2565",
+    "slug": "gastonia",
+    "store_id": "2565"
+  },
+  {
+    "url": "https://www.target.com/sl/hanover/2567",
+    "slug": "hanover",
+    "store_id": "2567"
+  },
+  {
+    "url": "https://www.target.com/sl/henderson-green-valley-ranch-pkwy/2568",
+    "slug": "henderson-green-valley-ranch-pkwy",
+    "store_id": "2568"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-n-decatur/2569",
+    "slug": "las-vegas-n-decatur",
+    "store_id": "2569"
+  },
+  {
+    "url": "https://www.target.com/sl/marlborough-east/2570",
+    "slug": "marlborough-east",
+    "store_id": "2570"
+  },
+  {
+    "url": "https://www.target.com/sl/mesquite/2572",
+    "slug": "mesquite",
+    "store_id": "2572"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-north/2581",
+    "slug": "san-jose-north",
+    "store_id": "2581"
+  },
+  {
+    "url": "https://www.target.com/sl/sunnyvale/2584",
+    "slug": "sunnyvale",
+    "store_id": "2584"
+  },
+  {
+    "url": "https://www.target.com/sl/wauwatosa/2586",
+    "slug": "wauwatosa",
+    "store_id": "2586"
+  },
+  {
+    "url": "https://www.target.com/sl/king-of-prussia/2596",
+    "slug": "king-of-prussia",
+    "store_id": "2596"
+  },
+  {
+    "url": "https://www.target.com/sl/petaluma/2601",
+    "slug": "petaluma",
+    "store_id": "2601"
+  },
+  {
+    "url": "https://www.target.com/sl/rocklin/2604",
+    "slug": "rocklin",
+    "store_id": "2604"
+  },
+  {
+    "url": "https://www.target.com/sl/san-jose-south/2605",
+    "slug": "san-jose-south",
+    "store_id": "2605"
+  },
+  {
+    "url": "https://www.target.com/sl/swansea/2607",
+    "slug": "swansea",
+    "store_id": "2607"
+  },
+  {
+    "url": "https://www.target.com/sl/lower-macungie-twp/2608",
+    "slug": "lower-macungie-twp",
+    "store_id": "2608"
+  },
+  {
+    "url": "https://www.target.com/sl/west-valley-city/2609",
+    "slug": "west-valley-city",
+    "store_id": "2609"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-gold-coast/2613",
+    "slug": "chicago-gold-coast",
+    "store_id": "2613"
+  },
+  {
+    "url": "https://www.target.com/sl/fremont-south/2615",
+    "slug": "fremont-south",
+    "store_id": "2615"
+  },
+  {
+    "url": "https://www.target.com/sl/azusa/2627",
+    "slug": "azusa",
+    "store_id": "2627"
+  },
+  {
+    "url": "https://www.target.com/sl/crofton/2631",
+    "slug": "crofton",
+    "store_id": "2631"
+  },
+  {
+    "url": "https://www.target.com/sl/culver-city-westfield-mall/2632",
+    "slug": "culver-city-westfield-mall",
+    "store_id": "2632"
+  },
+  {
+    "url": "https://www.target.com/sl/salt-lake-city/2641",
+    "slug": "salt-lake-city",
+    "store_id": "2641"
+  },
+  {
+    "url": "https://www.target.com/sl/westwood/2649",
+    "slug": "westwood",
+    "store_id": "2649"
+  },
+  {
+    "url": "https://www.target.com/sl/maui-kahului/2660",
+    "slug": "maui-kahului",
+    "store_id": "2660"
+  },
+  {
+    "url": "https://www.target.com/sl/hawaii-hilo/2682",
+    "slug": "hawaii-hilo",
+    "store_id": "2682"
+  },
+  {
+    "url": "https://www.target.com/sl/braintree/2693",
+    "slug": "braintree",
+    "store_id": "2693"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-kailua/2697",
+    "slug": "oahu-kailua",
+    "store_id": "2697"
+  },
+  {
+    "url": "https://www.target.com/sl/bakersfield-west/2715",
+    "slug": "bakersfield-west",
+    "store_id": "2715"
+  },
+  {
+    "url": "https://www.target.com/sl/highlands-ranch/2716",
+    "slug": "highlands-ranch",
+    "store_id": "2716"
+  },
+  {
+    "url": "https://www.target.com/sl/lakewood/2717",
+    "slug": "lakewood",
+    "store_id": "2717"
+  },
+  {
+    "url": "https://www.target.com/sl/morrisville/2721",
+    "slug": "morrisville",
+    "store_id": "2721"
+  },
+  {
+    "url": "https://www.target.com/sl/kyle/2725",
+    "slug": "kyle",
+    "store_id": "2725"
+  },
+  {
+    "url": "https://www.target.com/sl/moore/2727",
+    "slug": "moore",
+    "store_id": "2727"
+  },
+  {
+    "url": "https://www.target.com/sl/middletown/2728",
+    "slug": "middletown",
+    "store_id": "2728"
+  },
+  {
+    "url": "https://www.target.com/sl/wilmington/2729",
+    "slug": "wilmington",
+    "store_id": "2729"
+  },
+  {
+    "url": "https://www.target.com/sl/san-clemente/2730",
+    "slug": "san-clemente",
+    "store_id": "2730"
+  },
+  {
+    "url": "https://www.target.com/sl/little-rock-univer/2737",
+    "slug": "little-rock-univer",
+    "store_id": "2737"
+  },
+  {
+    "url": "https://www.target.com/sl/lawton/2739",
+    "slug": "lawton",
+    "store_id": "2739"
+  },
+  {
+    "url": "https://www.target.com/sl/myrtle-beach-17-and-544/2742",
+    "slug": "myrtle-beach-17-and-544",
+    "store_id": "2742"
+  },
+  {
+    "url": "https://www.target.com/sl/fresno-nw/2744",
+    "slug": "fresno-nw",
+    "store_id": "2744"
+  },
+  {
+    "url": "https://www.target.com/sl/chandler-south/2747",
+    "slug": "chandler-south",
+    "store_id": "2747"
+  },
+  {
+    "url": "https://www.target.com/sl/staten-island-cntl/2753",
+    "slug": "staten-island-cntl",
+    "store_id": "2753"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-worth/2754",
+    "slug": "fort-worth",
+    "store_id": "2754"
+  },
+  {
+    "url": "https://www.target.com/sl/east-liberty/2757",
+    "slug": "east-liberty",
+    "store_id": "2757"
+  },
+  {
+    "url": "https://www.target.com/sl/san-luis-obispo/2759",
+    "slug": "san-luis-obispo",
+    "store_id": "2759"
+  },
+  {
+    "url": "https://www.target.com/sl/oxnard-west/2760",
+    "slug": "oxnard-west",
+    "store_id": "2760"
+  },
+  {
+    "url": "https://www.target.com/sl/christiana/2764",
+    "slug": "christiana",
+    "store_id": "2764"
+  },
+  {
+    "url": "https://www.target.com/sl/madison-hilldale/2765",
+    "slug": "madison-hilldale",
+    "store_id": "2765"
+  },
+  {
+    "url": "https://www.target.com/sl/san-francisco-central/2766",
+    "slug": "san-francisco-central",
+    "store_id": "2766"
+  },
+  {
+    "url": "https://www.target.com/sl/oakland-emeryville/2767",
+    "slug": "oakland-emeryville",
+    "store_id": "2767"
+  },
+  {
+    "url": "https://www.target.com/sl/san-francisco-west/2768",
+    "slug": "san-francisco-west",
+    "store_id": "2768"
+  },
+  {
+    "url": "https://www.target.com/sl/pembroke/2770",
+    "slug": "pembroke",
+    "store_id": "2770"
+  },
+  {
+    "url": "https://www.target.com/sl/dublin-east/2771",
+    "slug": "dublin-east",
+    "store_id": "2771"
+  },
+  {
+    "url": "https://www.target.com/sl/san-rafael/2772",
+    "slug": "san-rafael",
+    "store_id": "2772"
+  },
+  {
+    "url": "https://www.target.com/sl/la-westwood/2774",
+    "slug": "la-westwood",
+    "store_id": "2774"
+  },
+  {
+    "url": "https://www.target.com/sl/la-beverly/2775",
+    "slug": "la-beverly",
+    "store_id": "2775"
+  },
+  {
+    "url": "https://www.target.com/sl/la-central/2776",
+    "slug": "la-central",
+    "store_id": "2776"
+  },
+  {
+    "url": "https://www.target.com/sl/portland-hayden-island-dr/2779",
+    "slug": "portland-hayden-island-dr",
+    "store_id": "2779"
+  },
+  {
+    "url": "https://www.target.com/sl/brookfield/2780",
+    "slug": "brookfield",
+    "store_id": "2780"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-west-loop/2781",
+    "slug": "chicago-west-loop",
+    "store_id": "2781"
+  },
+  {
+    "url": "https://www.target.com/sl/cary-west/2784",
+    "slug": "cary-west",
+    "store_id": "2784"
+  },
+  {
+    "url": "https://www.target.com/sl/holly-springs/2785",
+    "slug": "holly-springs",
+    "store_id": "2785"
+  },
+  {
+    "url": "https://www.target.com/sl/seattle-pike-plaza/2786",
+    "slug": "seattle-pike-plaza",
+    "store_id": "2786"
+  },
+  {
+    "url": "https://www.target.com/sl/upper-st.-clair/2787",
+    "slug": "upper-st.-clair",
+    "store_id": "2787"
+  },
+  {
+    "url": "https://www.target.com/sl/merrifield/2790",
+    "slug": "merrifield",
+    "store_id": "2790"
+  },
+  {
+    "url": "https://www.target.com/sl/capitola/2795",
+    "slug": "capitola",
+    "store_id": "2795"
+  },
+  {
+    "url": "https://www.target.com/sl/homewood/2796",
+    "slug": "homewood",
+    "store_id": "2796"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-state-st./2799",
+    "slug": "chicago-state-st.",
+    "store_id": "2799"
+  },
+  {
+    "url": "https://www.target.com/sl/escondido-south/2802",
+    "slug": "escondido-south",
+    "store_id": "2802"
+  },
+  {
+    "url": "https://www.target.com/sl/alamo-heights/2803",
+    "slug": "alamo-heights",
+    "store_id": "2803"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-rosa-north/2804",
+    "slug": "santa-rosa-north",
+    "store_id": "2804"
+  },
+  {
+    "url": "https://www.target.com/sl/glenville/2805",
+    "slug": "glenville",
+    "store_id": "2805"
+  },
+  {
+    "url": "https://www.target.com/sl/westlake-village/2810",
+    "slug": "westlake-village",
+    "store_id": "2810"
+  },
+  {
+    "url": "https://www.target.com/sl/bronx-throggs-neck/2811",
+    "slug": "bronx-throggs-neck",
+    "store_id": "2811"
+  },
+  {
+    "url": "https://www.target.com/sl/albuquerque-uptown/2813",
+    "slug": "albuquerque-uptown",
+    "store_id": "2813"
+  },
+  {
+    "url": "https://www.target.com/sl/knoxville-south/2815",
+    "slug": "knoxville-south",
+    "store_id": "2815"
+  },
+  {
+    "url": "https://www.target.com/sl/madison/2816",
+    "slug": "madison",
+    "store_id": "2816"
+  },
+  {
+    "url": "https://www.target.com/sl/grandville/2818",
+    "slug": "grandville",
+    "store_id": "2818"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-se/2820",
+    "slug": "denver-se",
+    "store_id": "2820"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-fenway/2822",
+    "slug": "boston-fenway",
+    "store_id": "2822"
+  },
+  {
+    "url": "https://www.target.com/sl/east-peoria/2824",
+    "slug": "east-peoria",
+    "store_id": "2824"
+  },
+  {
+    "url": "https://www.target.com/sl/alameda/2829",
+    "slug": "alameda",
+    "store_id": "2829"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-clara/2830",
+    "slug": "santa-clara",
+    "store_id": "2830"
+  },
+  {
+    "url": "https://www.target.com/sl/pomona/2831",
+    "slug": "pomona",
+    "store_id": "2831"
+  },
+  {
+    "url": "https://www.target.com/sl/valley-stream/2840",
+    "slug": "valley-stream",
+    "store_id": "2840"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-sw-104th-street/2843",
+    "slug": "miami-sw-104th-street",
+    "store_id": "2843"
+  },
+  {
+    "url": "https://www.target.com/sl/huntington/2844",
+    "slug": "huntington",
+    "store_id": "2844"
+  },
+  {
+    "url": "https://www.target.com/sl/baltimore-east/2845",
+    "slug": "baltimore-east",
+    "store_id": "2845"
+  },
+  {
+    "url": "https://www.target.com/sl/sayville/2847",
+    "slug": "sayville",
+    "store_id": "2847"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-flagler/2848",
+    "slug": "miami-flagler",
+    "store_id": "2848"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-fulton-st/2850",
+    "slug": "brooklyn-fulton-st",
+    "store_id": "2850"
+  },
+  {
+    "url": "https://www.target.com/sl/powell/2851",
+    "slug": "powell",
+    "store_id": "2851"
+  },
+  {
+    "url": "https://www.target.com/sl/north-brunswick/2853",
+    "slug": "north-brunswick",
+    "store_id": "2853"
+  },
+  {
+    "url": "https://www.target.com/sl/san-diego-del-sur/2855",
+    "slug": "san-diego-del-sur",
+    "store_id": "2855"
+  },
+  {
+    "url": "https://www.target.com/sl/spokane-south/2857",
+    "slug": "spokane-south",
+    "store_id": "2857"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-bluff/2860",
+    "slug": "lake-bluff",
+    "store_id": "2860"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-grand-parkway-north/2865",
+    "slug": "spring-grand-parkway-north",
+    "store_id": "2865"
+  },
+  {
+    "url": "https://www.target.com/sl/lancaster-central/2867",
+    "slug": "lancaster-central",
+    "store_id": "2867"
+  },
+  {
+    "url": "https://www.target.com/sl/richmond-grand-pkwy-sw/2868",
+    "slug": "richmond-grand-pkwy-sw",
+    "store_id": "2868"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-honolulu-ala-moana/2870",
+    "slug": "oahu-honolulu-ala-moana",
+    "store_id": "2870"
+  },
+  {
+    "url": "https://www.target.com/sl/oceanside-east/2871",
+    "slug": "oceanside-east",
+    "store_id": "2871"
+  },
+  {
+    "url": "https://www.target.com/sl/goleta/2872",
+    "slug": "goleta",
+    "store_id": "2872"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-six-forks-rd/2873",
+    "slug": "raleigh-six-forks-rd",
+    "store_id": "2873"
+  },
+  {
+    "url": "https://www.target.com/sl/wilmington-prices-corner/2875",
+    "slug": "wilmington-prices-corner",
+    "store_id": "2875"
+  },
+  {
+    "url": "https://www.target.com/sl/glendale-north-shore/2877",
+    "slug": "glendale-north-shore",
+    "store_id": "2877"
+  },
+  {
+    "url": "https://www.target.com/sl/somers-point/2878",
+    "slug": "somers-point",
+    "store_id": "2878"
+  },
+  {
+    "url": "https://www.target.com/sl/yonkers-cross-county/2879",
+    "slug": "yonkers-cross-county",
+    "store_id": "2879"
+  },
+  {
+    "url": "https://www.target.com/sl/auburn-center-st/2880",
+    "slug": "auburn-center-st",
+    "store_id": "2880"
+  },
+  {
+    "url": "https://www.target.com/sl/kearny/2881",
+    "slug": "kearny",
+    "store_id": "2881"
+  },
+  {
+    "url": "https://www.target.com/sl/katy-elyson/2882",
+    "slug": "katy-elyson",
+    "store_id": "2882"
+  },
+  {
+    "url": "https://www.target.com/sl/lake-success/2883",
+    "slug": "lake-success",
+    "store_id": "2883"
+  },
+  {
+    "url": "https://www.target.com/sl/prosper/2884",
+    "slug": "prosper",
+    "store_id": "2884"
+  },
+  {
+    "url": "https://www.target.com/sl/jersey-city-route-440/2885",
+    "slug": "jersey-city-route-440",
+    "store_id": "2885"
+  },
+  {
+    "url": "https://www.target.com/sl/lebanon-quentin-road/2886",
+    "slug": "lebanon-quentin-road",
+    "store_id": "2886"
+  },
+  {
+    "url": "https://www.target.com/sl/southern-pines/2887",
+    "slug": "southern-pines",
+    "store_id": "2887"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-windward-mall/2888",
+    "slug": "oahu-windward-mall",
+    "store_id": "2888"
+  },
+  {
+    "url": "https://www.target.com/sl/new-caney/2889",
+    "slug": "new-caney",
+    "store_id": "2889"
+  },
+  {
+    "url": "https://www.target.com/sl/jamestown/2890",
+    "slug": "jamestown",
+    "store_id": "2890"
+  },
+  {
+    "url": "https://www.target.com/sl/grass-valley/2891",
+    "slug": "grass-valley",
+    "store_id": "2891"
+  },
+  {
+    "url": "https://www.target.com/sl/san-fernando/2892",
+    "slug": "san-fernando",
+    "store_id": "2892"
+  },
+  {
+    "url": "https://www.target.com/sl/old-bridge-route-9/2893",
+    "slug": "old-bridge-route-9",
+    "store_id": "2893"
+  },
+  {
+    "url": "https://www.target.com/sl/norwalk-route-1/2894",
+    "slug": "norwalk-route-1",
+    "store_id": "2894"
+  },
+  {
+    "url": "https://www.target.com/sl/west-orange/2895",
+    "slug": "west-orange",
+    "store_id": "2895"
+  },
+  {
+    "url": "https://www.target.com/sl/quincy/2896",
+    "slug": "quincy",
+    "store_id": "2896"
+  },
+  {
+    "url": "https://www.target.com/sl/teays-valley/2897",
+    "slug": "teays-valley",
+    "store_id": "2897"
+  },
+  {
+    "url": "https://www.target.com/sl/spanish-fork/2898",
+    "slug": "spanish-fork",
+    "store_id": "2898"
+  },
+  {
+    "url": "https://www.target.com/sl/portland-northshore/2899",
+    "slug": "portland-northshore",
+    "store_id": "2899"
+  },
+  {
+    "url": "https://www.target.com/sl/lecanto/2900",
+    "slug": "lecanto",
+    "store_id": "2900"
+  },
+  {
+    "url": "https://www.target.com/sl/danbury-fair-mall/2902",
+    "slug": "danbury-fair-mall",
+    "store_id": "2902"
+  },
+  {
+    "url": "https://www.target.com/sl/sevierville/2903",
+    "slug": "sevierville",
+    "store_id": "2903"
+  },
+  {
+    "url": "https://www.target.com/sl/provo-towne-centre/2904",
+    "slug": "provo-towne-centre",
+    "store_id": "2904"
+  },
+  {
+    "url": "https://www.target.com/sl/west-goshen/2905",
+    "slug": "west-goshen",
+    "store_id": "2905"
+  },
+  {
+    "url": "https://www.target.com/sl/wildwood/2906",
+    "slug": "wildwood",
+    "store_id": "2906"
+  },
+  {
+    "url": "https://www.target.com/sl/oak-cliff/2907",
+    "slug": "oak-cliff",
+    "store_id": "2907"
+  },
+  {
+    "url": "https://www.target.com/sl/middletown-warwick-road/2908",
+    "slug": "middletown-warwick-road",
+    "store_id": "2908"
+  },
+  {
+    "url": "https://www.target.com/sl/waukee/2909",
+    "slug": "waukee",
+    "store_id": "2909"
+  },
+  {
+    "url": "https://www.target.com/sl/el-monte/2910",
+    "slug": "el-monte",
+    "store_id": "2910"
+  },
+  {
+    "url": "https://www.target.com/sl/stafford-kirkwood-rd/2911",
+    "slug": "stafford-kirkwood-rd",
+    "store_id": "2911"
+  },
+  {
+    "url": "https://www.target.com/sl/boiling-springs/2912",
+    "slug": "boiling-springs",
+    "store_id": "2912"
+  },
+  {
+    "url": "https://www.target.com/sl/flemington/2914",
+    "slug": "flemington",
+    "store_id": "2914"
+  },
+  {
+    "url": "https://www.target.com/sl/surprise-west-prasada/2915",
+    "slug": "surprise-west-prasada",
+    "store_id": "2915"
+  },
+  {
+    "url": "https://www.target.com/sl/jurupa-valley/2916",
+    "slug": "jurupa-valley",
+    "store_id": "2916"
+  },
+  {
+    "url": "https://www.target.com/sl/denton-north/2917",
+    "slug": "denton-north",
+    "store_id": "2917"
+  },
+  {
+    "url": "https://www.target.com/sl/grand-island/2918",
+    "slug": "grand-island",
+    "store_id": "2918"
+  },
+  {
+    "url": "https://www.target.com/sl/wesley-chapel-grove/2919",
+    "slug": "wesley-chapel-grove",
+    "store_id": "2919"
+  },
+  {
+    "url": "https://www.target.com/sl/queen-creek-gantzel-and-combs/2920",
+    "slug": "queen-creek-gantzel-and-combs",
+    "store_id": "2920"
+  },
+  {
+    "url": "https://www.target.com/sl/delano/2921",
+    "slug": "delano",
+    "store_id": "2921"
+  },
+  {
+    "url": "https://www.target.com/sl/fresno-fancher-creek/2922",
+    "slug": "fresno-fancher-creek",
+    "store_id": "2922"
+  },
+  {
+    "url": "https://www.target.com/sl/university-city-olive-blvd/2923",
+    "slug": "university-city-olive-blvd",
+    "store_id": "2923"
+  },
+  {
+    "url": "https://www.target.com/sl/guilford/2925",
+    "slug": "guilford",
+    "store_id": "2925"
+  },
+  {
+    "url": "https://www.target.com/sl/bradenton-heritage-harbor/2927",
+    "slug": "bradenton-heritage-harbor",
+    "store_id": "2927"
+  },
+  {
+    "url": "https://www.target.com/sl/myrtle-grove/2928",
+    "slug": "myrtle-grove",
+    "store_id": "2928"
+  },
+  {
+    "url": "https://www.target.com/sl/bakersfield-panama-and-gosford/2929",
+    "slug": "bakersfield-panama-and-gosford",
+    "store_id": "2929"
+  },
+  {
+    "url": "https://www.target.com/sl/selma/2930",
+    "slug": "selma",
+    "store_id": "2930"
+  },
+  {
+    "url": "https://www.target.com/sl/springfield-sunshine-towne-centre/2931",
+    "slug": "springfield-sunshine-towne-centre",
+    "store_id": "2931"
+  },
+  {
+    "url": "https://www.target.com/sl/indian-land/2934",
+    "slug": "indian-land",
+    "store_id": "2934"
+  },
+  {
+    "url": "https://www.target.com/sl/fuquay-varina/2936",
+    "slug": "fuquay-varina",
+    "store_id": "2936"
+  },
+  {
+    "url": "https://www.target.com/sl/south-riding/2938",
+    "slug": "south-riding",
+    "store_id": "2938"
+  },
+  {
+    "url": "https://www.target.com/sl/buckeye---verrado/2944",
+    "slug": "buckeye---verrado",
+    "store_id": "2944"
+  },
+  {
+    "url": "https://www.target.com/sl/casa-grande-promenade/2953",
+    "slug": "casa-grande-promenade",
+    "store_id": "2953"
+  },
+  {
+    "url": "https://www.target.com/sl/minneapolis-dinkytown/3200",
+    "slug": "minneapolis-dinkytown",
+    "store_id": "3200"
+  },
+  {
+    "url": "https://www.target.com/sl/berkeley-central/3202",
+    "slug": "berkeley-central",
+    "store_id": "3202"
+  },
+  {
+    "url": "https://www.target.com/sl/st.-paul-highland-park/3204",
+    "slug": "st.-paul-highland-park",
+    "store_id": "3204"
+  },
+  {
+    "url": "https://www.target.com/sl/san-diego-south-park/3205",
+    "slug": "san-diego-south-park",
+    "store_id": "3205"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-rittenhouse-square/3206",
+    "slug": "philadelphia-rittenhouse-square",
+    "store_id": "3206"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-streeterville/3207",
+    "slug": "chicago-streeterville",
+    "store_id": "3207"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-lakeview-belmont-stn/3208",
+    "slug": "chicago-lakeview-belmont-stn",
+    "store_id": "3208"
+  },
+  {
+    "url": "https://www.target.com/sl/rosslyn/3210",
+    "slug": "rosslyn",
+    "store_id": "3210"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-lakeview-ashland/3214",
+    "slug": "chicago-lakeview-ashland",
+    "store_id": "3214"
+  },
+  {
+    "url": "https://www.target.com/sl/los-angeles-koreatown/3216",
+    "slug": "los-angeles-koreatown",
+    "store_id": "3216"
+  },
+  {
+    "url": "https://www.target.com/sl/los-angeles-usc-village/3217",
+    "slug": "los-angeles-usc-village",
+    "store_id": "3217"
+  },
+  {
+    "url": "https://www.target.com/sl/mission-hills-ca/3218",
+    "slug": "mission-hills-ca",
+    "store_id": "3218"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-hyde-park-il/3219",
+    "slug": "chicago-hyde-park-il",
+    "store_id": "3219"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-lincoln-park-north/3221",
+    "slug": "chicago-lincoln-park-north",
+    "store_id": "3221"
+  },
+  {
+    "url": "https://www.target.com/sl/cambridge-central-square/3222",
+    "slug": "cambridge-central-square",
+    "store_id": "3222"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-roslindale/3223",
+    "slug": "boston-roslindale",
+    "store_id": "3223"
+  },
+  {
+    "url": "https://www.target.com/sl/long-beach-bixby/3225",
+    "slug": "long-beach-bixby",
+    "store_id": "3225"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-packards-corner/3226",
+    "slug": "boston-packards-corner",
+    "store_id": "3226"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-art-museum/3227",
+    "slug": "philadelphia-art-museum",
+    "store_id": "3227"
+  },
+  {
+    "url": "https://www.target.com/sl/tribeca/3229",
+    "slug": "tribeca",
+    "store_id": "3229"
+  },
+  {
+    "url": "https://www.target.com/sl/forest-hills/3230",
+    "slug": "forest-hills",
+    "store_id": "3230"
+  },
+  {
+    "url": "https://www.target.com/sl/la-sawtelle/3231",
+    "slug": "la-sawtelle",
+    "store_id": "3231"
+  },
+  {
+    "url": "https://www.target.com/sl/irvine-university-town-center/3233",
+    "slug": "irvine-university-town-center",
+    "store_id": "3233"
+  },
+  {
+    "url": "https://www.target.com/sl/state-college-university-campus/3234",
+    "slug": "state-college-university-campus",
+    "store_id": "3234"
+  },
+  {
+    "url": "https://www.target.com/sl/closter-nj/3235",
+    "slug": "closter-nj",
+    "store_id": "3235"
+  },
+  {
+    "url": "https://www.target.com/sl/freeport/3236",
+    "slug": "freeport",
+    "store_id": "3236"
+  },
+  {
+    "url": "https://www.target.com/sl/elmont/3237",
+    "slug": "elmont",
+    "store_id": "3237"
+  },
+  {
+    "url": "https://www.target.com/sl/marin-city/3240",
+    "slug": "marin-city",
+    "store_id": "3240"
+  },
+  {
+    "url": "https://www.target.com/sl/unc-franklin-st/3241",
+    "slug": "unc-franklin-st",
+    "store_id": "3241"
+  },
+  {
+    "url": "https://www.target.com/sl/bethesda/3242",
+    "slug": "bethesda",
+    "store_id": "3242"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-midwood/3243",
+    "slug": "brooklyn-midwood",
+    "store_id": "3243"
+  },
+  {
+    "url": "https://www.target.com/sl/columbus-ohio-state-u/3244",
+    "slug": "columbus-ohio-state-u",
+    "store_id": "3244"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-roxborough/3247",
+    "slug": "philadelphia-roxborough",
+    "store_id": "3247"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-east-village/3249",
+    "slug": "manhattan-east-village",
+    "store_id": "3249"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-ut-campus/3250",
+    "slug": "austin-ut-campus",
+    "store_id": "3250"
+  },
+  {
+    "url": "https://www.target.com/sl/la-burbank-west/3251",
+    "slug": "la-burbank-west",
+    "store_id": "3251"
+  },
+  {
+    "url": "https://www.target.com/sl/skokie-il/3252",
+    "slug": "skokie-il",
+    "store_id": "3252"
+  },
+  {
+    "url": "https://www.target.com/sl/stoneham-redstone/3253",
+    "slug": "stoneham-redstone",
+    "store_id": "3253"
+  },
+  {
+    "url": "https://www.target.com/sl/uc-calhoun-st/3254",
+    "slug": "uc-calhoun-st",
+    "store_id": "3254"
+  },
+  {
+    "url": "https://www.target.com/sl/raleigh-nc-state-hillsborough-st/3255",
+    "slug": "raleigh-nc-state-hillsborough-st",
+    "store_id": "3255"
+  },
+  {
+    "url": "https://www.target.com/sl/ballston/3257",
+    "slug": "ballston",
+    "store_id": "3257"
+  },
+  {
+    "url": "https://www.target.com/sl/east-orange/3258",
+    "slug": "east-orange",
+    "store_id": "3258"
+  },
+  {
+    "url": "https://www.target.com/sl/port-washington-north/3259",
+    "slug": "port-washington-north",
+    "store_id": "3259"
+  },
+  {
+    "url": "https://www.target.com/sl/phoenix-uptown-camelback/3261",
+    "slug": "phoenix-uptown-camelback",
+    "store_id": "3261"
+  },
+  {
+    "url": "https://www.target.com/sl/la-glassell-park/3262",
+    "slug": "la-glassell-park",
+    "store_id": "3262"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-broad-and-washington/3263",
+    "slug": "philadelphia-broad-and-washington",
+    "store_id": "3263"
+  },
+  {
+    "url": "https://www.target.com/sl/san-francisco-stonestown/3264",
+    "slug": "san-francisco-stonestown",
+    "store_id": "3264"
+  },
+  {
+    "url": "https://www.target.com/sl/berkeley-univ-ave/3267",
+    "slug": "berkeley-univ-ave",
+    "store_id": "3267"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-hells-kitchen/3268",
+    "slug": "manhattan-hells-kitchen",
+    "store_id": "3268"
+  },
+  {
+    "url": "https://www.target.com/sl/south-beach/3269",
+    "slug": "south-beach",
+    "store_id": "3269"
+  },
+  {
+    "url": "https://www.target.com/sl/oakpark/3270",
+    "slug": "oakpark",
+    "store_id": "3270"
+  },
+  {
+    "url": "https://www.target.com/sl/rogers-park/3272",
+    "slug": "rogers-park",
+    "store_id": "3272"
+  },
+  {
+    "url": "https://www.target.com/sl/tallahassee-fl-state-u/3273",
+    "slug": "tallahassee-fl-state-u",
+    "store_id": "3273"
+  },
+  {
+    "url": "https://www.target.com/sl/anaheim-east/3274",
+    "slug": "anaheim-east",
+    "store_id": "3274"
+  },
+  {
+    "url": "https://www.target.com/sl/bellevue-4th-st-and-116th-ave/3275",
+    "slug": "bellevue-4th-st-and-116th-ave",
+    "store_id": "3275"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-bensonhurst/3276",
+    "slug": "brooklyn-bensonhurst",
+    "store_id": "3276"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-herald-square/3277",
+    "slug": "manhattan-herald-square",
+    "store_id": "3277"
+  },
+  {
+    "url": "https://www.target.com/sl/east-lansing-downtown/3278",
+    "slug": "east-lansing-downtown",
+    "store_id": "3278"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-downtown/3279",
+    "slug": "denver-downtown",
+    "store_id": "3279"
+  },
+  {
+    "url": "https://www.target.com/sl/jackson-heights/3280",
+    "slug": "jackson-heights",
+    "store_id": "3280"
+  },
+  {
+    "url": "https://www.target.com/sl/evanston-downtown/3283",
+    "slug": "evanston-downtown",
+    "store_id": "3283"
+  },
+  {
+    "url": "https://www.target.com/sl/lower-east-side-grand-and-clinton/3284",
+    "slug": "lower-east-side-grand-and-clinton",
+    "store_id": "3284"
+  },
+  {
+    "url": "https://www.target.com/sl/philadelphia-northern-liberties/3285",
+    "slug": "philadelphia-northern-liberties",
+    "store_id": "3285"
+  },
+  {
+    "url": "https://www.target.com/sl/medford-ma/3287",
+    "slug": "medford-ma",
+    "store_id": "3287"
+  },
+  {
+    "url": "https://www.target.com/sl/la-silver-lake/3288",
+    "slug": "la-silver-lake",
+    "store_id": "3288"
+  },
+  {
+    "url": "https://www.target.com/sl/queens-astoria-31st-and-ditmars/3289",
+    "slug": "queens-astoria-31st-and-ditmars",
+    "store_id": "3289"
+  },
+  {
+    "url": "https://www.target.com/sl/parsippany/3290",
+    "slug": "parsippany",
+    "store_id": "3290"
+  },
+  {
+    "url": "https://www.target.com/sl/staten-island-forest-ave/3291",
+    "slug": "staten-island-forest-ave",
+    "store_id": "3291"
+  },
+  {
+    "url": "https://www.target.com/sl/dallas-preston-center/3292",
+    "slug": "dallas-preston-center",
+    "store_id": "3292"
+  },
+  {
+    "url": "https://www.target.com/sl/la-canada-flintridge/3293",
+    "slug": "la-canada-flintridge",
+    "store_id": "3293"
+  },
+  {
+    "url": "https://www.target.com/sl/la-mid-city/3294",
+    "slug": "la-mid-city",
+    "store_id": "3294"
+  },
+  {
+    "url": "https://www.target.com/sl/haddon-township/3296",
+    "slug": "haddon-township",
+    "store_id": "3296"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-barbara-galleria/3298",
+    "slug": "santa-barbara-galleria",
+    "store_id": "3298"
+  },
+  {
+    "url": "https://www.target.com/sl/san-diego-north-park/3302",
+    "slug": "san-diego-north-park",
+    "store_id": "3302"
+  },
+  {
+    "url": "https://www.target.com/sl/ocean-beach/3303",
+    "slug": "ocean-beach",
+    "store_id": "3303"
+  },
+  {
+    "url": "https://www.target.com/sl/cambridge-porter-square/3304",
+    "slug": "cambridge-porter-square",
+    "store_id": "3304"
+  },
+  {
+    "url": "https://www.target.com/sl/burlington-ma/3305",
+    "slug": "burlington-ma",
+    "store_id": "3305"
+  },
+  {
+    "url": "https://www.target.com/sl/south-burlington/3306",
+    "slug": "south-burlington",
+    "store_id": "3306"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-wicker-park/3307",
+    "slug": "chicago-wicker-park",
+    "store_id": "3307"
+  },
+  {
+    "url": "https://www.target.com/sl/west-lafayette-state-street/3309",
+    "slug": "west-lafayette-state-street",
+    "store_id": "3309"
+  },
+  {
+    "url": "https://www.target.com/sl/devon/3310",
+    "slug": "devon",
+    "store_id": "3310"
+  },
+  {
+    "url": "https://www.target.com/sl/upper-east-side-70th-and-3rd/3312",
+    "slug": "upper-east-side-70th-and-3rd",
+    "store_id": "3312"
+  },
+  {
+    "url": "https://www.target.com/sl/lexington-campus/3313",
+    "slug": "lexington-campus",
+    "store_id": "3313"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-mayfair/3314",
+    "slug": "chicago-mayfair",
+    "store_id": "3314"
+  },
+  {
+    "url": "https://www.target.com/sl/mission-viejo-south/3315",
+    "slug": "mission-viejo-south",
+    "store_id": "3315"
+  },
+  {
+    "url": "https://www.target.com/sl/provo-state-st-and-bulldog-blvd-ut/3316",
+    "slug": "provo-state-st-and-bulldog-blvd-ut",
+    "store_id": "3316"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-logan-square-milwaukee/3317",
+    "slug": "chicago-logan-square-milwaukee",
+    "store_id": "3317"
+  },
+  {
+    "url": "https://www.target.com/sl/selden/3318",
+    "slug": "selden",
+    "store_id": "3318"
+  },
+  {
+    "url": "https://www.target.com/sl/spring-valley-jamacha-rd/3319",
+    "slug": "spring-valley-jamacha-rd",
+    "store_id": "3319"
+  },
+  {
+    "url": "https://www.target.com/sl/dc-new-york-ave-ne/3320",
+    "slug": "dc-new-york-ave-ne",
+    "store_id": "3320"
+  },
+  {
+    "url": "https://www.target.com/sl/kips-bay/3321",
+    "slug": "kips-bay",
+    "store_id": "3321"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-grove-central/3322",
+    "slug": "miami-grove-central",
+    "store_id": "3322"
+  },
+  {
+    "url": "https://www.target.com/sl/las-vegas-showcase/3323",
+    "slug": "las-vegas-showcase",
+    "store_id": "3323"
+  },
+  {
+    "url": "https://www.target.com/sl/hyannis-cape-cod/3324",
+    "slug": "hyannis-cape-cod",
+    "store_id": "3324"
+  },
+  {
+    "url": "https://www.target.com/sl/north-quincy-t-station/3325",
+    "slug": "north-quincy-t-station",
+    "store_id": "3325"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-kings-hwy/3326",
+    "slug": "brooklyn-kings-hwy",
+    "store_id": "3326"
+  },
+  {
+    "url": "https://www.target.com/sl/georgia-and-eastern/3328",
+    "slug": "georgia-and-eastern",
+    "store_id": "3328"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-washington-heights/3329",
+    "slug": "manhattan-washington-heights",
+    "store_id": "3329"
+  },
+  {
+    "url": "https://www.target.com/sl/bishops-corner/3333",
+    "slug": "bishops-corner",
+    "store_id": "3333"
+  },
+  {
+    "url": "https://www.target.com/sl/upper-west-side-61st-and-broadway/3334",
+    "slug": "upper-west-side-61st-and-broadway",
+    "store_id": "3334"
+  },
+  {
+    "url": "https://www.target.com/sl/san-marcos-downtown/3335",
+    "slug": "san-marcos-downtown",
+    "store_id": "3335"
+  },
+  {
+    "url": "https://www.target.com/sl/lawndale-hawthorne-blvd/3336",
+    "slug": "lawndale-hawthorne-blvd",
+    "store_id": "3336"
+  },
+  {
+    "url": "https://www.target.com/sl/harlem-125th-st/3337",
+    "slug": "harlem-125th-st",
+    "store_id": "3337"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-monica-16th-and-wilshire/3338",
+    "slug": "santa-monica-16th-and-wilshire",
+    "store_id": "3338"
+  },
+  {
+    "url": "https://www.target.com/sl/oxon-hill/3339",
+    "slug": "oxon-hill",
+    "store_id": "3339"
+  },
+  {
+    "url": "https://www.target.com/sl/champaign-campustown/3341",
+    "slug": "champaign-campustown",
+    "store_id": "3341"
+  },
+  {
+    "url": "https://www.target.com/sl/austin-saltillo/3342",
+    "slug": "austin-saltillo",
+    "store_id": "3342"
+  },
+  {
+    "url": "https://www.target.com/sl/inglewood-florence-and-la-brea/3343",
+    "slug": "inglewood-florence-and-la-brea",
+    "store_id": "3343"
+  },
+  {
+    "url": "https://www.target.com/sl/santa-monica-broadway-and-5th-st/3344",
+    "slug": "santa-monica-broadway-and-5th-st",
+    "store_id": "3344"
+  },
+  {
+    "url": "https://www.target.com/sl/encino-ventura-blvd/3345",
+    "slug": "encino-ventura-blvd",
+    "store_id": "3345"
+  },
+  {
+    "url": "https://www.target.com/sl/hollywood-galaxy/3346",
+    "slug": "hollywood-galaxy",
+    "store_id": "3346"
+  },
+  {
+    "url": "https://www.target.com/sl/la-18th-and-la-cienega/3347",
+    "slug": "la-18th-and-la-cienega",
+    "store_id": "3347"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-lincoln-park-south-webster/3349",
+    "slug": "chicago-lincoln-park-south-webster",
+    "store_id": "3349"
+  },
+  {
+    "url": "https://www.target.com/sl/coral-gables/3350",
+    "slug": "coral-gables",
+    "store_id": "3350"
+  },
+  {
+    "url": "https://www.target.com/sl/dc-tenleytown/3351",
+    "slug": "dc-tenleytown",
+    "store_id": "3351"
+  },
+  {
+    "url": "https://www.target.com/sl/daly-city-westlake/3353",
+    "slug": "daly-city-westlake",
+    "store_id": "3353"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando-vineland/3354",
+    "slug": "orlando-vineland",
+    "store_id": "3354"
+  },
+  {
+    "url": "https://www.target.com/sl/placerville/3355",
+    "slug": "placerville",
+    "store_id": "3355"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-bay-parkway/3356",
+    "slug": "brooklyn-bay-parkway",
+    "store_id": "3356"
+  },
+  {
+    "url": "https://www.target.com/sl/la-labrea-and-4th-st/3359",
+    "slug": "la-labrea-and-4th-st",
+    "store_id": "3359"
+  },
+  {
+    "url": "https://www.target.com/sl/rolling-hills/3360",
+    "slug": "rolling-hills",
+    "store_id": "3360"
+  },
+  {
+    "url": "https://www.target.com/sl/athens-broad-street/3362",
+    "slug": "athens-broad-street",
+    "store_id": "3362"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-dorchester-fields-corner/3363",
+    "slug": "boston-dorchester-fields-corner",
+    "store_id": "3363"
+  },
+  {
+    "url": "https://www.target.com/sl/salt-lake-city-sugar-house/3365",
+    "slug": "salt-lake-city-sugar-house",
+    "store_id": "3365"
+  },
+  {
+    "url": "https://www.target.com/sl/san-juan-capistrano/3366",
+    "slug": "san-juan-capistrano",
+    "store_id": "3366"
+  },
+  {
+    "url": "https://www.target.com/sl/boston-beacon-hill/3368",
+    "slug": "boston-beacon-hill",
+    "store_id": "3368"
+  },
+  {
+    "url": "https://www.target.com/sl/uc-san-diego-price-center/3369",
+    "slug": "uc-san-diego-price-center",
+    "store_id": "3369"
+  },
+  {
+    "url": "https://www.target.com/sl/la-westchester-sepulveda-blvd/3371",
+    "slug": "la-westchester-sepulveda-blvd",
+    "store_id": "3371"
+  },
+  {
+    "url": "https://www.target.com/sl/queens-jamaica-avenue/3372",
+    "slug": "queens-jamaica-avenue",
+    "store_id": "3372"
+  },
+  {
+    "url": "https://www.target.com/sl/iowa-city-downtown/3374",
+    "slug": "iowa-city-downtown",
+    "store_id": "3374"
+  },
+  {
+    "url": "https://www.target.com/sl/houston-montrose/3375",
+    "slug": "houston-montrose",
+    "store_id": "3375"
+  },
+  {
+    "url": "https://www.target.com/sl/taylorsville/3376",
+    "slug": "taylorsville",
+    "store_id": "3376"
+  },
+  {
+    "url": "https://www.target.com/sl/orlando-flamingo-crossings/3378",
+    "slug": "orlando-flamingo-crossings",
+    "store_id": "3378"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-union-square/3380",
+    "slug": "manhattan-union-square",
+    "store_id": "3380"
+  },
+  {
+    "url": "https://www.target.com/sl/lawrence-five-towns/3382",
+    "slug": "lawrence-five-towns",
+    "store_id": "3382"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-downtown/3383",
+    "slug": "miami-downtown",
+    "store_id": "3383"
+  },
+  {
+    "url": "https://www.target.com/sl/sacramento-midtown/3384",
+    "slug": "sacramento-midtown",
+    "store_id": "3384"
+  },
+  {
+    "url": "https://www.target.com/sl/times-square-42nd-street/3385",
+    "slug": "times-square-42nd-street",
+    "store_id": "3385"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-university-hills-plaza/3386",
+    "slug": "denver-university-hills-plaza",
+    "store_id": "3386"
+  },
+  {
+    "url": "https://www.target.com/sl/upper-east-side-86th-and-lex/3387",
+    "slug": "upper-east-side-86th-and-lex",
+    "store_id": "3387"
+  },
+  {
+    "url": "https://www.target.com/sl/wynnewood/3389",
+    "slug": "wynnewood",
+    "store_id": "3389"
+  },
+  {
+    "url": "https://www.target.com/sl/costa-mesa-17th-st/3391",
+    "slug": "costa-mesa-17th-st",
+    "store_id": "3391"
+  },
+  {
+    "url": "https://www.target.com/sl/pittsburgh-downtown/3392",
+    "slug": "pittsburgh-downtown",
+    "store_id": "3392"
+  },
+  {
+    "url": "https://www.target.com/sl/la-bonnie-brae/3393",
+    "slug": "la-bonnie-brae",
+    "store_id": "3393"
+  },
+  {
+    "url": "https://www.target.com/sl/upper-west-side-98th-and-columbus/3394",
+    "slug": "upper-west-side-98th-and-columbus",
+    "store_id": "3394"
+  },
+  {
+    "url": "https://www.target.com/sl/bronx-fordham-road/3395",
+    "slug": "bronx-fordham-road",
+    "store_id": "3395"
+  },
+  {
+    "url": "https://www.target.com/sl/bradenton-beach/3396",
+    "slug": "bradenton-beach",
+    "store_id": "3396"
+  },
+  {
+    "url": "https://www.target.com/sl/port-chester/3399",
+    "slug": "port-chester",
+    "store_id": "3399"
+  },
+  {
+    "url": "https://www.target.com/sl/lihue-kauai/3400",
+    "slug": "lihue-kauai",
+    "store_id": "3400"
+  },
+  {
+    "url": "https://www.target.com/sl/west-lebanon-main-st/3401",
+    "slug": "west-lebanon-main-st",
+    "store_id": "3401"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-river-north/3402",
+    "slug": "chicago-river-north",
+    "store_id": "3402"
+  },
+  {
+    "url": "https://www.target.com/sl/denver-lowry/3403",
+    "slug": "denver-lowry",
+    "store_id": "3403"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-flatbush-and-church/3404",
+    "slug": "brooklyn-flatbush-and-church",
+    "store_id": "3404"
+  },
+  {
+    "url": "https://www.target.com/sl/madison-state-street/3405",
+    "slug": "madison-state-street",
+    "store_id": "3405"
+  },
+  {
+    "url": "https://www.target.com/sl/la-huntington-park/3406",
+    "slug": "la-huntington-park",
+    "store_id": "3406"
+  },
+  {
+    "url": "https://www.target.com/sl/moscow-west-pullman-road/3407",
+    "slug": "moscow-west-pullman-road",
+    "store_id": "3407"
+  },
+  {
+    "url": "https://www.target.com/sl/wall-township/3408",
+    "slug": "wall-township",
+    "store_id": "3408"
+  },
+  {
+    "url": "https://www.target.com/sl/jackson-hole/3409",
+    "slug": "jackson-hole",
+    "store_id": "3409"
+  },
+  {
+    "url": "https://www.target.com/sl/scotts-valley/3410",
+    "slug": "scotts-valley",
+    "store_id": "3410"
+  },
+  {
+    "url": "https://www.target.com/sl/manhattan-soho/3411",
+    "slug": "manhattan-soho",
+    "store_id": "3411"
+  },
+  {
+    "url": "https://www.target.com/sl/chelsea-23rd-and-8th/3412",
+    "slug": "chelsea-23rd-and-8th",
+    "store_id": "3412"
+  },
+  {
+    "url": "https://www.target.com/sl/cedar-mill/3413",
+    "slug": "cedar-mill",
+    "store_id": "3413"
+  },
+  {
+    "url": "https://www.target.com/sl/outer-banks/3414",
+    "slug": "outer-banks",
+    "store_id": "3414"
+  },
+  {
+    "url": "https://www.target.com/sl/ann-arbor-state-street/3415",
+    "slug": "ann-arbor-state-street",
+    "store_id": "3415"
+  },
+  {
+    "url": "https://www.target.com/sl/fort-collins-old-town/3416",
+    "slug": "fort-collins-old-town",
+    "store_id": "3416"
+  },
+  {
+    "url": "https://www.target.com/sl/kent-island/3419",
+    "slug": "kent-island",
+    "store_id": "3419"
+  },
+  {
+    "url": "https://www.target.com/sl/miami-nw-7th-street/3420",
+    "slug": "miami-nw-7th-street",
+    "store_id": "3420"
+  },
+  {
+    "url": "https://www.target.com/sl/auburn-toomers-corner/3421",
+    "slug": "auburn-toomers-corner",
+    "store_id": "3421"
+  },
+  {
+    "url": "https://www.target.com/sl/huntington-beach-garfield-and-beach/3422",
+    "slug": "huntington-beach-garfield-and-beach",
+    "store_id": "3422"
+  },
+  {
+    "url": "https://www.target.com/sl/homestead/3424",
+    "slug": "homestead",
+    "store_id": "3424"
+  },
+  {
+    "url": "https://www.target.com/sl/noho-valley-plaza/3427",
+    "slug": "noho-valley-plaza",
+    "store_id": "3427"
+  },
+  {
+    "url": "https://www.target.com/sl/charleston-king-street/3428",
+    "slug": "charleston-king-street",
+    "store_id": "3428"
+  },
+  {
+    "url": "https://www.target.com/sl/brooklyn-kings-plaza/3429",
+    "slug": "brooklyn-kings-plaza",
+    "store_id": "3429"
+  },
+  {
+    "url": "https://www.target.com/sl/pentagon-city-army-navy-dr/3430",
+    "slug": "pentagon-city-army-navy-dr",
+    "store_id": "3430"
+  },
+  {
+    "url": "https://www.target.com/sl/eatontown-plaza/3432",
+    "slug": "eatontown-plaza",
+    "store_id": "3432"
+  },
+  {
+    "url": "https://www.target.com/sl/lic-court-square/3433",
+    "slug": "lic-court-square",
+    "store_id": "3433"
+  },
+  {
+    "url": "https://www.target.com/sl/woodmere-village-square/3437",
+    "slug": "woodmere-village-square",
+    "store_id": "3437"
+  },
+  {
+    "url": "https://www.target.com/sl/oahu-waikiki/3438",
+    "slug": "oahu-waikiki",
+    "store_id": "3438"
+  },
+  {
+    "url": "https://www.target.com/sl/st.-louis-midtown/3439",
+    "slug": "st.-louis-midtown",
+    "store_id": "3439"
+  },
+  {
+    "url": "https://www.target.com/sl/jersey-city-journal-square/3440",
+    "slug": "jersey-city-journal-square",
+    "store_id": "3440"
+  },
+  {
+    "url": "https://www.target.com/sl/mandeville/3441",
+    "slug": "mandeville",
+    "store_id": "3441"
+  },
+  {
+    "url": "https://www.target.com/sl/yorba-linda/3445",
+    "slug": "yorba-linda",
+    "store_id": "3445"
+  },
+  {
+    "url": "https://www.target.com/sl/north-ontario/3446",
+    "slug": "north-ontario",
+    "store_id": "3446"
+  },
+  {
+    "url": "https://www.target.com/sl/chicago-portage-park/3447",
+    "slug": "chicago-portage-park",
+    "store_id": "3447"
+  },
+  {
+    "url": "https://www.target.com/sl/lomita/3451",
+    "slug": "lomita",
+    "store_id": "3451"
+  },
+  {
+    "url": "https://www.target.com/sl/south-lake-tahoe/3452",
+    "slug": "south-lake-tahoe",
+    "store_id": "3452"
+  },
+  {
+    "url": "https://www.target.com/sl/doylestown/3453",
+    "slug": "doylestown",
+    "store_id": "3453"
+  },
+  {
+    "url": "https://www.target.com/sl/store-labs-saturn/7819",
+    "slug": "store-labs-saturn",
+    "store_id": "7819"
+  }
+]

--- a/target-scraper/results/stores.json
+++ b/target-scraper/results/stores.json
@@ -1,0 +1,3916 @@
+[
+  {
+    "store_id": "5",
+    "location_name": "Bloomington 79th and Penn",
+    "status": "Open",
+    "is_test_location": false,
+    "geofence": {
+      "latitude": 44.860029,
+      "longitude": -93.311579,
+      "radius": 166
+    },
+    "mailing_address": {
+      "address_line1": "2555 W 79th St",
+      "city": "Bloomington",
+      "country": "United States of America",
+      "country_code": "US",
+      "county": "Hennepin",
+      "state": "Minnesota",
+      "postal_code": "55431-1250",
+      "region": "MN"
+    },
+    "main_voice_phone_number": "952-888-7701",
+    "capabilities": [
+      {
+        "capability_code": "Drive Up",
+        "capability_name": "Drive Up",
+        "effective_date": "2018-03-14"
+      },
+      {
+        "capability_code": "Eye Exam Warby",
+        "capability_name": "Eye exams at Warby Parker",
+        "effective_date": "2025-11-14"
+      },
+      {
+        "capability_code": "CVS pharmacy",
+        "capability_name": "CVS pharmacy",
+        "effective_date": "2016-05-13"
+      },
+      {
+        "capability_code": "Warby Parker",
+        "capability_name": "Warby Parker at Target",
+        "effective_date": "2025-07-30"
+      },
+      {
+        "capability_code": "WIC",
+        "capability_name": "Accepts WIC",
+        "effective_date": "2013-05-01"
+      },
+      {
+        "capability_code": "Shipt Delivery",
+        "capability_name": "Shipt Delivery",
+        "effective_date": "2021-09-23"
+      },
+      {
+        "capability_code": "Cafe-Pizza",
+        "capability_name": "Café-Pizza",
+        "effective_date": "2013-09-10"
+      },
+      {
+        "capability_code": "EV Charging",
+        "capability_name": "EV Charging",
+        "effective_date": "2023-11-06"
+      },
+      {
+        "capability_code": "Ulta",
+        "capability_name": "Ulta Beauty at Target",
+        "effective_date": "2021-08-15"
+      },
+      {
+        "capability_code": "Fresh Grocery",
+        "capability_name": "Fresh Grocery",
+        "effective_date": "2010-04-15"
+      },
+      {
+        "capability_code": "Mobile",
+        "capability_name": "AT&T Cell Phone Activations",
+        "effective_date": "2010-09-09"
+      },
+      {
+        "capability_code": "Starbucks",
+        "capability_name": "Starbucks Cafe",
+        "effective_date": "2004-10-02"
+      },
+      {
+        "capability_code": "Store Pickup",
+        "capability_name": "Store Pickup",
+        "effective_date": "2019-02-28"
+      },
+      {
+        "capability_code": "PokemonX",
+        "capability_name": "Pokemon x Target",
+        "effective_date": "2026-04-15"
+      },
+      {
+        "capability_code": "Hollister",
+        "capability_name": "The Hollister Collection at Target",
+        "effective_date": "2026-06-18"
+      },
+      {
+        "capability_code": "LoveShackFancy",
+        "capability_name": "Love Shack Fancy X Target",
+        "effective_date": "2026-06-24",
+        "expiration_date": "2026-08-21"
+      }
+    ],
+    "drive_up": {
+      "latitude": 44.859999,
+      "longitude": -93.311424,
+      "radius": 47
+    },
+    "contact_information": [
+      {
+        "building_area": "Capability",
+        "capability": "Mobile",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "952-888-7701"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "952-888-4677"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "952-356-3921"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "952-888-7701"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "952-356-3920"
+      }
+    ],
+    "physical_specifications": {
+      "total_building_area": 148756,
+      "merchandise_level": 1,
+      "format": "Pfresh"
+    },
+    "geographic_specifications": {
+      "latitude": 44.860029,
+      "longitude": -93.311579,
+      "time_zone_code": "CST",
+      "time_zone_description": "Central Std Time",
+      "time_zone_utc_offset_name": "UTC-06",
+      "time_zone_offset_hours": "06:00:00",
+      "is_daylight_savings_time_recognized": true,
+      "iso_time_zone_code": "America/Chicago"
+    },
+    "miscellaneous": {
+      "google_cid": "https://maps.google.com/maps?cid=2820580094994725596"
+    },
+    "rolling_operating_hours": {
+      "main_hours": {
+        "days": [
+          {
+            "sequence_number": "1",
+            "date": "2026-07-07",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-07",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-07",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "2",
+            "date": "2026-07-08",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-08",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-08",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "3",
+            "date": "2026-07-09",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-09",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-09",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "4",
+            "date": "2026-07-10",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-10",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-10",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "5",
+            "date": "2026-07-11",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-11",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-11",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "6",
+            "date": "2026-07-12",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-12",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-12",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "7",
+            "date": "2026-07-13",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-13",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-13",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "8",
+            "date": "2026-07-14",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-14",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-14",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "9",
+            "date": "2026-07-15",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-15",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-15",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "10",
+            "date": "2026-07-16",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-16",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-16",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "11",
+            "date": "2026-07-17",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-17",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-17",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "12",
+            "date": "2026-07-18",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-18",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-18",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "13",
+            "date": "2026-07-19",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-19",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-19",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "14",
+            "date": "2026-07-20",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-20",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-20",
+                "end_time": "22:00:00"
+              }
+            ]
+          }
+        ]
+      },
+      "capability_hours": [
+        {
+          "capability_code": "Mobile",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Starbucks",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "20:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "CVS pharmacy",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Warby Parker",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "12:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "12:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "18:00:00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "store_id": "4",
+    "location_name": "Duluth",
+    "status": "Open",
+    "is_test_location": false,
+    "geofence": {
+      "latitude": 46.808391,
+      "longitude": -92.16745,
+      "radius": 170
+    },
+    "mailing_address": {
+      "address_line1": "1902 Miller Trunk Hwy",
+      "city": "Duluth",
+      "country": "United States of America",
+      "country_code": "US",
+      "county": "St. Louis",
+      "state": "Minnesota",
+      "postal_code": "55811-1810",
+      "region": "MN"
+    },
+    "main_voice_phone_number": "218-727-8851",
+    "capabilities": [
+      {
+        "capability_code": "Kendra Scott",
+        "capability_name": "Kendra Scott x Target",
+        "effective_date": "2023-10-08"
+      },
+      {
+        "capability_code": "Drive Up",
+        "capability_name": "Drive Up",
+        "effective_date": "2019-08-26"
+      },
+      {
+        "capability_code": "Opt",
+        "capability_name": "Target Optical",
+        "effective_date": "2001-07-01"
+      },
+      {
+        "capability_code": "WIC",
+        "capability_name": "Accepts WIC",
+        "effective_date": "2013-05-01"
+      },
+      {
+        "capability_code": "Apple",
+        "capability_name": "Apple Experience",
+        "effective_date": "2023-06-21"
+      },
+      {
+        "capability_code": "Shipt Delivery",
+        "capability_name": "Shipt Delivery",
+        "effective_date": "2021-11-04"
+      },
+      {
+        "capability_code": "Fresh Grocery",
+        "capability_name": "Fresh Grocery",
+        "effective_date": "2009-07-09"
+      },
+      {
+        "capability_code": "Mobile",
+        "capability_name": "AT&T Cell Phone Activations",
+        "effective_date": "2010-10-15"
+      },
+      {
+        "capability_code": "PokemonX",
+        "capability_name": "Pokemon x Target",
+        "effective_date": "2026-04-15"
+      },
+      {
+        "capability_code": "ParkeXTarget",
+        "capability_name": "Parke x Target",
+        "effective_date": "2026-04-21"
+      },
+      {
+        "capability_code": "Wine Beer Spir",
+        "capability_name": "Wine, Beer & Spirits Available",
+        "effective_date": "2022-11-15"
+      },
+      {
+        "capability_code": "Snack Bar Pizza",
+        "capability_name": "Snack Bar - Pizza",
+        "effective_date": "2023-10-04"
+      },
+      {
+        "capability_code": "CVS pharmacy",
+        "capability_name": "CVS pharmacy",
+        "effective_date": "2016-04-29"
+      },
+      {
+        "capability_code": "Ulta",
+        "capability_name": "Ulta Beauty at Target",
+        "effective_date": "2022-07-31"
+      },
+      {
+        "capability_code": "Starbucks",
+        "capability_name": "Starbucks Cafe",
+        "effective_date": "2011-05-02"
+      },
+      {
+        "capability_code": "Converse",
+        "capability_name": "Converse",
+        "effective_date": "2025-07-20"
+      },
+      {
+        "capability_code": "Store Pickup",
+        "capability_name": "Store Pickup",
+        "effective_date": "2019-02-28"
+      },
+      {
+        "capability_code": "Champion",
+        "capability_name": "Champion",
+        "effective_date": "2026-01-19"
+      },
+      {
+        "capability_code": "Hollister",
+        "capability_name": "The Hollister Collection at Target",
+        "effective_date": "2026-06-18"
+      },
+      {
+        "capability_code": "LoveShackFancy",
+        "capability_name": "Love Shack Fancy X Target",
+        "effective_date": "2026-06-24",
+        "expiration_date": "2026-08-21"
+      }
+    ],
+    "drive_up": {
+      "latitude": 46.80838,
+      "longitude": -92.167435,
+      "radius": 49
+    },
+    "contact_information": [
+      {
+        "building_area": "Capability",
+        "capability": "Mobile",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "218-727-8851"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "Opt",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "218-213-9521"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "218-727-8475"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "218-213-9525"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "218-727-8851"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "218-213-9524"
+      }
+    ],
+    "physical_specifications": {
+      "total_building_area": 155559,
+      "merchandise_level": 1,
+      "format": "Pfresh"
+    },
+    "geographic_specifications": {
+      "latitude": 46.808391,
+      "longitude": -92.16745,
+      "time_zone_code": "CST",
+      "time_zone_description": "Central Std Time",
+      "time_zone_utc_offset_name": "UTC-06",
+      "time_zone_offset_hours": "06:00:00",
+      "is_daylight_savings_time_recognized": true,
+      "iso_time_zone_code": "America/Chicago"
+    },
+    "miscellaneous": {
+      "google_cid": "https://maps.google.com/maps?cid=17309704771221185075"
+    },
+    "rolling_operating_hours": {
+      "main_hours": {
+        "days": [
+          {
+            "sequence_number": "1",
+            "date": "2026-07-07",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-07",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-07",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "2",
+            "date": "2026-07-08",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-08",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-08",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "3",
+            "date": "2026-07-09",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-09",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-09",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "4",
+            "date": "2026-07-10",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-10",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-10",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "5",
+            "date": "2026-07-11",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-11",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-11",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "6",
+            "date": "2026-07-12",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-12",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-12",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "7",
+            "date": "2026-07-13",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-13",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-13",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "8",
+            "date": "2026-07-14",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-14",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-14",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "9",
+            "date": "2026-07-15",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-15",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-15",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "10",
+            "date": "2026-07-16",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-16",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-16",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "11",
+            "date": "2026-07-17",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-17",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-17",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "12",
+            "date": "2026-07-18",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-18",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-18",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "13",
+            "date": "2026-07-19",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-19",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-19",
+                "end_time": "23:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "14",
+            "date": "2026-07-20",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-20",
+                "begin_time": "07:00:00",
+                "end_date": "2026-07-20",
+                "end_time": "23:00:00"
+              }
+            ]
+          }
+        ]
+      },
+      "capability_hours": [
+        {
+          "capability_code": "Mobile",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Opt",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "12:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "16:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "12:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "16:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Starbucks",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "07:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "20:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "CVS pharmacy",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Wine Beer Spir",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "22:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Adult Bev PU",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "22:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "22:00:00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "store_id": "3",
+    "location_name": "Crystal",
+    "status": "Open",
+    "is_test_location": false,
+    "geofence": {
+      "latitude": 45.052732,
+      "longitude": -93.365555,
+      "radius": 163
+    },
+    "mailing_address": {
+      "address_line1": "5537 W Broadway Ave",
+      "city": "Crystal",
+      "country": "United States of America",
+      "country_code": "US",
+      "county": "Hennepin",
+      "state": "Minnesota",
+      "postal_code": "55428-3507",
+      "region": "MN"
+    },
+    "main_voice_phone_number": "763-533-2231",
+    "capabilities": [
+      {
+        "capability_code": "Drive Up",
+        "capability_name": "Drive Up",
+        "effective_date": "2018-03-14"
+      },
+      {
+        "capability_code": "CVS pharmacy",
+        "capability_name": "CVS pharmacy",
+        "effective_date": "2016-05-06"
+      },
+      {
+        "capability_code": "WIC",
+        "capability_name": "Accepts WIC",
+        "effective_date": "2013-05-01"
+      },
+      {
+        "capability_code": "Shipt Delivery",
+        "capability_name": "Shipt Delivery",
+        "effective_date": "2018-03-16"
+      },
+      {
+        "capability_code": "Cafe-Pizza",
+        "capability_name": "Café-Pizza",
+        "effective_date": "2013-09-10"
+      },
+      {
+        "capability_code": "Fresh Grocery",
+        "capability_name": "Fresh Grocery",
+        "effective_date": "2010-04-15"
+      },
+      {
+        "capability_code": "Mobile",
+        "capability_name": "AT&T Cell Phone Activations",
+        "effective_date": "2010-08-16"
+      },
+      {
+        "capability_code": "Starbucks",
+        "capability_name": "Starbucks Cafe",
+        "effective_date": "2004-10-02"
+      },
+      {
+        "capability_code": "Store Pickup",
+        "capability_name": "Store Pickup",
+        "effective_date": "2019-02-28"
+      },
+      {
+        "capability_code": "Champion",
+        "capability_name": "Champion",
+        "effective_date": "2026-01-19"
+      },
+      {
+        "capability_code": "PokemonX",
+        "capability_name": "Pokemon x Target",
+        "effective_date": "2026-04-15"
+      },
+      {
+        "capability_code": "Hollister",
+        "capability_name": "The Hollister Collection at Target",
+        "effective_date": "2026-06-18"
+      },
+      {
+        "capability_code": "LoveShackFancy",
+        "capability_name": "Love Shack Fancy X Target",
+        "effective_date": "2026-06-24",
+        "expiration_date": "2026-08-21"
+      }
+    ],
+    "drive_up": {
+      "latitude": 45.052636,
+      "longitude": -93.36533,
+      "radius": 47
+    },
+    "contact_information": [
+      {
+        "building_area": "Capability",
+        "capability": "Mobile",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "763-533-2231"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "763-533-1651"
+      },
+      {
+        "building_area": "Capability",
+        "capability": "CVS pharmacy",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "763-252-2005"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "VOICE",
+        "is_international_phone_number": false,
+        "telephone_number": "763-533-2231"
+      },
+      {
+        "building_area": "MAIN",
+        "telephone_type": "FAX",
+        "is_international_phone_number": false,
+        "telephone_number": "763-252-2003"
+      }
+    ],
+    "physical_specifications": {
+      "total_building_area": 143186,
+      "merchandise_level": 1,
+      "format": "Pfresh"
+    },
+    "geographic_specifications": {
+      "latitude": 45.052732,
+      "longitude": -93.365555,
+      "time_zone_code": "CST",
+      "time_zone_description": "Central Std Time",
+      "time_zone_utc_offset_name": "UTC-06",
+      "time_zone_offset_hours": "06:00:00",
+      "is_daylight_savings_time_recognized": true,
+      "iso_time_zone_code": "America/Chicago"
+    },
+    "miscellaneous": {
+      "google_cid": "https://maps.google.com/maps?cid=3989297578078319655"
+    },
+    "rolling_operating_hours": {
+      "main_hours": {
+        "days": [
+          {
+            "sequence_number": "1",
+            "date": "2026-07-07",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-07",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-07",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "2",
+            "date": "2026-07-08",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-08",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-08",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "3",
+            "date": "2026-07-09",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-09",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-09",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "4",
+            "date": "2026-07-10",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-10",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-10",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "5",
+            "date": "2026-07-11",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-11",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-11",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "6",
+            "date": "2026-07-12",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-12",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-12",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "7",
+            "date": "2026-07-13",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-13",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-13",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "8",
+            "date": "2026-07-14",
+            "day_name": "Tuesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-14",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-14",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "9",
+            "date": "2026-07-15",
+            "day_name": "Wednesday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-15",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-15",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "10",
+            "date": "2026-07-16",
+            "day_name": "Thursday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-16",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-16",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "11",
+            "date": "2026-07-17",
+            "day_name": "Friday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-17",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-17",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "12",
+            "date": "2026-07-18",
+            "day_name": "Saturday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-18",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-18",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "13",
+            "date": "2026-07-19",
+            "day_name": "Sunday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-19",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-19",
+                "end_time": "22:00:00"
+              }
+            ]
+          },
+          {
+            "sequence_number": "14",
+            "date": "2026-07-20",
+            "day_name": "Monday",
+            "is_open": true,
+            "hours": [
+              {
+                "begin_date": "2026-07-20",
+                "begin_time": "08:00:00",
+                "end_date": "2026-07-20",
+                "end_time": "22:00:00"
+              }
+            ]
+          }
+        ]
+      },
+      "capability_hours": [
+        {
+          "capability_code": "Mobile",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": false
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "Starbucks",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "20:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "08:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "20:00:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "capability_code": "CVS pharmacy",
+          "days": [
+            {
+              "sequence_number": "1",
+              "date": "2026-07-07",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-07",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-07",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "2",
+              "date": "2026-07-08",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-08",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-08",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "3",
+              "date": "2026-07-09",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-09",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-09",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "4",
+              "date": "2026-07-10",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-10",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-10",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "5",
+              "date": "2026-07-11",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-11",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-11",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "6",
+              "date": "2026-07-12",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-12",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-12",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "7",
+              "date": "2026-07-13",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-13",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-13",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "8",
+              "date": "2026-07-14",
+              "day_name": "Tuesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-14",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-14",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "9",
+              "date": "2026-07-15",
+              "day_name": "Wednesday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-15",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-15",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "10",
+              "date": "2026-07-16",
+              "day_name": "Thursday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-16",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-16",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "11",
+              "date": "2026-07-17",
+              "day_name": "Friday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-17",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-17",
+                  "end_time": "19:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "12",
+              "date": "2026-07-18",
+              "day_name": "Saturday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "10:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-18",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-18",
+                  "end_time": "18:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "13",
+              "date": "2026-07-19",
+              "day_name": "Sunday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "11:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-19",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-19",
+                  "end_time": "17:00:00"
+                }
+              ]
+            },
+            {
+              "sequence_number": "14",
+              "date": "2026-07-20",
+              "day_name": "Monday",
+              "is_open": true,
+              "hours": [
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "09:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "13:30:00"
+                },
+                {
+                  "begin_date": "2026-07-20",
+                  "begin_time": "14:00:00",
+                  "end_date": "2026-07-20",
+                  "end_time": "19:00:00"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+]

--- a/target-scraper/run.py
+++ b/target-scraper/run.py
@@ -20,14 +20,13 @@ async def run():
     print("running Target scrape and saving results to ./results directory")
 
     # scrape a single product detail page by URL
-    # store/pricing context comes from Target's page session when the PDP loads
     product_data = await target.scrape_product(
         "https://www.target.com/p/women-s-lace-godet-tank-top-wild-fable/-/A-95213693"
     )
     with open(output.joinpath("product.json"), "w", encoding="utf-8") as file:
         json.dump(product_data, file, indent=2, ensure_ascii=False)
 
-    # scrape availability/fulfillment for a set of TCINs at a given store and zip
+    # # scrape availability/fulfillment for a set of TCINs at a given store and zip
     availability_data = await target.scrape_availability(
         tcins=["89231676"],
         store_id="1771",
@@ -35,22 +34,28 @@ async def run():
     )
     with open(output.joinpath("availability.json"), "w", encoding="utf-8") as file:
         json.dump(availability_data, file, indent=2, ensure_ascii=False)
+        
+    # scrape store location URLs from the Target store sitemap
+    store_locations_data = await target.scrape_store_locations_sitemap(
+        url="https://www.target.com/sl/sitemap_0001.xml.gz",
+    )
+    with open(output.joinpath("store_locations.json"), "w", encoding="utf-8") as file:
+        json.dump(store_locations_data, file, indent=2, ensure_ascii=False)
 
-    # # discover store IDs via the Target store sitemap
-    # store_data = await target.scrape_store_locations(
-    #     url="https://www.target.com/sitemap_stores-index.xml.gz",
-    # )
-    # with open(output.joinpath("stores.json"), "w", encoding="utf-8") as file:
-    #     json.dump(store_data, file, indent=2, ensure_ascii=False)
+    # scrape store location details by store ID
+    store_data = await target.scrape_store_locations(
+        store_ids=["3", "4", "5"],
+    )
+    with open(output.joinpath("stores.json"), "w", encoding="utf-8") as file:
+        json.dump(store_data, file, indent=2, ensure_ascii=False)
 
-    # # scrape search results for a keyword (returns TCINs and listing metadata)
-    # search_data = await target.scrape_search(
-    #     keyword="laptop",
-    #     store_id="1357",
-    #     max_pages=3,
-    # )
-    # with open(output.joinpath("search.json"), "w", encoding="utf-8") as file:
-    #     json.dump(search_data, file, indent=2, ensure_ascii=False)
+    # scrape search results for a keyword (returns TCINs and listing metadata)
+    search_data = await target.scrape_search(
+        keyword="laptop",
+        max_pages=3,
+    )
+    with open(output.joinpath("search.json"), "w", encoding="utf-8") as file:
+        json.dump(search_data, file, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/target-scraper/run.py
+++ b/target-scraper/run.py
@@ -1,0 +1,57 @@
+"""
+This example run script shows how to run the Target.com scraper defined in ./target.py
+It scrapes product data and saves it to ./results/
+
+To run this script set the env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+
+import asyncio
+import json
+from pathlib import Path
+import target
+
+output = Path(__file__).parent / "results"
+output.mkdir(exist_ok=True)
+
+
+async def run():
+    
+    print("running Target scrape and saving results to ./results directory")
+
+    # scrape a single product detail page by URL
+    # store/pricing context comes from Target's page session when the PDP loads
+    product_data = await target.scrape_product(
+        "https://www.target.com/p/women-s-lace-godet-tank-top-wild-fable/-/A-95213693"
+    )
+    with open(output.joinpath("product.json"), "w", encoding="utf-8") as file:
+        json.dump(product_data, file, indent=2, ensure_ascii=False)
+
+    # scrape availability/fulfillment for a set of TCINs at a given store and zip
+    availability_data = await target.scrape_availability(
+        tcins=["89231676"],
+        store_id="1771",
+        zip_code="52404",
+    )
+    with open(output.joinpath("availability.json"), "w", encoding="utf-8") as file:
+        json.dump(availability_data, file, indent=2, ensure_ascii=False)
+
+    # # discover store IDs via the Target store sitemap
+    # store_data = await target.scrape_store_locations(
+    #     url="https://www.target.com/sitemap_stores-index.xml.gz",
+    # )
+    # with open(output.joinpath("stores.json"), "w", encoding="utf-8") as file:
+    #     json.dump(store_data, file, indent=2, ensure_ascii=False)
+
+    # # scrape search results for a keyword (returns TCINs and listing metadata)
+    # search_data = await target.scrape_search(
+    #     keyword="laptop",
+    #     store_id="1357",
+    #     max_pages=3,
+    # )
+    # with open(output.joinpath("search.json"), "w", encoding="utf-8") as file:
+    #     json.dump(search_data, file, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/target-scraper/target.py
+++ b/target-scraper/target.py
@@ -211,6 +211,26 @@ async def scrape_availability(
     response = await SCRAPFLY.async_scrape(ScrapeConfig(url, session=session, **BASE_CONFIG))
     return parse_availability(response)
 
+def parse_store_locations_sitemap(response: ScrapeApiResponse) -> List[Dict]:
+    """parse store location entries from a sitemap response"""
+    content = response.scrape_result["content"]
+    bytes_data = content.read() if hasattr(content, "read") else content.encode("latin1")
+    if bytes_data.startswith(b"\x1f\x8b"):
+        bytes_data = gzip.decompress(bytes_data)
+    selector = Selector(text=bytes_data.decode("utf-8"))
+
+    locations = []
+    for url in selector.xpath("//url/loc/text()"):
+        url = url.get()
+        slug, store_id = urlparse(url).path.strip("/").split("/")[-2:]
+        locations.append({"url": url, "slug": slug, "store_id": store_id})
+    return locations
+
+
+async def scrape_store_locations_sitemap(url: str) -> List[Dict]:
+    """scrape store location URLs from the Target store sitemap"""
+    response = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
+    return parse_store_locations_sitemap(response)
 
 def parse_store_locations(response: ScrapeApiResponse) -> List[Dict]:
     """parse store location entries from a sitemap response"""

--- a/target-scraper/target.py
+++ b/target-scraper/target.py
@@ -5,12 +5,14 @@ To run this scraper set env variable $SCRAPFLY_KEY with your scrapfly API key:
 $ export SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
 """
 
+import gzip
 import os
 import re
 import json
 from typing import Dict, List, Optional, TypedDict
 from urllib.parse import parse_qs, urlencode, urlparse
 from uuid import uuid4
+from parsel import Selector
 from scrapfly import ScrapeConfig, ScrapflyClient, ScrapeApiResponse
 
 SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
@@ -232,25 +234,92 @@ async def scrape_store_locations_sitemap(url: str) -> List[Dict]:
     response = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
     return parse_store_locations_sitemap(response)
 
-def parse_store_locations(response: ScrapeApiResponse) -> List[Dict]:
-    """parse store location entries from a sitemap response"""
-    pass
+def parse_store_locations(response: ScrapeApiResponse) -> Dict:
+    """parse store location data from a store_location_v1 response"""
+    data = json.loads(response.content)
+    store = data.get("data", {}).get("store")
+    if store is None:
+        raise ValueError("missing data.store in store location response")
+
+    params = parse_qs(urlparse(response.context["url"]).query)
+    page = params.get("page", [""])[0]
+    if page.startswith("/sl/"):
+        slug, store_id = page.strip("/").split("/")[-2:]
+        store["slug"] = slug
+        store["url"] = f"https://www.target.com/sl/{slug}/{store_id}"
+    return store
 
 
-async def scrape_store_locations(url: str) -> List[Dict]:
-    """scrape store location URLs from the Target store sitemap (stable fallback for store-id discovery)"""
-    pass
+async def scrape_store_locations(store_ids: List[str]) -> List[Dict]:
+    """scrape store location details from store_location_v1 for a list of store IDs"""
+    session = str(uuid4()).replace("-", "")
+    warm_up = await SCRAPFLY.async_scrape(ScrapeConfig(
+        "https://www.target.com/",
+        session=session,
+        render_js=True,
+        wait_for_selector="xhr:store_location_v1",
+        rendering_wait=5000,
+        **BASE_CONFIG,
+    ))
+    credentials = _extract_redsky_credentials(warm_up)
+
+    to_scrape = [
+        ScrapeConfig(
+            "https://redsky.target.com/redsky_aggregations/v1/web/store_location_v1?" + urlencode({
+                "key": credentials["key"],
+                "visitor_id": credentials["visitor_id"],
+                "store_id": store_id,
+                "channel": "WEB",
+                "page": "/c/root",
+            }),
+            session=session,
+            **BASE_CONFIG,
+        )
+        for store_id in store_ids
+    ]
+
+    stores = []
+    async for response in SCRAPFLY.concurrent_scrape(to_scrape):
+        stores.append(parse_store_locations(response))
+    return stores
 
 
-def parse_search(response: ScrapeApiResponse) -> Dict:
-    """parse product listing data from a search API response"""
-    pass
+
+def parse_search(response: ScrapeApiResponse) -> List[Dict]:
+    """parse product listing data from a search results page"""
+    products = []
+    for card in response.selector.css('[data-test="@web/site-top-of-funnel/ProductCardWrapper"]'):
+        link = card.css('a[href*="/A-"]::attr(href)').get()
+        if not link:
+            continue
+        match = re.search(r'/A-(\d+)', link)
+        if not match:
+            continue
+        products.append({
+            "tcin": match.group(1),
+            "url": "https://www.target.com" + link.split("#")[0],
+            "title": (
+                card.css('[data-test="@web/ProductCard/title"] ::text').get()
+                or card.css('[data-test="@web/ProductCard/title"]::attr(aria-label)').get()
+            ),
+            "brand": card.css('[data-test="@web/ProductCard/ProductCardBrandAndRibbonMessage/brand"] ::text').get(),
+            "price": card.css('[data-test="current-price"] span ::text').get(),
+            "reg_price": card.css('[data-test="comparison-price"] span ::text').get(),
+        })
+    return products
 
 
 async def scrape_search(
     keyword: str,
-    store_id: str,
     max_pages: Optional[int] = None,
 ) -> List[Dict]:
-    """scrape product search results and paginate through all result pages"""
-    pass
+    """scrape search results and paginate through all result pages"""
+    results: List[Dict] = []
+    for page in range(max_pages or 1):
+        params = {"searchTerm": keyword}
+        if page > 0:
+            params["Nao"] = page * 24
+        url = "https://www.target.com/s?" + urlencode(params)
+        response = await SCRAPFLY.async_scrape(ScrapeConfig(url, render_js=True, **BASE_CONFIG))
+        results.extend(parse_search(response))
+    return results

--- a/target-scraper/target.py
+++ b/target-scraper/target.py
@@ -1,0 +1,178 @@
+"""
+This is an example web scraper for Target.com.
+
+To run this scraper set env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+
+import os
+import re
+import json
+from typing import Dict, List, Optional, TypedDict
+from scrapfly import ScrapeConfig, ScrapflyClient, ScrapeApiResponse
+
+SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
+
+BASE_CONFIG = {
+    # bypass target.com Akamai Bot Manager blocking
+    "asp": True,
+    # set the proxy country to US
+    "country": "US",
+    "proxy_pool": "public_residential_pool",
+}
+
+
+class Price(TypedDict):
+    current_retail: Optional[float]
+    reg_retail: Optional[float]
+    formatted_current_price: Optional[str]
+    location_id: Optional[int]
+
+
+class ProductVariant(TypedDict):
+    tcin: str
+    price: Optional[Price]
+    free_shipping: bool
+    in_stock: bool
+
+
+class Product(TypedDict):
+    tcin: str
+    title: Optional[str]
+    rating: Optional[float]
+    review_count: Optional[int]
+    variants: List[ProductVariant]
+
+
+MODULE_FULFILLMENT = "ProductDetailWebDatasourceFulfillmentAndVariations"
+MODULE_WITH_STORE = "ProductDetailWebDatasourceWithStore"
+MODULE_REVIEWS = "ProductDetailReviewsAndQuestions"
+
+
+def _extract_deferred_modules(response: ScrapeApiResponse) -> Dict[str, Dict]:
+    """collect deferred_enrichment module payloads from captured XHR calls"""
+    modules = {}
+    xhr_calls = response.scrape_result.get("browser_data", {}).get("xhr_call") or []
+    for xhr in xhr_calls:
+        if "deferred_enrichment/modules" not in xhr.get("url", ""):
+            continue
+        body = (xhr.get("response") or {}).get("body")
+        if not body:
+            continue
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            continue
+        for module in data.get("modules", []):
+            if module_type := module.get("module_type"):
+                modules[module_type] = module.get("module_data", {})
+    return modules
+
+
+def _is_in_stock(fulfillment: Optional[Dict]) -> bool:
+    if not fulfillment or fulfillment.get("sold_out"):
+        return False
+    if (fulfillment.get("shipping_options") or {}).get("availability_status") == "IN_STOCK":
+        return True
+    for store in fulfillment.get("store_options") or []:
+        statuses = (
+            (store.get("order_pickup") or {}).get("availability_status"),
+            (store.get("in_store_only") or {}).get("availability_status"),
+        )
+        if "IN_STOCK" in statuses:
+            return True
+    return False
+
+
+def parse_product(response: ScrapeApiResponse) -> Product:
+    """parse product data from deferred_enrichment XHR modules captured on the PDP"""
+    modules = _extract_deferred_modules(response)
+    for name in (MODULE_FULFILLMENT, MODULE_WITH_STORE):
+        if name not in modules:
+            raise ValueError(f"missing deferred_enrichment module: {name}")
+
+    fulfillment = modules[MODULE_FULFILLMENT]["data"]["product"]
+    store = modules[MODULE_WITH_STORE]["data"]["product"]
+    fulfillment_by_tcin = {c["tcin"]: c for c in fulfillment.get("children", [])}
+    store_by_tcin = {c["tcin"]: c for c in store.get("children", [])}
+
+    variants: List[ProductVariant] = []
+    for tcin in sorted(set(fulfillment_by_tcin) | set(store_by_tcin)):
+        store_child = store_by_tcin.get(tcin, {})
+        fulfillment_child = fulfillment_by_tcin.get(tcin, {})
+        price_data = store_child.get("price") or {}
+        variants.append({
+            "tcin": tcin,
+            "price": {
+                "current_retail": price_data.get("current_retail"),
+                "reg_retail": price_data.get("reg_retail"),
+                "formatted_current_price": price_data.get("formatted_current_price"),
+                "location_id": price_data.get("location_id"),
+            } if price_data else None,
+            "free_shipping": (store_child.get("free_shipping") or {}).get("enabled", False),
+            "in_stock": _is_in_stock(fulfillment_child.get("fulfillment")),
+        })
+
+    ratings = modules.get(MODULE_REVIEWS, {}).get("ratings_and_reviews") or {}
+    tcin = fulfillment.get("tcin") or store.get("tcin")
+    if not tcin:
+        match = re.search(r"/A-(\d+)", response.context["url"])
+        tcin = match.group(1) if match else None
+
+    return {
+        "tcin": tcin,
+        "title": response.selector.css('h1[data-test="product-title"]::text').get(),
+        "rating": ratings.get("average"),
+        "review_count": ratings.get("count"),
+        "variants": variants,
+    }
+
+
+async def scrape_product(url: str) -> Product:
+    """scrape a Target product page and return parsed product data"""
+    response = await SCRAPFLY.async_scrape(ScrapeConfig(
+        url,
+        **BASE_CONFIG,
+        render_js=True,
+        wait_for_selector="xhr:deferred_enrichment/modules",
+        rendering_wait=5000,
+    ))
+    return parse_product(response)
+
+
+def parse_availability(response: ScrapeApiResponse) -> Dict:
+    """parse fulfillment and availability data from a product_summary_with_fulfillment_v1 response"""
+    pass
+
+
+async def scrape_availability(
+    tcins: List[str],
+    store_id: str,
+    zip_code: str,
+) -> Dict:
+    """scrape product availability and fulfillment data from product_summary_with_fulfillment_v1"""
+    pass
+
+
+def parse_store_locations(response: ScrapeApiResponse) -> List[Dict]:
+    """parse store location entries from a sitemap response"""
+    pass
+
+
+async def scrape_store_locations(url: str) -> List[Dict]:
+    """scrape store location URLs from the Target store sitemap (stable fallback for store-id discovery)"""
+    pass
+
+
+def parse_search(response: ScrapeApiResponse) -> Dict:
+    """parse product listing data from a search API response"""
+    pass
+
+
+async def scrape_search(
+    keyword: str,
+    store_id: str,
+    max_pages: Optional[int] = None,
+) -> List[Dict]:
+    """scrape product search results and paginate through all result pages"""
+    pass

--- a/target-scraper/target.py
+++ b/target-scraper/target.py
@@ -9,6 +9,8 @@ import os
 import re
 import json
 from typing import Dict, List, Optional, TypedDict
+from urllib.parse import parse_qs, urlencode, urlparse
+from uuid import uuid4
 from scrapfly import ScrapeConfig, ScrapflyClient, ScrapeApiResponse
 
 SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
@@ -67,6 +69,20 @@ def _extract_deferred_modules(response: ScrapeApiResponse) -> Dict[str, Dict]:
             if module_type := module.get("module_type"):
                 modules[module_type] = module.get("module_data", {})
     return modules
+
+
+def _extract_redsky_credentials(response: ScrapeApiResponse) -> Dict[str, str]:
+    """extract the redsky 'key' and 'visitor_id' from the store_location_v1 XHR captured on the homepage"""
+    xhr_calls = response.scrape_result.get("browser_data", {}).get("xhr_call") or []
+    for xhr in xhr_calls:
+        if "store_location_v1" not in xhr.get("url", ""):
+            continue
+        params = parse_qs(urlparse(xhr["url"]).query)
+        key = params.get("key", [None])[0]
+        visitor_id = params.get("visitor_id", [None])[0]
+        if key and visitor_id:
+            return {"key": key, "visitor_id": visitor_id}
+    raise ValueError("missing store_location_v1 XHR with key and visitor_id")
 
 
 def _is_in_stock(fulfillment: Optional[Dict]) -> bool:
@@ -142,7 +158,24 @@ async def scrape_product(url: str) -> Product:
 
 def parse_availability(response: ScrapeApiResponse) -> Dict:
     """parse fulfillment and availability data from a product_summary_with_fulfillment_v1 response"""
-    pass
+    data = json.loads(response.content)
+    summaries = data.get("data", {}).get("product_summaries")
+    if summaries is None:
+        raise ValueError("missing data.product_summaries in availability response")
+
+    availability = {}
+    for summary in summaries:
+        tcin = summary["tcin"]
+        fulfillment = summary.get("fulfillment") or {}
+        availability[tcin] = {
+            "tcin": tcin,
+            "title": summary.get("item", {}).get("product_description", {}).get("title"),
+            "price": summary.get("price"),
+            "free_shipping": (summary.get("free_shipping") or {}).get("enabled", False),
+            "fulfillment": fulfillment,
+            "in_stock": _is_in_stock(fulfillment),
+        }
+    return availability
 
 
 async def scrape_availability(
@@ -151,7 +184,32 @@ async def scrape_availability(
     zip_code: str,
 ) -> Dict:
     """scrape product availability and fulfillment data from product_summary_with_fulfillment_v1"""
-    pass
+    session = str(uuid4()).replace("-", "")
+    warm_up = await SCRAPFLY.async_scrape(ScrapeConfig(
+        "https://www.target.com/",
+        session=session,
+        render_js=True,
+        wait_for_selector="xhr:store_location_v1",
+        rendering_wait=5000,
+        **BASE_CONFIG,
+    ))
+    credentials = _extract_redsky_credentials(warm_up)
+
+    url = "https://redsky.target.com/redsky_aggregations/v1/web/product_summary_with_fulfillment_v1?" + urlencode({
+        "key": credentials["key"],
+        "visitor_id": credentials["visitor_id"],
+        "tcins": ",".join(tcins),
+        "store_id": store_id,
+        "pricing_store_id": store_id,
+        "required_store_id": store_id,
+        "scheduled_delivery_store_id": store_id,
+        "zip": zip_code,
+        "channel": "WEB",
+        "page": f"/p/A-{tcins[0]}",
+    })
+
+    response = await SCRAPFLY.async_scrape(ScrapeConfig(url, session=session, **BASE_CONFIG))
+    return parse_availability(response)
 
 
 def parse_store_locations(response: ScrapeApiResponse) -> List[Dict]:

--- a/target-scraper/test.py
+++ b/target-scraper/test.py
@@ -1,0 +1,108 @@
+from cerberus import Validator
+import pytest
+import target
+import pprint
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+
+def validate_or_fail(item, validator):
+    if not validator.validate(item):
+        pp.pformat(item)
+        pytest.fail(f"Validation failed for item: {pp.pformat(item)}\nErrors: {validator.errors}")
+
+
+product_schema = {
+    "tcin": {"type": "string"},
+    "title": {"type": "string"},
+    "variants": {
+        "type": "list",
+        "schema": {
+            "type": "dict",
+            "schema": {
+                "tcin": {"type": "string"},
+                "free_shipping": {"type": "boolean"},
+                "in_stock": {"type": "boolean"},
+            },
+        },
+    },
+}
+
+search_schema = {
+    "tcin": {"type": "string"},
+    "url": {"type": "string"},
+    "title": {"type": "string", "nullable": True},
+}
+
+availability_schema = {
+    "tcin": {"type": "string"},
+    "in_stock": {"type": "boolean"},
+}
+
+store_location_schema = {
+    "url": {"type": "string"},
+    "slug": {"type": "string"},
+    "store_id": {"type": "string"},
+}
+
+store_schema = {
+    "store_id": {"type": "string"},
+    "location_name": {"type": "string"},
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_product_scraping():
+    product_data = await target.scrape_product(
+        "https://www.target.com/p/women-s-lace-godet-tank-top-wild-fable/-/A-95213693"
+    )
+    validator = Validator(product_schema, allow_unknown=True)
+    validate_or_fail(product_data, validator)
+    assert len(product_data["variants"]) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_search_scraping():
+    search_data = await target.scrape_search(keyword="laptop", max_pages=1)
+    validator = Validator(search_schema, allow_unknown=True)
+    for item in search_data:
+        validate_or_fail(item, validator)
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_availability_scraping():
+    availability_data = await target.scrape_availability(
+        tcins=["89231676"],
+        store_id="1771",
+        zip_code="52404",
+    )
+    validator = Validator(availability_schema, allow_unknown=True)
+    for item in availability_data.values():
+        validate_or_fail(item, validator)
+    assert len(availability_data) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_store_locations_sitemap():
+    store_locations_data = await target.scrape_store_locations_sitemap(
+        url="https://www.target.com/sl/sitemap_0001.xml.gz",
+    )
+    validator = Validator(store_location_schema, allow_unknown=True)
+    for item in store_locations_data[:10]:
+        validate_or_fail(item, validator)
+    assert len(store_locations_data) > 100
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_store_locations():
+    store_data = await target.scrape_store_locations(store_ids=["3"])
+    validator = Validator(store_schema, allow_unknown=True)
+    for item in store_data:
+        validate_or_fail(item, validator)
+    assert len(store_data) == 1


### PR DESCRIPTION
For scrape_product : 
the requirement is to scrape the PDP data from redsky.target.com/redsky_aggregations/v1/web/pdp_client_v1. However, I couldn't find this endpoint  in a real browser session. The page loads product data via deferred_enrichment/modules XHR instead.

capture that XHR, and parse:

- ProductDetailWebDatasourceWithStore -> price, shipping
- ProductDetailWebDatasourceFulfillmentAndVariations ->stock/Variations 
- ProductDetailReviewsAndQuestions -> ratings (if present)

for scrape_availability :
the key and visitor_id change dynamically, so we need a warm-up session to obtain these values before sending the request. 

for Store-id discovery:  in requirement the sitemap should be as fallback

implemented two separate functions: one for the sitemap and another for store_location_v1, since they provide different information. The sitemap only contains the store URL and ID, while store_location_v1 provides additional store details. This allows us to use the sitemap as a reliable fallback if the store_location_v1 endpoint is unavailable.

For scrape_search: parse the HTML, and for pagination, increase the offset `Nao`  by 24 for each new page.

<img width="1610" height="480" alt="image" src="https://github.com/user-attachments/assets/d45f740e-0211-4188-8197-d89c6cdf0e2d" />

