### PR TITLE
Add Maersk scraper implementation

### DIFF
--- a/maersk-scraper/README.md
+++ b/maersk-scraper/README.md
@@ -1,0 +1,45 @@
+# Maersk Scraper
+
+This scraper is using [scrapfly.io](https://scrapfly.io/) and Python to scrape container tracking and schedule data from maersk.com.
+
+Maersk.com can be difficult to scrape because of scraper blocking, so this scraper uses Scrapfly's [Anti Scraping Protection Bypass](https://scrapfly.io/docs/scrape-api/anti-scraping-protection) feature and browser rendering to capture the tracking and routings API responses.
+
+The scraping code is located in the `maersk.py` file. It's fully documented and simplified for educational purposes and the example scraper run code can be found in `run.py` file.
+
+This scraper scrapes:
+- Maersk.com container, BL, and booking tracking
+- Point-to-point schedule routes with vessels, voyages, transit times, and port calls
+
+For output examples see the `./results` directory.
+
+## Fair Use Disclaimer
+
+Note that this code is provided free of charge as is, and Scrapfly does __not__ provide free web scraping support or consultation. For any bugs, see the issue tracker.
+
+## Setup and Use
+
+This Maersk scraper uses __Python 3.10__ with [scrapfly-sdk](https://pypi.org/project/scrapfly-sdk/) package which is used to scrape and parse Maersk tracking and schedule data.
+
+0. Ensure you have __Python 3.10__ and [poetry Python package manager](https://python-poetry.org/docs/#installation) on your system.
+1. Retrieve your Scrapfly API key from <https://scrapfly.io/dashboard> and set `SCRAPFLY_KEY` environment variable:
+    ```shell
+    $ export SCRAPFLY_KEY="YOUR SCRAPFLY KEY"
+    ```
+2. Clone and install Python environment:
+    ```shell
+    $ git clone https://github.com/scrapfly/scrapfly-scrapers.git
+    $ cd scrapfly-scrapers/maersk-scraper
+    $ poetry install
+    ```
+3. Run example scrape:
+    ```shell
+    $ poetry run python run.py
+    ```
+4. Run tests:
+    ```shell
+    $ poetry install --with dev
+    $ poetry run pytest test.py
+    # or specific scraping areas
+    $ poetry run pytest test.py -k test_scrape_tracking
+    $ poetry run pytest test.py -k test_scrape_schedule_search
+    ```

--- a/maersk-scraper/maersk.py
+++ b/maersk-scraper/maersk.py
@@ -1,0 +1,300 @@
+"""
+This is an example web scraper for maersk.com container tracking and schedules.
+
+To run this scraper set env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+
+import json
+import os
+import re
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, TypedDict
+from urllib.parse import urlencode
+
+from loguru import logger as log
+from scrapfly import ScrapeApiResponse, ScrapeConfig, ScrapflyClient
+
+SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
+
+BASE_CONFIG = {
+    "asp": True,
+    "country": "US",
+    "render_js": True,
+    "rendering_wait": 5000,
+
+}
+
+
+class VesselInfo(TypedDict):
+    name: str
+    code: str
+    flag_country: str
+
+
+class PortCall(TypedDict):
+    facility_code: str
+    geo_id: Optional[str]
+    estimated_arrival: Optional[str]
+    estimated_departure: Optional[str]
+    voyage_number: Optional[str]
+    service_name: Optional[str]
+    service_code: Optional[str]
+
+
+class RoutingLeg(TypedDict):
+    carriage_type: str
+    transport_mode: str
+    vessel: Optional[VesselInfo]
+    origin: PortCall
+    destination: PortCall
+    transit_time: Optional[str]
+
+
+class ScheduleRoute(TypedDict):
+    route_id: str
+    route_code: str
+    route_direction: str
+    estimated_transit_time: str
+    estimated_transit_days: Optional[int]
+    vessel_name: Optional[str]
+    origin_facility: Optional[str]
+    destination_facility: Optional[str]
+    departure_time: Optional[str]
+    arrival_time: Optional[str]
+    service_name: Optional[str]
+    voyage_number: Optional[str]
+    legs: List[RoutingLeg]
+
+
+class ScheduleSearch(TypedDict):
+    url: str
+    from_rkst_code: str
+    to_rkst_code: str
+    departure_date: str
+    route_count: int
+    routes: List[ScheduleRoute]
+
+class TrackingEvent(TypedDict):
+    location: Optional[str]
+    facility: Optional[str]
+    description: str
+    date: Optional[str]
+    vessel: Optional[str]
+    voyage: Optional[str]
+    is_current: bool
+
+class TrackingContainer(TypedDict):
+    container_number: Optional[str]
+    container_type: Optional[str]
+    last_updated: Optional[str]
+    status: Optional[str]
+    current_location: Optional[str]
+    status_date: Optional[str]
+    events: List[TrackingEvent]
+
+
+class TrackingResult(TypedDict):
+    tracking_number: str
+    origin: Optional[str]
+    destination: Optional[str]
+    containers: List[TrackingContainer]
+
+def _parse_port_call(port_call: Dict) -> PortCall:
+    facility = port_call.get("location", {}).get("facility", {})
+    service = port_call.get("departureService") or port_call.get("arrivalService") or {}
+
+    geo_id = None
+    for code in facility.get("alternativeCodes", []):
+        if code.get("alternativeCodeType") == "GEO_ID":
+            geo_id = code.get("alternativeCode")
+            break
+
+    return PortCall(
+        facility_code=facility.get("facilityCode", ""),
+        geo_id=geo_id,
+        estimated_arrival=port_call.get("estimatedTimeOfArrival"),
+        estimated_departure=port_call.get("estimatedTimeOfDeparture"),
+        voyage_number=port_call.get("departureVoyageNumber") or port_call.get("arrivalVoyageNumber"),
+        service_name=service.get("serviceName"),
+        service_code=service.get("serviceCode"),
+    )
+
+
+def _parse_routing(routing: Dict) -> Optional[ScheduleRoute]:
+    legs: List[RoutingLeg] = []
+    for leg in routing.get("routingLegs", []):
+        carriage = leg.get("carriage", {})
+        start = carriage.get("vesselPortCallStart")
+        end = carriage.get("vesselPortCallEnd")
+        if not start or not end:
+            continue
+
+        vessel_data = carriage.get("vessel")
+        vessel = None
+        if vessel_data:
+            vessel = VesselInfo(
+                name=vessel_data.get("vesselName", ""),
+                code=vessel_data.get("vesselMaerskCode", ""),
+                flag_country=vessel_data.get("flagCountryCode", ""),
+            )
+
+        legs.append(
+            RoutingLeg(
+                carriage_type=carriage.get("carriageType", ""),
+                transport_mode=leg.get("transportMode", {}).get("transportModeCode", ""),
+                vessel=vessel,
+                origin=_parse_port_call(start),
+                destination=_parse_port_call(end),
+                transit_time=leg.get("estimatedTransitTime"),
+            )
+        )
+
+    if not legs:
+        return None
+
+    first_leg = legs[0]
+    last_leg = legs[-1]
+    vessel = first_leg.get("vessel")
+    estimated_transit = routing.get("estimatedTransitTime") or ""
+    days_match = re.match(r"^P(?:(\d+)D)", estimated_transit)
+
+    return ScheduleRoute(
+        route_id=routing.get("routeId", ""),
+        route_code=routing.get("routeCode", ""),
+        route_direction=routing.get("routeCodeDirection", ""),
+        estimated_transit_time=estimated_transit,
+        estimated_transit_days=int(days_match.group(1)) if days_match else None,
+        vessel_name=vessel["name"] if vessel else None,
+        origin_facility=first_leg["origin"]["facility_code"] or None,
+        destination_facility=last_leg["destination"]["facility_code"] or None,
+        departure_time=first_leg["origin"]["estimated_departure"],
+        arrival_time=last_leg["destination"]["estimated_arrival"],
+        service_name=first_leg["origin"]["service_name"],
+        voyage_number=first_leg["origin"]["voyage_number"],
+        legs=legs,
+    )
+
+
+def _get_xhr_data(response: ScrapeApiResponse, url_pattern: str) -> Dict:
+    """Extract and parse the JSON body of the first XHR call whose URL contains url_pattern."""
+    xhr_calls = response.scrape_result.get("browser_data", {}).get("xhr_call", [])
+    call = next((c for c in xhr_calls if url_pattern in c.get("url", "")), None)
+    if not call:
+        raise RuntimeError(f"XHR call matching '{url_pattern}' not found — try increasing rendering_wait")
+    return json.loads(call["response"]["body"])
+
+
+def parse_schedule_search(
+    response: ScrapeApiResponse,
+    from_rkst_code: str,
+    to_rkst_code: str,
+    departure_date: str,
+) -> ScheduleSearch:
+    """Parse point-to-point schedule results from the routings-queries XHR response."""
+    data = _get_xhr_data(response, "routing/routings-queries")
+    if "routings" not in data:
+        raise RuntimeError("'routings' key missing in routings-queries XHR response")
+
+    routes: List[ScheduleRoute] = []
+    for routing in data.get("routings", []):
+        parsed_route = _parse_routing(routing)
+        if parsed_route:
+            routes.append(parsed_route)
+
+    log.success("parsed {} schedule routes {} -> {}", len(routes), from_rkst_code, to_rkst_code)
+    return ScheduleSearch(
+        url=response.context.get("url", ""),
+        from_rkst_code=from_rkst_code,
+        to_rkst_code=to_rkst_code,
+        departure_date=departure_date,
+        route_count=len(routes),
+        routes=routes,
+    )
+
+
+def parse_tracking(data: Dict, tracking_number: str) -> TrackingResult:
+    """Parse Maersk synergy tracking API JSON into structured tracking data."""
+    containers: List[TrackingContainer] = []
+
+    for c in data.get("containers", []):
+        locations = c.get("locations", [])
+        all_events = [
+            (loc, ev)
+            for loc in locations
+            for ev in loc.get("events", [])
+        ]
+        events = [
+            TrackingEvent(
+                location=loc.get("city"),
+                facility=loc.get("terminal"),
+                description=ev.get("activity", ""),
+                date=ev.get("event_time"),
+                vessel=ev.get("vessel_name"),
+                voyage=ev.get("voyage_num"),
+                is_current=(i == len(all_events) - 1),
+            )
+            for i, (loc, ev) in enumerate(all_events)
+        ]
+
+        last_loc = locations[-1] if locations else {}
+        containers.append(TrackingContainer(
+            container_number=c.get("container_num"),
+            container_type=f"{c.get('container_size', '')}' {c.get('container_type', '')}".strip() or None,
+            last_updated=c.get("last_update_time"),
+            status=c.get("status"),
+            current_location=last_loc.get("city"),
+            status_date=last_loc.get("events", [{}])[-1].get("event_time"),
+            events=events,
+        ))
+
+    return TrackingResult(
+        tracking_number=tracking_number,
+        origin=data.get("origin", {}).get("city"),
+        destination=data.get("destination", {}).get("city"),
+        containers=containers,
+    )
+
+
+async def scrape_schedule_search(
+    from_location: str,
+    to_location: str,
+    from_rkst_code: str,
+    to_rkst_code: str,
+    departure_date: str,
+) -> ScheduleSearch:
+    """Search maersk.com Point-to-Point schedules"""
+    date_to = (datetime.strptime(departure_date, "%Y-%m-%d") + timedelta(weeks=4)).strftime("%Y-%m-%d")
+    url = "https://www.maersk.com/schedules/pointToPoint?" + urlencode({
+        "from": from_location,
+        "to": to_location,
+        "fromRkstCode": from_rkst_code,
+        "toRkstCode": to_rkst_code,
+        "date": departure_date,
+        "dateTo": date_to,
+    })
+
+    response = await SCRAPFLY.async_scrape(
+        ScrapeConfig(
+            url,
+            **BASE_CONFIG,
+            wait_for_selector="xhr:routings-queries",
+        )
+    )
+    log.success("searched schedules {} -> {}", from_rkst_code, to_rkst_code)
+    return parse_schedule_search(response, from_rkst_code, to_rkst_code, departure_date)
+
+
+async def scrape_tracking(tracking_number: str) -> TrackingResult:
+    """Scrape a container/BL/booking number from maersk.com's tracking widget."""
+    url = f"https://www.maersk.com/tracking/{tracking_number}"
+    response = await SCRAPFLY.async_scrape(
+        ScrapeConfig(
+            url,
+            **BASE_CONFIG,
+            wait_for_selector="xhr:synergy/tracking",
+        )
+    )
+    data = _get_xhr_data(response, "synergy/tracking")
+    log.success("scraped tracking details for {}", tracking_number)
+    return parse_tracking(data, tracking_number)

--- a/maersk-scraper/pyproject.toml
+++ b/maersk-scraper/pyproject.toml
@@ -1,0 +1,31 @@
+[tool.poetry]
+name = "scrapfly-maersk"
+version = "0.1.0"
+description = "demo web scraper for maersk.com using Scrapfly"
+authors = ["Abdelrahman Arafa <abdelrahman@scrapfly.io>"]
+license = "NPOS-3.0"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+scrapfly-sdk = {extras = ["all"], version = "^0.8.5"}
+loguru = "^0.7.1"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.7.0"
+pytest = "^7.3.1"
+cerberus = "^1.3.4"
+asyncio = "^3.4.3"
+pytest-asyncio = "^0.21.0"
+pytest-rerunfailures = "^14.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+python_files = "test.py"
+
+[tool.black]
+line-length = 120
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']

--- a/maersk-scraper/results/schedule.json
+++ b/maersk-scraper/results/schedule.json
@@ -1,0 +1,229 @@
+{
+  "url": "https://www.maersk.com/schedules/pointToPoint?from=2IW9P6J7XAW72&to=1JUKNJGWHQBNJ&fromRkstCode=CNSGH&toRkstCode=NLROT&containerIsoCode=45G1&fromServiceMode=CY&toServiceMode=CY&numberOfWeeks=4&dateType=D&date=2026-08-15&dateTo=2026-09-12&vesselFlag=",
+  "from_rkst_code": "CNSGH",
+  "to_rkst_code": "NLROT",
+  "departure_date": "2026-08-15",
+  "route_count": 5,
+  "routes": [
+    {
+      "route_id": "769242022",
+      "route_code": "E1",
+      "route_direction": "W",
+      "estimated_transit_time": "P40DT1H",
+      "estimated_transit_days": 40,
+      "vessel_name": "BUSAN EXPRESS",
+      "origin_facility": "CNSGHY3",
+      "destination_facility": "NLROTTM",
+      "departure_time": "2026-08-15T12:00:00",
+      "arrival_time": "2026-09-24T07:00:00",
+      "service_name": "AE1",
+      "voyage_number": "633W",
+      "legs": [
+        {
+          "carriage_type": "OCEAN",
+          "transport_mode": "MVS",
+          "vessel": {
+            "name": "BUSAN EXPRESS",
+            "code": "IE8",
+            "flag_country": "DE"
+          },
+          "origin": {
+            "facility_code": "CNSGHY3",
+            "geo_id": "37O5HQ17XCL3X",
+            "estimated_arrival": "2026-08-13T00:01:00",
+            "estimated_departure": "2026-08-15T12:00:00",
+            "voyage_number": "633W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "destination": {
+            "facility_code": "NLROTTM",
+            "geo_id": "HHMT8D8RO96BR",
+            "estimated_arrival": "2026-09-24T07:00:00",
+            "estimated_departure": "2026-09-26T03:00:00",
+            "voyage_number": "633W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "transit_time": "P40DT1H"
+        }
+      ]
+    },
+    {
+      "route_id": "769242022",
+      "route_code": "E1",
+      "route_direction": "W",
+      "estimated_transit_time": "P40DT1H",
+      "estimated_transit_days": 40,
+      "vessel_name": "BARZAN",
+      "origin_facility": "CNSGHY3",
+      "destination_facility": "NLROTTM",
+      "departure_time": "2026-08-22T12:00:00",
+      "arrival_time": "2026-10-01T07:00:00",
+      "service_name": "AE1",
+      "voyage_number": "634W",
+      "legs": [
+        {
+          "carriage_type": "OCEAN",
+          "transport_mode": "MVS",
+          "vessel": {
+            "name": "BARZAN",
+            "code": "IA5",
+            "flag_country": "DE"
+          },
+          "origin": {
+            "facility_code": "CNSGHY3",
+            "geo_id": "37O5HQ17XCL3X",
+            "estimated_arrival": "2026-08-20T00:01:00",
+            "estimated_departure": "2026-08-22T12:00:00",
+            "voyage_number": "634W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "destination": {
+            "facility_code": "NLROTTM",
+            "geo_id": "HHMT8D8RO96BR",
+            "estimated_arrival": "2026-10-01T07:00:00",
+            "estimated_departure": "2026-10-03T03:00:00",
+            "voyage_number": "634W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "transit_time": "P40DT1H"
+        }
+      ]
+    },
+    {
+      "route_id": "769242022",
+      "route_code": "E1",
+      "route_direction": "W",
+      "estimated_transit_time": "P40DT1H",
+      "estimated_transit_days": 40,
+      "vessel_name": "BERLIN EXPRESS",
+      "origin_facility": "CNSGHY3",
+      "destination_facility": "NLROTTM",
+      "departure_time": "2026-08-29T12:00:00",
+      "arrival_time": "2026-10-08T07:00:00",
+      "service_name": "AE1",
+      "voyage_number": "635W",
+      "legs": [
+        {
+          "carriage_type": "OCEAN",
+          "transport_mode": "MVS",
+          "vessel": {
+            "name": "BERLIN EXPRESS",
+            "code": "IE6",
+            "flag_country": "DE"
+          },
+          "origin": {
+            "facility_code": "CNSGHY3",
+            "geo_id": "37O5HQ17XCL3X",
+            "estimated_arrival": "2026-08-27T00:01:00",
+            "estimated_departure": "2026-08-29T12:00:00",
+            "voyage_number": "635W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "destination": {
+            "facility_code": "NLROTTM",
+            "geo_id": "HHMT8D8RO96BR",
+            "estimated_arrival": "2026-10-08T07:00:00",
+            "estimated_departure": "2026-10-10T03:00:00",
+            "voyage_number": "635W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "transit_time": "P40DT1H"
+        }
+      ]
+    },
+    {
+      "route_id": "769242022",
+      "route_code": "E1",
+      "route_direction": "W",
+      "estimated_transit_time": "P42DT1H",
+      "estimated_transit_days": 42,
+      "vessel_name": "GDANSK EXPRESS",
+      "origin_facility": "CNSGHY3",
+      "destination_facility": "NLROTTM",
+      "departure_time": "2026-09-05T12:00:00",
+      "arrival_time": "2026-10-17T07:00:00",
+      "service_name": "AE1",
+      "voyage_number": "636W",
+      "legs": [
+        {
+          "carriage_type": "OCEAN",
+          "transport_mode": "MVS",
+          "vessel": {
+            "name": "GDANSK EXPRESS",
+            "code": "IF3",
+            "flag_country": "DE"
+          },
+          "origin": {
+            "facility_code": "CNSGHY3",
+            "geo_id": "37O5HQ17XCL3X",
+            "estimated_arrival": "2026-09-03T00:01:00",
+            "estimated_departure": "2026-09-05T12:00:00",
+            "voyage_number": "636W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "destination": {
+            "facility_code": "NLROTTM",
+            "geo_id": "HHMT8D8RO96BR",
+            "estimated_arrival": "2026-10-17T07:00:00",
+            "estimated_departure": "2026-10-19T03:00:00",
+            "voyage_number": "636W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "transit_time": "P40DT1H"
+        }
+      ]
+    },
+    {
+      "route_id": "769242022",
+      "route_code": "E1",
+      "route_direction": "W",
+      "estimated_transit_time": "P42DT1H",
+      "estimated_transit_days": 42,
+      "vessel_name": "ROTTERDAM EXPRESS",
+      "origin_facility": "CNSGHY3",
+      "destination_facility": "NLROTTM",
+      "departure_time": "2026-09-12T12:00:00",
+      "arrival_time": "2026-10-24T07:00:00",
+      "service_name": "AE1",
+      "voyage_number": "637W",
+      "legs": [
+        {
+          "carriage_type": "OCEAN",
+          "transport_mode": "MVS",
+          "vessel": {
+            "name": "ROTTERDAM EXPRESS",
+            "code": "II9",
+            "flag_country": "DE"
+          },
+          "origin": {
+            "facility_code": "CNSGHY3",
+            "geo_id": "37O5HQ17XCL3X",
+            "estimated_arrival": "2026-09-10T00:01:00",
+            "estimated_departure": "2026-09-12T12:00:00",
+            "voyage_number": "637W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "destination": {
+            "facility_code": "NLROTTM",
+            "geo_id": "HHMT8D8RO96BR",
+            "estimated_arrival": "2026-10-24T07:00:00",
+            "estimated_departure": "2026-10-26T03:00:00",
+            "voyage_number": "637W",
+            "service_name": "AE1",
+            "service_code": "411"
+          },
+          "transit_time": "P40DT1H"
+        }
+      ]
+    }
+  ]
+}

--- a/maersk-scraper/results/tracking.json
+++ b/maersk-scraper/results/tracking.json
@@ -1,0 +1,143 @@
+{
+  "tracking_number": "269124324",
+  "origin": "JAWAHARLAL NEHRU",
+  "destination": "VERACRUZ",
+  "containers": [
+    {
+      "container_number": "MSKU1026068",
+      "container_type": "40' DRY",
+      "last_updated": "2026-07-03T16:58:38Z",
+      "status": "IN_PROGRESS",
+      "current_location": "VERACRUZ",
+      "status_date": "2026-07-03T10:13:00.000",
+      "events": [
+        {
+          "location": "Mumbai",
+          "facility": "JM Yard",
+          "description": "GATE-OUT",
+          "date": "2026-04-18T08:17:00.000",
+          "vessel": null,
+          "voyage": null,
+          "is_current": false
+        },
+        {
+          "location": "JAWAHARLAL NEHRU",
+          "facility": "JAWAHARLAL NEHRU NSICT DPW",
+          "description": "GATE-IN",
+          "date": "2026-04-21T09:39:00.000",
+          "vessel": null,
+          "voyage": null,
+          "is_current": false
+        },
+        {
+          "location": "JAWAHARLAL NEHRU",
+          "facility": "JAWAHARLAL NEHRU NSICT DPW",
+          "description": "LOAD",
+          "date": "2026-04-24T18:40:00.000",
+          "vessel": "MAERSK HARTFORD",
+          "voyage": "616W",
+          "is_current": false
+        },
+        {
+          "location": "JAWAHARLAL NEHRU",
+          "facility": "JAWAHARLAL NEHRU NSICT DPW",
+          "description": "CONTAINER DEPARTURE",
+          "date": "2026-04-25T09:00:00.000",
+          "vessel": "MAERSK HARTFORD",
+          "voyage": "616W",
+          "is_current": false
+        },
+        {
+          "location": "SALALAH",
+          "facility": "SALALAH TERMINAL",
+          "description": "CONTAINER ARRIVAL",
+          "date": "2026-04-27T19:42:00.000",
+          "vessel": "MAERSK HARTFORD",
+          "voyage": "616W",
+          "is_current": false
+        },
+        {
+          "location": "SALALAH",
+          "facility": "SALALAH TERMINAL",
+          "description": "DISCHARG",
+          "date": "2026-04-28T06:07:00.000",
+          "vessel": "MAERSK HARTFORD",
+          "voyage": "616W",
+          "is_current": false
+        },
+        {
+          "location": "SALALAH",
+          "facility": "SALALAH TERMINAL",
+          "description": "LOAD",
+          "date": "2026-05-12T23:45:00.000",
+          "vessel": "MAERSK COPENHAGEN",
+          "voyage": "615N",
+          "is_current": false
+        },
+        {
+          "location": "SALALAH",
+          "facility": "SALALAH TERMINAL",
+          "description": "CONTAINER DEPARTURE",
+          "date": "2026-05-13T04:45:00.000",
+          "vessel": "MAERSK COPENHAGEN",
+          "voyage": "615N",
+          "is_current": false
+        },
+        {
+          "location": "PORT TANGIER MEDITERRANEE",
+          "facility": "TANGER MED 2",
+          "description": "CONTAINER ARRIVAL",
+          "date": "2026-06-17T04:42:00.000",
+          "vessel": "MAERSK COPENHAGEN",
+          "voyage": "615N",
+          "is_current": false
+        },
+        {
+          "location": "PORT TANGIER MEDITERRANEE",
+          "facility": "TANGER MED 2",
+          "description": "DISCHARG",
+          "date": "2026-06-17T06:15:00.000",
+          "vessel": "MAERSK COPENHAGEN",
+          "voyage": "615N",
+          "is_current": false
+        },
+        {
+          "location": "PORT TANGIER MEDITERRANEE",
+          "facility": "TANGER MED 2",
+          "description": "LOAD",
+          "date": "2026-06-19T13:00:00.000",
+          "vessel": "COLOMBIA EXPRESS",
+          "voyage": "624W",
+          "is_current": false
+        },
+        {
+          "location": "PORT TANGIER MEDITERRANEE",
+          "facility": "TANGER MED 2",
+          "description": "CONTAINER DEPARTURE",
+          "date": "2026-06-20T05:04:00.000",
+          "vessel": "COLOMBIA EXPRESS",
+          "voyage": "624W",
+          "is_current": false
+        },
+        {
+          "location": "VERACRUZ",
+          "facility": "HUTCHISON PORTS ICAVE",
+          "description": "CONTAINER ARRIVAL",
+          "date": "2026-07-02T16:30:00.000",
+          "vessel": "COLOMBIA EXPRESS",
+          "voyage": "624W",
+          "is_current": false
+        },
+        {
+          "location": "VERACRUZ",
+          "facility": "HUTCHISON PORTS ICAVE",
+          "description": "DISCHARG",
+          "date": "2026-07-03T10:13:00.000",
+          "vessel": "COLOMBIA EXPRESS",
+          "voyage": "624W",
+          "is_current": true
+        }
+      ]
+    }
+  ]
+}

--- a/maersk-scraper/run.py
+++ b/maersk-scraper/run.py
@@ -1,0 +1,41 @@
+"""
+This example run script shows how to run the maersk.com scraper defined in ./maersk.py
+It scrapes data and saves it to ./results/
+
+To run this script set the env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import maersk
+
+output = Path(__file__).parent / "results"
+output.mkdir(exist_ok=True)
+
+
+async def run():
+    maersk.BASE_CONFIG["cache"] = False
+    maersk.BASE_CONFIG["debug"] = True
+
+    print("running Maersk scrape and saving results to ./results directory")
+
+    tracking = await maersk.scrape_tracking("269124324")
+    with open(output / "tracking.json", "w", encoding="utf-8") as f:
+        json.dump(tracking, f, indent=2, ensure_ascii=False)
+
+    schedule = await maersk.scrape_schedule_search(
+        from_location="2IW9P6J7XAW72",
+        to_location="1JUKNJGWHQBNJ",
+        from_rkst_code="CNSGH",
+        to_rkst_code="NLROT",
+        departure_date="2026-08-15",
+    )
+    with open(output / "schedule.json", "w", encoding="utf-8") as f:
+        json.dump(schedule, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/maersk-scraper/test.py
+++ b/maersk-scraper/test.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timedelta
+
+import pytest
+from cerberus import Validator
+
+import maersk
+
+
+DEPARTURE_DATE = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
+
+vessel_schema = {
+    "name": {"type": "string"},
+    "code": {"type": "string"},
+    "flag_country": {"type": "string"},
+}
+
+port_call_schema = {
+    "facility_code": {"type": "string"},
+    "geo_id": {"type": "string", "nullable": True},
+    "estimated_arrival": {"type": "string", "nullable": True},
+    "estimated_departure": {"type": "string", "nullable": True},
+    "voyage_number": {"type": "string", "nullable": True},
+    "service_name": {"type": "string", "nullable": True},
+    "service_code": {"type": "string", "nullable": True},
+}
+
+routing_leg_schema = {
+    "carriage_type": {"type": "string"},
+    "transport_mode": {"type": "string"},
+    "vessel": {"type": "dict", "nullable": True, "schema": vessel_schema},
+    "origin": {"type": "dict", "schema": port_call_schema},
+    "destination": {"type": "dict", "schema": port_call_schema},
+    "transit_time": {"type": "string", "nullable": True},
+}
+
+schedule_route_schema = {
+    "route_id": {"type": "string"},
+    "route_code": {"type": "string"},
+    "route_direction": {"type": "string"},
+    "estimated_transit_time": {"type": "string"},
+    "estimated_transit_days": {"type": "integer", "nullable": True},
+    "vessel_name": {"type": "string", "nullable": True},
+    "origin_facility": {"type": "string", "nullable": True},
+    "destination_facility": {"type": "string", "nullable": True},
+    "departure_time": {"type": "string", "nullable": True},
+    "arrival_time": {"type": "string", "nullable": True},
+    "service_name": {"type": "string", "nullable": True},
+    "voyage_number": {"type": "string", "nullable": True},
+    "legs": {"type": "list", "schema": {"type": "dict", "schema": routing_leg_schema}},
+}
+
+schedule_search_schema = {
+    "url": {"type": "string"},
+    "from_rkst_code": {"type": "string"},
+    "to_rkst_code": {"type": "string"},
+    "departure_date": {"type": "string", "regex": r"\d{4}-\d{2}-\d{2}"},
+    "route_count": {"type": "integer", "min": 1},
+    "routes": {"type": "list", "schema": {"type": "dict", "schema": schedule_route_schema}},
+}
+
+tracking_event_schema = {
+    "location": {"type": "string", "nullable": True},
+    "facility": {"type": "string", "nullable": True},
+    "description": {"type": "string"},
+    "date": {"type": "string", "nullable": True},
+    "vessel": {"type": "string", "nullable": True},
+    "voyage": {"type": "string", "nullable": True},
+    "is_current": {"type": "boolean"},
+}
+
+tracking_container_schema = {
+    "container_number": {"type": "string", "nullable": True},
+    "container_type": {"type": "string", "nullable": True},
+    "last_updated": {"type": "string", "nullable": True},
+    "status": {"type": "string", "nullable": True},
+    "current_location": {"type": "string", "nullable": True},
+    "status_date": {"type": "string", "nullable": True},
+    "events": {"type": "list", "schema": {"type": "dict", "schema": tracking_event_schema}},
+}
+
+tracking_result_schema = {
+    "tracking_number": {"type": "string"},
+    "origin": {"type": "string", "nullable": True},
+    "destination": {"type": "string", "nullable": True},
+    "containers": {"type": "list", "schema": {"type": "dict", "schema": tracking_container_schema}},
+}
+
+
+def _validate_or_raise(item, schema):
+    validator = Validator(schema, allow_unknown=True)
+    if not validator.validate(item):
+        raise Exception({"item": item, "errors": validator.errors})
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_scrape_tracking():
+    result = await maersk.scrape_tracking("269124324")
+    _validate_or_raise(result, tracking_result_schema)
+    
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_scrape_schedule_search():
+    result = await maersk.scrape_schedule_search(
+        from_location="2IW9P6J7XAW72",
+        to_location="1JUKNJGWHQBNJ",
+        from_rkst_code="CNSGH",
+        to_rkst_code="NLROT",
+        departure_date=DEPARTURE_DATE,
+    )
+    _validate_or_raise(result, schedule_search_schema)
+


### PR DESCRIPTION
Requirements:
Schedules = interactive, not deterministic. Vessel/point-to-point schedules are hash-routed (/schedules/#vesselSchedules, /schedules/) — no per-route results URL — so route the schedules flow through the Cloud Browser interactive path (origin/destination/date → sailing rows), unless an authorized schedules API is found.


For Schedules, I scraped `https://www.maersk.com/schedules/pointToPoint` instead of /schedules/#vesselSchedules because it is the only endpoint that accepts the origin, destination, and date in a deterministic way, so there is no need for (js_scenario).