### PR TITLE
Add  implementation of Shopify scraper.

### DIFF
--- a/shopify-scraper/README.md
+++ b/shopify-scraper/README.md
@@ -1,0 +1,45 @@
+# Shopify Scraper
+
+This scraper is using [scrapfly.io](https://scrapfly.io/) and Python to scrape product and sitemap data from Shopify stores.
+
+The scraping code is located in the `shopify.py` file. It's fully documented and simplified for educational purposes and the example scraper run code can be found in the `run.py` file.
+
+This scraper scrapes:
+- Shopify store product catalog (via `/products.json`).
+- Shopify individual product data (via `/products/<handle>.json`, falling back to the product page HTML).
+- Shopify XML sitemap data.
+
+For output examples see the `./results` directory.
+
+## Fair Use Disclaimer
+
+Note that this code is provided free of charge as is, and Scrapfly does __not__ provide free web scraping support or consultation. For any bugs, see the issue tracker.
+
+## Setup and Use
+
+This Shopify scraper uses __Python 3.10__ with [scrapfly-sdk](https://pypi.org/project/scrapfly-sdk/) package which is used to scrape and parse Shopify's data.
+
+0. Ensure you have __Python 3.10__ and [poetry Python package manager](https://python-poetry.org/docs/#installation) on your system.
+1. Retrieve your Scrapfly API key from <https://scrapfly.io/dashboard> and set `SCRAPFLY_KEY` environment variable:
+    ```shell
+    $ export SCRAPFLY_KEY="YOUR SCRAPFLY KEY"
+    ```
+2. Clone and install Python environment:
+    ```shell
+    $ git clone https://github.com/scrapfly/scrapfly-scrapers.git
+    $ cd scrapfly-scrapers/shopify-scraper
+    $ poetry install
+    ```
+3. Run example scrape:
+    ```shell
+    $ poetry run python run.py
+    ```
+4. Run tests:
+    ```shell
+    $ poetry install --with dev
+    $ poetry run pytest test.py
+    # or specific scraping areas
+    $ poetry run pytest test.py -k test_catalog_scraping
+    $ poetry run pytest test.py -k test_product_scraping
+    $ poetry run pytest test.py -k test_sitemap_scraping
+    ```

--- a/shopify-scraper/pyproject.toml
+++ b/shopify-scraper/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.poetry]
+name = "scrapfly-shopify"
+version = "0.1.0"
+description = "demo web scraper for Shopify stores using Scrapfly"
+authors = ["Abdelrahman Arafa <abdelrhman@scrapfly.io>"]
+license = "NPOS-3.0"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+scrapfly-sdk = {extras = ["all"], version = "^0.8.5"}
+loguru = "^0.7.0"
+
+[tool.poetry.group.dev.dependencies]
+black = "^23.3.0"
+ruff = "^0.0.269"
+cerberus = "^1.3.4"
+pytest = "^7.3.1"
+pytest-asyncio = "^0.21.0"
+pytest-rerunfailures = "^14.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+python_files = "test.py"
+
+[tool.black]
+line-length = 120
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+
+[tool.ruff]
+line-length = 120

--- a/shopify-scraper/results/catalog.json
+++ b/shopify-scraper/results/catalog.json
@@ -1,0 +1,1781 @@
+[
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-cruiser-rugged-beige",
+    "product_id": "7193759613008",
+    "handle": "womens-cruiser-rugged-beige",
+    "title": "Women's Cruiser - Rugged Beige (Rugged Beige Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41222392283216",
+        "title": "5",
+        "sku": "A11839W050",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392315984",
+        "title": "5.5",
+        "sku": "A11839W055",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392348752",
+        "title": "6",
+        "sku": "A11839W060",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392381520",
+        "title": "6.5",
+        "sku": "A11839W065",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392414288",
+        "title": "7",
+        "sku": "A11839W070",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392447056",
+        "title": "7.5",
+        "sku": "A11839W075",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392479824",
+        "title": "8",
+        "sku": "A11839W080",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392512592",
+        "title": "8.5",
+        "sku": "A11839W085",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392545360",
+        "title": "9",
+        "sku": "A11839W090",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392578128",
+        "title": "9.5",
+        "sku": "A11839W095",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392610896",
+        "title": "10",
+        "sku": "A11839W100",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392643664",
+        "title": "10.5",
+        "sku": "A11839W105",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392676432",
+        "title": "11",
+        "sku": "A11839W110",
+        "price": "105.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11838_25Q3_Cruiser_Rugged_Beige_Rugged_Beige_PDP_LEFT-2000x2000_3f9eafa0-74e8-4cd9-8b78-c5cc2ac0612f.png?v=1751901321",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11838_25Q3_Cruiser_Rugged_Beige_Rugged_Beige_PDP_BACK-2000x2000_e6c48ffa-fd58-42ed-9375-7fa31e176e7e.png?v=1751901321",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11838_25Q3_Cruiser_Rugged_Beige_Rugged_Beige_PDP_TD-2000x2000_33f77a5f-e686-41f8-8332-f85c81c29e2f.png?v=1751901321",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11838_25Q3_Cruiser_Rugged_Beige_Rugged_Beige_PDP_SOLE-2000x2000_a56a8a04-b8d0-4573-b138-9ea5a732b31d.png?v=1751901321",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11838_25Q3_Cruiser_Rugged_Beige_Rugged_Beige_PDP_PAIR_3Q-2000x2000_596010c8-8953-4bb2-961c-46a19e00ea14.png?v=1751901321"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-cruiser-natural-white",
+    "product_id": "7193758990416",
+    "handle": "mens-cruiser-natural-white",
+    "title": "Men's Cruiser - Natural White (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41222387957840",
+        "title": "8",
+        "sku": "A11822M080",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222387990608",
+        "title": "8.5",
+        "sku": "A11822M085",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388023376",
+        "title": "9",
+        "sku": "A11822M090",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388056144",
+        "title": "9.5",
+        "sku": "A11822M095",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388088912",
+        "title": "10",
+        "sku": "A11822M100",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388121680",
+        "title": "10.5",
+        "sku": "A11822M105",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388154448",
+        "title": "11",
+        "sku": "A11822M110",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388187216",
+        "title": "11.5",
+        "sku": "A11822M115",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388219984",
+        "title": "12",
+        "sku": "A11822M120",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222388252752",
+        "title": "12.5",
+        "sku": "A11822M125",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222388285520",
+        "title": "13",
+        "sku": "A11822M130",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222388318288",
+        "title": "13.5",
+        "sku": "A11822M135",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222388351056",
+        "title": "14",
+        "sku": "A11822M140",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222388383824",
+        "title": "15",
+        "sku": "A11822M150",
+        "price": "105.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_LEFT-2000x2000_3b9395b8-9536-4094-8be0-9e280e22252a.png?v=1751901151",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_BACK-2000x2000_224f2599-1b7b-4de5-977b-cec6837fdfa8.png?v=1751901151",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_TD-2000x2000_cf33e3ed-dbfd-448c-ae03-8b85119ec5db.png?v=1751901151",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_SOLE-2000x2000_20aad2b8-197b-4c40-9ab5-41c9c62c86b1.png?v=1751901151",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_PAIR_3Q-2000x2000_41750921-b4fe-4471-a950-770a8f18be3e.png?v=1751901151"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-tree-breezer-bow",
+    "product_id": "7193242992720",
+    "handle": "womens-tree-breezer-bow",
+    "title": "Women's Tree Breezer Bow - Medium Grey",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41220623073360",
+        "title": "5",
+        "sku": "A11594W050",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623106128",
+        "title": "5.5",
+        "sku": "A11594W055",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623138896",
+        "title": "6",
+        "sku": "A11594W060",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623171664",
+        "title": "6.5",
+        "sku": "A11594W065",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623204432",
+        "title": "7",
+        "sku": "A11594W070",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623237200",
+        "title": "7.5",
+        "sku": "A11594W075",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623269968",
+        "title": "8",
+        "sku": "A11594W080",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623302736",
+        "title": "8.5",
+        "sku": "A11594W085",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623335504",
+        "title": "9",
+        "sku": "A11594W090",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623368272",
+        "title": "9.5",
+        "sku": "A11594W095",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623401040",
+        "title": "10",
+        "sku": "A11594W100",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623433808",
+        "title": "10.5",
+        "sku": "A11594W105",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "41220623466576",
+        "title": "11",
+        "sku": "A11594W110",
+        "price": "60.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11594_25Q3_Tree_Breezer_Bow_Medium_Grey_PDP_LEFT-2000x2000.png?v=1751993156",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11594_25Q3_Tree_Breezer_Bow_Medium_Grey_PDP_BACK-2000x2000.png?v=1751993155",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11594_25Q3_Tree_Breezer_Bow_Medium_Grey_PDP_TD_V2-2000x2000.png?v=1751993156",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11594_25Q3_Tree_Breezer_Bow_Medium_Grey_PDP_SOLE-2000x2000.png?v=1751993156",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11594_25Q3_Tree_Breezer_Bow_Medium_Grey_PDP_PAIR_3Q-2000x2000.png?v=1751993156"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-tree-runner-nz",
+    "product_id": "7188364361808",
+    "handle": "womens-tree-runner-nz",
+    "title": "Women's Tree Runner NZ - Blizzard (Blizzard Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41206424928336",
+        "title": "5",
+        "sku": "A11940W050",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424961104",
+        "title": "5.5",
+        "sku": "A11940W055",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206424993872",
+        "title": "6",
+        "sku": "A11940W060",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425026640",
+        "title": "6.5",
+        "sku": "A11940W065",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206425059408",
+        "title": "7",
+        "sku": "A11940W070",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425092176",
+        "title": "7.5",
+        "sku": "A11940W075",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425124944",
+        "title": "8",
+        "sku": "A11940W080",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425157712",
+        "title": "8.5",
+        "sku": "A11940W085",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425190480",
+        "title": "9",
+        "sku": "A11940W090",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425223248",
+        "title": "9.5",
+        "sku": "A11940W095",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425256016",
+        "title": "10",
+        "sku": "A11940W100",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425288784",
+        "title": "10.5",
+        "sku": "A11940W105",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206425321552",
+        "title": "11",
+        "sku": "A11940W110",
+        "price": "100.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11918_25Q3_Tree_Runner_NZ_Blizzard_Blizzard_Sole_PDP_LEFT-2000x2000_77f92b7c-e2d6-494c-aa3c-caa9a2d8b6bc.png?v=1751898682",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11918_25Q3_Tree_Runner_NZ_Blizzard_Blizzard_Sole_PDP_BACK-2000x2000_3a51eff2-0634-48f1-9357-7ebb113765ee.png?v=1751898682",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11918_25Q3_Tree_Runner_NZ_Blizzard_Blizzard_Sole_PDP_TD-2000x2000_26295c14-f8f9-4572-be69-5daf87163a99.png?v=1751898682",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11918_25Q3_Tree_Runner_NZ_Blizzard_Blizzard_Sole_PDP_SOLE-2000x2000_2065eca5-6c20-403e-8d15-5aa790c8beb5.png?v=1751898682",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11918_25Q3_Tree_Runner_NZ_Blizzard_Blizzard_Sole_PDP_PAIR_3Q-2000x2000_3c61e5fd-f05d-4110-a1c7-dd63c8b60bad.png?v=1751898682"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-tree-runner-nz-natural-white",
+    "product_id": "7188364329040",
+    "handle": "womens-tree-runner-nz-natural-white",
+    "title": "Women's Tree Runner NZ - Natural White (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41206424502352",
+        "title": "5",
+        "sku": "A11960W050",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424535120",
+        "title": "5.5",
+        "sku": "A11960W055",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424567888",
+        "title": "6",
+        "sku": "A11960W060",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424600656",
+        "title": "6.5",
+        "sku": "A11960W065",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424633424",
+        "title": "7",
+        "sku": "A11960W070",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424666192",
+        "title": "7.5",
+        "sku": "A11960W075",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424698960",
+        "title": "8",
+        "sku": "A11960W080",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424731728",
+        "title": "8.5",
+        "sku": "A11960W085",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424764496",
+        "title": "9",
+        "sku": "A11960W090",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424797264",
+        "title": "9.5",
+        "sku": "A11960W095",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206424830032",
+        "title": "10",
+        "sku": "A11960W100",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424862800",
+        "title": "10.5",
+        "sku": "A11960W105",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206424895568",
+        "title": "11",
+        "sku": "A11960W110",
+        "price": "100.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_LEFT-2000x2000_cac9c5e6-c236-4ba8-9730-90c4099aea69.png?v=1751899558",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_BACK-2000x2000_006f0715-8594-4827-94db-899874f4344f.png?v=1751899558",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_TD-2000x2000_51b63fc4-9f0e-4325-ae90-8f59749c0bbd.png?v=1751899558",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_SOLE-2000x2000_20b3d818-47e1-4c5a-847f-66424c49bda7.png?v=1751899558",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_PAIR_3Q-2000x2000_3976b695-0741-412a-a85c-b265e2591de2.png?v=1751899558"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-tree-runner-nz-thunder-green",
+    "product_id": "7188363771984",
+    "handle": "mens-tree-runner-nz-thunder-green",
+    "title": "Men's Tree Runner NZ - Thunder Green (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41206421815376",
+        "title": "8",
+        "sku": "A12096M080",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206421848144",
+        "title": "8.5",
+        "sku": "A12096M085",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206421880912",
+        "title": "9",
+        "sku": "A12096M090",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206421913680",
+        "title": "9.5",
+        "sku": "A12096M095",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206421946448",
+        "title": "10",
+        "sku": "A12096M100",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206421979216",
+        "title": "10.5",
+        "sku": "A12096M105",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422011984",
+        "title": "11",
+        "sku": "A12096M110",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422044752",
+        "title": "11.5",
+        "sku": "A12096M115",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422077520",
+        "title": "12",
+        "sku": "A12096M120",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422110288",
+        "title": "12.5",
+        "sku": "A12096M125",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422143056",
+        "title": "13",
+        "sku": "A12096M130",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422175824",
+        "title": "13.5",
+        "sku": "A12096M135",
+        "price": "80.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206422208592",
+        "title": "14",
+        "sku": "A12096M140",
+        "price": "80.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12096_25Q3_Tree_Runner_NZ_Thunder_Green_Natural_White_Sole_PDP_LEFT-2000x2000.png?v=1751899846",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12096_25Q3_Tree_Runner_NZ_Thunder_Green_Natural_White_Sole_PDP_BACK-2000x2000.png?v=1751899846",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12096_25Q3_Tree_Runner_NZ_Thunder_Green_Natural_White_Sole_PDP_TD-2000x2000.png?v=1751899846",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12096_25Q3_Tree_Runner_NZ_Thunder_Green_Natural_White_Sole_PDP_SOLE-2000x2000.png?v=1751899846",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12096_25Q3_Tree_Runner_NZ_Thunder_Green_Natural_White_Sole_PDP_PAIR_3Q-2000x2000.png?v=1751899846"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-tree-runner-nz-natural-white",
+    "product_id": "7188363542608",
+    "handle": "mens-tree-runner-nz-natural-white",
+    "title": "Men's Tree Runner NZ - Natural White (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41206418636880",
+        "title": "8",
+        "sku": "A11914M080",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206418669648",
+        "title": "8.5",
+        "sku": "A11914M085",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418702416",
+        "title": "9",
+        "sku": "A11914M090",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418735184",
+        "title": "9.5",
+        "sku": "A11914M095",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418767952",
+        "title": "10",
+        "sku": "A11914M100",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206418800720",
+        "title": "10.5",
+        "sku": "A11914M105",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418833488",
+        "title": "11",
+        "sku": "A11914M110",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418866256",
+        "title": "11.5",
+        "sku": "A11914M115",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418899024",
+        "title": "12",
+        "sku": "A11914M120",
+        "price": "100.00",
+        "available": false
+      },
+      {
+        "variant_id": "41206418931792",
+        "title": "12.5",
+        "sku": "A11914M125",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206418964560",
+        "title": "13",
+        "sku": "A11914M130",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206418997328",
+        "title": "13.5",
+        "sku": "A11914M135",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206419030096",
+        "title": "14",
+        "sku": "A11914M140",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41206419062864",
+        "title": "15",
+        "sku": "A11914M150",
+        "price": "100.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_LEFT-2000x2000.png?v=1751899537",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_BACK-2000x2000.png?v=1751899536",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_TD-2000x2000.png?v=1751899537",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_SOLE-2000x2000.png?v=1751899537",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11914_25Q3_Tree_Runner_NZ_Natural_White_Natural_White_Sole_PDP_PAIR_3Q-2000x2000.png?v=1751899537"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-merino-blend-sweatpant",
+    "product_id": "7142338625616",
+    "handle": "mens-merino-blend-sweatpant",
+    "title": "Men's Merino Blend Sweatpant - True Black",
+    "vendor": "Allbirds",
+    "product_type": "Apparel",
+    "variants": [
+      {
+        "variant_id": "41044402896976",
+        "title": "S",
+        "sku": "A11210M001",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41044402929744",
+        "title": "M",
+        "sku": "A11210M002",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41044402962512",
+        "title": "L",
+        "sku": "A11210M003",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41044402995280",
+        "title": "XL",
+        "sku": "A11210M004",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41044403028048",
+        "title": "XXL",
+        "sku": "A11210M005",
+        "price": "47.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_TrueBlack_Front_1600x1600_7d935343-837f-4a7d-aea0-b6cd81fab57f.jpg?v=1738092524",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_TrueBlack_Back_1600x1600_39d31db8-237c-4d15-a82e-c4973b2de78c.jpg?v=1738092524",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_TrueBlack_Detail_1600x1600_fa52502f-139a-44ae-95d3-6dc00b7e4742.jpg?v=1738092524",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_TrueBlack_FullBody_1600x1600_37290c67-fcb6-4c0c-964b-9531dc7f0cf8.jpg?v=1738092524"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-merino-blend-sweatshirt-natural-grey-heather",
+    "product_id": "7135000428624",
+    "handle": "womens-merino-blend-sweatshirt-natural-grey-heather",
+    "title": "Women's Merino Blend Sweatshirt - Natural Grey Heather",
+    "vendor": "Allbirds",
+    "product_type": "Apparel",
+    "variants": [
+      {
+        "variant_id": "41019302903888",
+        "title": "XS",
+        "sku": "A11221W000",
+        "price": "45.00",
+        "available": true
+      },
+      {
+        "variant_id": "41019302936656",
+        "title": "S",
+        "sku": "A11221W001",
+        "price": "45.00",
+        "available": true
+      },
+      {
+        "variant_id": "41019302969424",
+        "title": "M",
+        "sku": "A11221W002",
+        "price": "45.00",
+        "available": true
+      },
+      {
+        "variant_id": "41019303002192",
+        "title": "L",
+        "sku": "A11221W003",
+        "price": "45.00",
+        "available": true
+      },
+      {
+        "variant_id": "41019303034960",
+        "title": "XL",
+        "sku": "A11221W004",
+        "price": "45.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Women_Natural_Grey_Heather_WaistUpFront_5299_1600x1600_f12ac2a5-1dca-4b7e-a02c-76dd2ddcf37c.jpg?v=1740073161",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Women_Natural_Grey_Heather_WaistUpBack_5341_1600x1600_7abcd017-b171-45aa-a321-e11751ad5638.jpg?v=1740073162",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Women_Natural_Grey_Heather_Detail_5386_1600x1600_0f9dfcb8-c061-4f7e-956a-77eaf7a10a94.jpg?v=1740073161",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Women_Natural_Grey_Heather_Detail_7495_1600x1600_e28e369c-71f8-44de-890a-2bca68bdff40.jpg?v=1740073161",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Women_Natural_Grey_Heather_HeadToToe_5229_1600x1600_226b6710-2052-419d-a986-625e5120e932.jpg?v=1740073161"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-merino-blend-sweatpant-natural-grey-heather",
+    "product_id": "7134998790224",
+    "handle": "mens-merino-blend-sweatpant-natural-grey-heather",
+    "title": "Men's Merino Blend Sweatpant - Natural Grey Heather",
+    "vendor": "Allbirds",
+    "product_type": "Apparel",
+    "variants": [
+      {
+        "variant_id": "41019299102800",
+        "title": "S",
+        "sku": "A11215M001",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41019299135568",
+        "title": "M",
+        "sku": "A11215M002",
+        "price": "47.00",
+        "available": true
+      },
+      {
+        "variant_id": "41019299168336",
+        "title": "L",
+        "sku": "A11215M003",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41019299201104",
+        "title": "XL",
+        "sku": "A11215M004",
+        "price": "47.00",
+        "available": false
+      },
+      {
+        "variant_id": "41019299233872",
+        "title": "XXL",
+        "sku": "A11215M005",
+        "price": "47.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_Natural_Grey_Heather_WaistDownFront_2085_1600x1600_09eed79a-3de6-44b0-8a72-201112a12e23.jpg?v=1740073271",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_Natural_Grey_Heather_WaistDownBack_2362_1600x1600_fbefb00c-7add-4311-8aee-0b911a6c65ff.jpg?v=1740073271",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatpant_Site_PDP_Men_Natural_Grey_Heather_Detail_2237_1600x1600_328d829e-a239-499c-b4d5-b6374337b848.jpg?v=1740073271",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/25Q1_Apparel_MerinoBlendSweatshirt_Site_PDP_Men_Natural_Grey_Heather_HeadToToe_4210_1600x1600_9a6c97d2-e185-42e8-bb3d-37e1d4a72aa4.jpg?v=1740073271"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-cruiser-shadow-blue-natural-white-sole",
+    "product_id": "7292464955472",
+    "handle": "mens-cruiser-shadow-blue-natural-white-sole",
+    "title": "Men's Cruiser - Shadow Blue (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41990816759888",
+        "title": "8",
+        "sku": "A12856M080",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816792656",
+        "title": "8.5",
+        "sku": "A12856M085",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816825424",
+        "title": "9",
+        "sku": "A12856M090",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816858192",
+        "title": "9.5",
+        "sku": "A12856M095",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816890960",
+        "title": "10",
+        "sku": "A12856M100",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816923728",
+        "title": "10.5",
+        "sku": "A12856M105",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816956496",
+        "title": "11",
+        "sku": "A12856M110",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990816989264",
+        "title": "11.5",
+        "sku": "A12856M115",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990817022032",
+        "title": "12",
+        "sku": "A12856M120",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990817054800",
+        "title": "12.5",
+        "sku": "A12856M125",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990817087568",
+        "title": "13",
+        "sku": "A12856M130",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990817120336",
+        "title": "14",
+        "sku": "A12856M140",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41990817153104",
+        "title": "15",
+        "sku": "A12856M150",
+        "price": "105.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0010.png?v=1783535519",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0017.png?v=1783535524",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0029.png?v=1783535534",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0014_e70e39f1-8894-4050-bd34-c34dd5348523.png?v=1783535552",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0028.png?v=1783535556"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-cruiser-slip-on-canvas-sea-spray-natural-white-sole",
+    "product_id": "7215691300944",
+    "handle": "womens-cruiser-slip-on-canvas-sea-spray-natural-white-sole",
+    "title": "Women's Cruiser Slip On Canvas - Sea Spray (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41315822796880",
+        "title": "5",
+        "sku": "A12854W050",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822829648",
+        "title": "5.5",
+        "sku": "A12854W055",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822862416",
+        "title": "6",
+        "sku": "A12854W060",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822895184",
+        "title": "6.5",
+        "sku": "A12854W065",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822927952",
+        "title": "7",
+        "sku": "A12854W070",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822960720",
+        "title": "7.5",
+        "sku": "A12854W075",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315822993488",
+        "title": "8",
+        "sku": "A12854W080",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823026256",
+        "title": "8.5",
+        "sku": "A12854W085",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823059024",
+        "title": "9",
+        "sku": "A12854W090",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823091792",
+        "title": "9.5",
+        "sku": "A12854W095",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823124560",
+        "title": "10",
+        "sku": "A12854W100",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823157328",
+        "title": "10.5",
+        "sku": "A12854W105",
+        "price": "100.00",
+        "available": true
+      },
+      {
+        "variant_id": "41315823190096",
+        "title": "11",
+        "sku": "A12854W110",
+        "price": "100.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0005_c3386c3f-064e-43f2-9d46-66377d0ebd10.png?v=1783537948",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0018_0142b8ea-0931-49b0-9f1d-606d80803cdd.png?v=1783537948",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0035_02293746-a96e-41a3-b160-74814342fa8c.png?v=1783537948",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_007W_74c28fb0-9d3b-4a0b-a514-2f54a5a8c868.png?v=1783537948",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0025_5c2a22fc-9a99-4909-b929-cf41fbadd246.png?v=1783537948"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-cruiser-terralux-anthracite",
+    "product_id": "7205181653072",
+    "handle": "mens-cruiser-terralux-anthracite",
+    "title": "Men's Cruiser Terralux - Anthracite (Dark Gum Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41271112466512",
+        "title": "8",
+        "sku": "A12400M080",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112499280",
+        "title": "8.5",
+        "sku": "A12400M085",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112532048",
+        "title": "9",
+        "sku": "A12400M090",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112564816",
+        "title": "9.5",
+        "sku": "A12400M095",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112597584",
+        "title": "10",
+        "sku": "A12400M100",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112630352",
+        "title": "10.5",
+        "sku": "A12400M105",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112663120",
+        "title": "11",
+        "sku": "A12400M110",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112695888",
+        "title": "11.5",
+        "sku": "A12400M115",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112728656",
+        "title": "12",
+        "sku": "A12400M120",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112761424",
+        "title": "12.5",
+        "sku": "A12400M125",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112794192",
+        "title": "13",
+        "sku": "A12400M130",
+        "price": "135.00",
+        "available": false
+      },
+      {
+        "variant_id": "41271112859728",
+        "title": "14",
+        "sku": "A12400M140",
+        "price": "135.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12400_26Q1_Cruiser-Terralux-Anthracite-Dark-Gum-Sole_PDP_LEFT.png?v=1768947640",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12400_26Q1_Cruiser-Terralux-Anthracite-Dark-Gum-Sole_PDP_BACK.png?v=1768947640",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12400_26Q1_Cruiser-Terralux-Anthracite-Dark-Gum-Sole_PDP_TD.png?v=1768947642",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12400_26Q1_Cruiser-Terralux-Anthracite-Dark-Gum-Sole_PDP_SOLE.png?v=1768947640",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12400_26Q1_Cruiser-Terralux-Anthracite-Dark-Gum-Sole_PDP_PAIR_3Q.png?v=1768947640"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-wool-runner-nz-mid-waterproof",
+    "product_id": "7214904279120",
+    "handle": "womens-wool-runner-nz-mid-waterproof",
+    "title": "Women's Wool Runner NZ Mid Waterproof - Natural Black (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41313654669392",
+        "title": "5",
+        "sku": "A12050W050",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654702160",
+        "title": "5.5",
+        "sku": "A12050W055",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654734928",
+        "title": "6",
+        "sku": "A12050W060",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654767696",
+        "title": "6.5",
+        "sku": "A12050W065",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654800464",
+        "title": "7",
+        "sku": "A12050W070",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654833232",
+        "title": "7.5",
+        "sku": "A12050W075",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654866000",
+        "title": "8",
+        "sku": "A12050W080",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654898768",
+        "title": "8.5",
+        "sku": "A12050W085",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654931536",
+        "title": "9",
+        "sku": "A12050W090",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654964304",
+        "title": "9.5",
+        "sku": "A12050W095",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313654997072",
+        "title": "10",
+        "sku": "A12050W100",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313655029840",
+        "title": "10.5",
+        "sku": "A12050W105",
+        "price": "160.00",
+        "available": true
+      },
+      {
+        "variant_id": "41313655062608",
+        "title": "11",
+        "sku": "A12050W110",
+        "price": "160.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12023_25Q3_Wool-Runner-NZ-Mid-Waterproof-Natural-Black-Natural-White-Sole_PDP_LEFT_15a18748-ff33-4e50-8755-fbf0158abcdd.png?v=1757724073",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12023_25Q3_Wool-Runner-NZ-Mid-Waterproof-Natural-Black-Natural-White-Sole_PDP_BACK_df4a9fe9-71d4-46fb-8f54-1498b5c48138.png?v=1757724072",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12023_25Q3_Wool-Runner-NZ-Mid-Waterproof-Natural-Black-Natural-White-Sole_PDP_TD_76382c58-3bfa-4496-a89a-6cfa5f66301d.png?v=1757724072",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12023_25Q3_Wool-Runner-NZ-Mid-Waterproof-Natural-Black-Natural-White-Sole_PDP_SOLE_826db8b6-caf0-4a7d-ad39-f1e1a84cb7bf.png?v=1757724072",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A12023_25Q3_Wool-Runner-NZ-Mid-Waterproof-Natural-Black-Natural-White-Sole_PDP_PAIR_3Q_d5edd67d-f23a-4e7e-b8d8-b9f17a4cf145.png?v=1757724074"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-wool-runner-up-mizzles-hazy-indigo",
+    "product_id": "6712397496400",
+    "handle": "womens-wool-runner-up-mizzles-hazy-indigo",
+    "title": "Women's Wool Runner-up Mizzle - Hazy Indigo (Hazy Indigo Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "39812334518352",
+        "title": "5",
+        "sku": "AB0076W050",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334551120",
+        "title": "6",
+        "sku": "AB0076W060",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334583888",
+        "title": "7",
+        "sku": "AB0076W070",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334616656",
+        "title": "8",
+        "sku": "AB0076W080",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334649424",
+        "title": "9",
+        "sku": "AB0076W090",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334682192",
+        "title": "10",
+        "sku": "AB0076W100",
+        "price": "60.00",
+        "available": false
+      },
+      {
+        "variant_id": "39812334714960",
+        "title": "11",
+        "sku": "AB0076W110",
+        "price": "60.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AB0074M_SHOE_LEFT_GLOBAL_MENS_WOOL_RUNNER-UP_MIZZLE2_HAZY_INDIGO_RUGGED_KHAKI_9542e175-df7f-4dca-9092-29289041b8cc.png?v=1781829612",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AB0074M_SHOE_BACK_GLOBAL_MENS_WOOL_RUNNER-UP_MIZZLE2_HAZY_INDIGO_RUGGED_KHAKI_6ecb8314-b804-4320-b527-fb637c6a72df.png?v=1781829612",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AB0074M_SHOE_TOP_GLOBAL_MENS_WOOL_RUNNER-UP_MIZZLE2_HAZY_INDIGO_RUGGED_KHAKI_aa627c99-940e-4ed7-aeef-9f472360fb58.png?v=1781829613",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AB0074M_SHOE_BOTTOM_GLOBAL_MENS_WOOL_RUNNER-UP_MIZZLE2_HAZY_INDIGO_RUGGED_KHAKI_f5b1b155-0eb5-4338-b5d1-ac1312d96826.png?v=1781829613"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/trino-sprinters-low-buoyant-pink",
+    "product_id": "6698212458576",
+    "handle": "trino-sprinters-low-buoyant-pink",
+    "title": "Trino® Sprinters - Low - Buoyant Pink",
+    "vendor": "Allbirds",
+    "product_type": "Socks",
+    "variants": [
+      {
+        "variant_id": "39790553563216",
+        "title": "S (W5-7)",
+        "sku": "AR000AU001",
+        "price": "4.00",
+        "available": false
+      },
+      {
+        "variant_id": "39790553595984",
+        "title": "M (W8-10 / M8)",
+        "sku": "AR000AU002",
+        "price": "4.00",
+        "available": true
+      },
+      {
+        "variant_id": "39790553628752",
+        "title": "L (W11 / M9-12)",
+        "sku": "AR000AU003",
+        "price": "4.00",
+        "available": false
+      },
+      {
+        "variant_id": "39790553661520",
+        "title": "XL (M13-14)",
+        "sku": "AR000AU004",
+        "price": "4.00",
+        "available": true
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AR000AU_BASICS_FRONT_GLOBAL_UNISEX_TRINO_SPRINTERS_LOW_BUOYANT_PINK_3375.png?v=1781828642",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AR000AU_BASICS_BACK_GLOBAL_UNISEX_TRINO_SPRINTERS_LOW_BUOYANT_PINK_3384.png?v=1781828642",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/AR000AU_BASICS_MACRO_GLOBAL_UNISEX_TRINO_SPRINTERS_LOW_BUOYANT_PINK_3473.png?v=1781828642"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/trino-sprinters-cushioned-onyx-new-edition",
+    "product_id": "6691390423120",
+    "handle": "trino-sprinters-cushioned-onyx-new-edition",
+    "title": "Trino® Sprinters - Cushioned - Onyx - New Edition",
+    "vendor": "Allbirds",
+    "product_type": "Socks",
+    "variants": [
+      {
+        "variant_id": "39773456662608",
+        "title": "S (W5-7)",
+        "sku": "AR0008U001",
+        "price": "4.00",
+        "available": false
+      },
+      {
+        "variant_id": "39773456695376",
+        "title": "M (W8-10 / M8)",
+        "sku": "AR0008U002",
+        "price": "4.00",
+        "available": false
+      },
+      {
+        "variant_id": "39773456728144",
+        "title": "L (W11 / M9-12)",
+        "sku": "AR0008U003",
+        "price": "4.00",
+        "available": false
+      },
+      {
+        "variant_id": "39773456760912",
+        "title": "XL (M13-14)",
+        "sku": "AR0008U004",
+        "price": "4.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/Allbirds_FY21_Q3_Socks_PDP_black_form_front_PACER_b116c95f-f27a-4ebc-b9ea-32ad4164a4b2.png?v=1781825614",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/Allbirds_FY21_Q3_Socks_PDP_black_form_back_PACER__1_790f3502-bd4b-441d-87b0-e1a6c7631c9f.png?v=1781825614",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/PSS1XXXU_SOCK_PAIR_PACER_GLOBAL_ONYX_1f23366a-4942-4dcf-8512-dee5ecd06dea.png?v=1781825614"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/trino-sprinters-no-show-onyx",
+    "product_id": "6622704959568",
+    "handle": "trino-sprinters-no-show-onyx",
+    "title": "Trino® Sprinters - No Show - Onyx",
+    "vendor": "Allbirds",
+    "product_type": "Socks",
+    "variants": [
+      {
+        "variant_id": "39594659512400",
+        "title": "S (W5-7)",
+        "sku": "PSN2ONXU101",
+        "price": "3.00",
+        "available": true
+      },
+      {
+        "variant_id": "39594659545168",
+        "title": "M (W8-10 / M8)",
+        "sku": "PSN2ONXU102",
+        "price": "3.00",
+        "available": false
+      },
+      {
+        "variant_id": "39594659577936",
+        "title": "L (W11 / M9-12)",
+        "sku": "PSN2ONXU103",
+        "price": "3.00",
+        "available": true
+      },
+      {
+        "variant_id": "39594659610704",
+        "title": "XL (M13-14)",
+        "sku": "PSN2ONXU104",
+        "price": "3.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/PSN2ONXU_BASICS_FRONT_GLOBAL_UNISEX_TRINO_SPRINTERS_NO_SHOW_ONYX_3439.png?v=1781825117",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/PSN2ONXU_BASICS_BACK_GLOBAL_UNISEX_TRINO_SPRINTERS_NO_SHOW_ONYX_3446.png?v=1781825118",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/PSN2ONXU_BASICS_MACRO_GLOBAL_UNISEX_TRINO_SPRINTERS_NO_SHOW_ONYX_3469.png?v=1781825118"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-lounger-lift-rugged-beige-stony-cream",
+    "product_id": "7193832652880",
+    "handle": "womens-lounger-lift-rugged-beige-stony-cream",
+    "title": "Women's Lounger Lift - Rugged Beige (Stony Cream Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41222676316240",
+        "title": "5",
+        "sku": "A11844W050",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676349008",
+        "title": "5.5",
+        "sku": "A11844W055",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676381776",
+        "title": "6",
+        "sku": "A11844W060",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676414544",
+        "title": "6.5",
+        "sku": "A11844W065",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676447312",
+        "title": "7",
+        "sku": "A11844W070",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676480080",
+        "title": "7.5",
+        "sku": "A11844W075",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676512848",
+        "title": "8",
+        "sku": "A11844W080",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676545616",
+        "title": "8.5",
+        "sku": "A11844W085",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676578384",
+        "title": "9",
+        "sku": "A11844W090",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676611152",
+        "title": "9.5",
+        "sku": "A11844W095",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676643920",
+        "title": "10",
+        "sku": "A11844W100",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676676688",
+        "title": "10.5",
+        "sku": "A11844W105",
+        "price": "45.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222676709456",
+        "title": "11",
+        "sku": "A11844W110",
+        "price": "45.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11844_25Q3_Lounger_Lift_Travel_Rugged_Beige_Stony_Cream_Sole_PDP_LEFT-2000x2000.png?v=1751580756",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11844_25Q3_Lounger_Lift_Travel_Rugged_Beige_Stony_Cream_Sole_PDP_BACK-2000x2000.png?v=1751580756",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11844_25Q3_Lounger_Lift_Travel_Rugged_Beige_Stony_Cream_Sole_PDP_TD-2000x2000.png?v=1751580756",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11844_25Q3_Lounger_Lift_Travel_Rugged_Beige_Stony_Cream_Sole_PDP_SOLE-2000x2000.png?v=1751580756",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11844_25Q3_Lounger_Lift_Travel_Rugged_Beige_Stony_Cream_Sole_PDP_PAIR_3Q-2000x2000.png?v=1751580756"
+    ]
+  },
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/womens-cruiser-natural-white",
+    "product_id": "7193759645776",
+    "handle": "womens-cruiser-natural-white",
+    "title": "Women's Cruiser - Natural White (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41222391857232",
+        "title": "5",
+        "sku": "A11818W050",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222391890000",
+        "title": "5.5",
+        "sku": "A11818W055",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222391922768",
+        "title": "6",
+        "sku": "A11818W060",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222391955536",
+        "title": "6.5",
+        "sku": "A11818W065",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222391988304",
+        "title": "7",
+        "sku": "A11818W070",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392021072",
+        "title": "7.5",
+        "sku": "A11818W075",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392053840",
+        "title": "8",
+        "sku": "A11818W080",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392086608",
+        "title": "8.5",
+        "sku": "A11818W085",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392119376",
+        "title": "9",
+        "sku": "A11818W090",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392152144",
+        "title": "9.5",
+        "sku": "A11818W095",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392184912",
+        "title": "10",
+        "sku": "A11818W100",
+        "price": "105.00",
+        "available": false
+      },
+      {
+        "variant_id": "41222392217680",
+        "title": "10.5",
+        "sku": "A11818W105",
+        "price": "105.00",
+        "available": true
+      },
+      {
+        "variant_id": "41222392250448",
+        "title": "11",
+        "sku": "A11818W110",
+        "price": "105.00",
+        "available": false
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_LEFT-2000x2000.png?v=1751901147",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_BACK-2000x2000.png?v=1751901146",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_TD-2000x2000.png?v=1751901147",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_SOLE-2000x2000.png?v=1751901146",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/A11822_25Q3_Cruiser_Natural_White_Natural_White_PDP_PAIR_3Q-2000x2000.png?v=1751901147"
+    ]
+  }
+]

--- a/shopify-scraper/results/product.json
+++ b/shopify-scraper/results/product.json
@@ -1,0 +1,111 @@
+[
+  {
+    "store_url": "https://www.allbirds.com",
+    "source_url": "https://www.allbirds.com/products/mens-cruiser-shadow-blue-natural-white-sole",
+    "product_id": "7292464955472",
+    "handle": "mens-cruiser-shadow-blue-natural-white-sole",
+    "title": "Men's Cruiser - Shadow Blue (Natural White Sole)",
+    "vendor": "Allbirds",
+    "product_type": "Shoes",
+    "variants": [
+      {
+        "variant_id": "41990816759888",
+        "title": "8",
+        "sku": "A12856M080",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816792656",
+        "title": "8.5",
+        "sku": "A12856M085",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816825424",
+        "title": "9",
+        "sku": "A12856M090",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816858192",
+        "title": "9.5",
+        "sku": "A12856M095",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816890960",
+        "title": "10",
+        "sku": "A12856M100",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816923728",
+        "title": "10.5",
+        "sku": "A12856M105",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816956496",
+        "title": "11",
+        "sku": "A12856M110",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990816989264",
+        "title": "11.5",
+        "sku": "A12856M115",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990817022032",
+        "title": "12",
+        "sku": "A12856M120",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990817054800",
+        "title": "12.5",
+        "sku": "A12856M125",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990817087568",
+        "title": "13",
+        "sku": "A12856M130",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990817120336",
+        "title": "14",
+        "sku": "A12856M140",
+        "price": "105.00",
+        "available": null
+      },
+      {
+        "variant_id": "41990817153104",
+        "title": "15",
+        "sku": "A12856M150",
+        "price": "105.00",
+        "available": null
+      }
+    ],
+    "images": [
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0010.png?v=1783535519",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0017.png?v=1783535524",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0029.png?v=1783535534",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0014_e70e39f1-8894-4050-bd34-c34dd5348523.png?v=1783535552",
+      "https://cdn.shopify.com/s/files/1/1104/4168/files/All-birds_0028.png?v=1783535556"
+    ]
+  }
+]

--- a/shopify-scraper/results/sitemap.json
+++ b/shopify-scraper/results/sitemap.json
@@ -1,0 +1,567 @@
+[
+  {
+    "url": "https://www.gymshark.com/",
+    "lastmod": null,
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/shop-women",
+    "lastmod": "2026-07-22T18:15:53.391Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/leggings-guide",
+    "lastmod": "2026-07-22T17:59:16.090Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/home",
+    "lastmod": "2026-07-22T17:59:15.463Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/1",
+    "lastmod": "2026-07-21T18:31:10.936Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/lift-seamless",
+    "lastmod": "2026-07-20T14:07:05.360Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/shop-men",
+    "lastmod": "2026-07-16T19:18:57.508Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/onyx",
+    "lastmod": "2026-07-16T18:33:12.873Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/kalverstraat",
+    "lastmod": "2026-07-10T11:14:54.080Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/sports-bras",
+    "lastmod": "2026-07-09T16:46:09.792Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-loyalty",
+    "lastmod": "2026-07-09T13:00:15.324Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/coming-soon",
+    "lastmod": "2026-07-09T09:32:41.222Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/home_variant_a",
+    "lastmod": "2026-07-06T15:30:07.806Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/home_variant_c",
+    "lastmod": "2026-07-03T05:48:23.311Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/home_variant_b",
+    "lastmod": "2026-07-03T05:47:30.484Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/as-seen-on-social",
+    "lastmod": "2026-06-25T14:47:05.410Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-sale-giveaway-terms-and-conditions",
+    "lastmod": "2026-06-24T14:57:52.960Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/bratz",
+    "lastmod": "2026-06-22T10:15:22.423Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/new-users",
+    "lastmod": "2026-06-17T09:07:22.103Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gslc",
+    "lastmod": "2026-06-01T07:50:25.050Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/bratz-giveaway-social",
+    "lastmod": "2026-05-28T07:46:55.658Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/loyalty-bratz-giveaway",
+    "lastmod": "2026-05-28T07:39:18.105Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/2",
+    "lastmod": "2026-05-27T15:09:08.709Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/pink-trend",
+    "lastmod": "2026-05-22T13:13:51.695Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/back-to-school",
+    "lastmod": "2026-05-15T14:37:18.283Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/form",
+    "lastmod": "2026-05-12T12:16:16.211Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/cbum",
+    "lastmod": "2026-05-07T17:58:23.795Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/cbum-gymshark-member-prize-draw",
+    "lastmod": "2026-04-28T16:00:20.027Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/regent-street",
+    "lastmod": "2026-04-28T09:59:25.739Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/running-hub",
+    "lastmod": "2026-04-24T07:52:15.764Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/mens-shorts-guide",
+    "lastmod": "2026-04-24T07:43:26.133Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/trafford-centre",
+    "lastmod": "2026-04-18T11:00:11.827Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/power",
+    "lastmod": "2026-04-15T10:35:23.520Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/conditioning-club",
+    "lastmod": "2026-04-13T10:41:00.489Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/interval",
+    "lastmod": "2026-04-13T09:36:55.970Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/about-us",
+    "lastmod": "2026-04-09T14:07:46.685Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/new-users/men",
+    "lastmod": "2026-04-09T12:13:15.598Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/white-city",
+    "lastmod": "2026-03-30T08:36:38.090Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/new-users/women",
+    "lastmod": "2026-03-23T13:02:20.477Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/25-off-tier-4",
+    "lastmod": "2026-03-19T17:11:14.625Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/20-member-reward",
+    "lastmod": "2026-03-19T16:45:31.631Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/stratford-westfield",
+    "lastmod": "2026-03-06T09:52:10.865Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/ultimate-runners-giveaway",
+    "lastmod": "2026-03-03T11:45:25.593Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/roosevelt-store",
+    "lastmod": "2026-03-02T14:22:45.218Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/bond-street-store",
+    "lastmod": "2026-02-27T09:56:26.857Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/whitney",
+    "lastmod": "2026-02-26T19:00:12.996Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/terms-and-conditions",
+    "lastmod": "2026-02-25T16:26:39.466Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/privacy-notice",
+    "lastmod": "2026-02-24T11:51:55.727Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/15-off-next-purchase",
+    "lastmod": "2026-02-23T16:30:42.500Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/loyalty-free-next-day",
+    "lastmod": "2026-02-23T16:27:29.853Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/loyalty-first-100-new-members",
+    "lastmod": "2026-02-23T16:27:23.097Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/terms-of-use",
+    "lastmod": "2026-02-23T14:37:06.235Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/buy-to-get-terms-and-conditions",
+    "lastmod": "2026-02-20T10:34:31.893Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/california-privacy-notice",
+    "lastmod": "2026-02-20T10:34:20.493Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/cctv-and-access-control-privacy-notice",
+    "lastmod": "2026-02-20T10:34:11.099Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/cookie-policy",
+    "lastmod": "2026-02-20T10:34:03.127Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/customer-app-marketing-promotions-events-and-social-media-privacy-notice",
+    "lastmod": "2026-02-20T10:33:55.167Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/customer-ratings-reviews-questions-answers-terms-of-use",
+    "lastmod": "2026-02-20T10:33:47.197Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/emergency-service-and-nhs-discount",
+    "lastmod": "2026-02-20T10:33:38.670Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/group-tax-strategy",
+    "lastmod": "2026-02-20T10:33:30.016Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/loyalty-terms-and-conditions",
+    "lastmod": "2026-02-20T10:33:07.150Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/pay-gap-reports",
+    "lastmod": "2026-02-20T10:31:17.207Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/rest-of-the-world-privacy-notice",
+    "lastmod": "2026-02-20T10:30:59.123Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/retail-wifi-terms-and-conditions",
+    "lastmod": "2026-02-20T10:30:49.168Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/terms-and-conditions",
+    "lastmod": "2026-02-20T10:30:33.914Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-66-terms-and-conditions",
+    "lastmod": "2025-12-29T13:31:34.324Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/modern-slavery",
+    "lastmod": "2025-12-22T14:37:53.400Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/sustainability",
+    "lastmod": "2025-12-22T13:36:09.965Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gifting",
+    "lastmod": "2025-12-22T11:20:46.995Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-factory-list",
+    "lastmod": "2025-12-22T09:30:46.651Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores",
+    "lastmod": "2025-12-10T14:00:32.819Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/black-friday",
+    "lastmod": "2025-12-01T21:55:08.175Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/as-seen-on-social",
+    "lastmod": "2025-10-24T07:47:51.881Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/vital",
+    "lastmod": "2025-10-02T17:55:29.497Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/analis",
+    "lastmod": "2025-09-23T15:47:49.261Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/rad-collab",
+    "lastmod": "2025-09-10T18:15:55.218Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/events/lift-london-as-seen-on",
+    "lastmod": "2025-09-04T13:17:06.176Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/submit-a-fake",
+    "lastmod": "2025-08-11T13:31:11.808Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/live-shopping",
+    "lastmod": "2025-07-14T14:34:13.256Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/bicester-village",
+    "lastmod": "2025-04-08T15:34:24.098Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/events/lift-miami-as-seen-on",
+    "lastmod": "2025-02-09T19:43:32.469Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/stores/nyc-pop-up",
+    "lastmod": "2025-01-20T17:16:44.463Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/modest-wear",
+    "lastmod": "2025-01-16T16:04:51.123Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/new-year-starter-packs",
+    "lastmod": "2025-01-10T12:07:30.768Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/our-platform",
+    "lastmod": "2025-01-08T14:32:48.717Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/our-story",
+    "lastmod": "2025-01-08T14:32:00.278Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/our-audience",
+    "lastmod": "2025-01-08T14:27:25.570Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/home",
+    "lastmod": "2025-01-08T14:23:01.179Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-training-app",
+    "lastmod": "2024-12-13T10:17:44.048Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-innovation-lab",
+    "lastmod": "2024-11-25T13:55:18.222Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-app",
+    "lastmod": "2024-09-23T09:46:12.703Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/events/lift-nyc-as-seen-on",
+    "lastmod": "2024-09-17T08:34:50.078Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/events/lift-nyc-map",
+    "lastmod": "2024-09-14T22:28:07.953Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/guidelines",
+    "lastmod": "2024-07-18T12:46:17.696Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/our-purpose",
+    "lastmod": "2024-07-16T14:31:23.084Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/we-do-gym",
+    "lastmod": "2024-05-28T12:58:16.483Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/everywear",
+    "lastmod": "2024-05-27T08:00:18.384Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/lifting-lookbook",
+    "lastmod": "2024-05-20T10:07:11.086Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/bundles",
+    "lastmod": "2024-05-03T09:19:16.885Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/as-seen-on-draft",
+    "lastmod": "2024-04-18T10:14:18.626Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/libby",
+    "lastmod": "2024-04-16T14:52:32.340Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/francis-ngannou",
+    "lastmod": "2024-04-05T12:34:24.696Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/studentbeans",
+    "lastmod": "2024-03-25T14:49:49.060Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/studio-girl",
+    "lastmod": "2024-03-08T10:39:57.429Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/leana-deeb",
+    "lastmod": "2024-02-27T14:26:47.061Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/lift-miami-as-seen-on",
+    "lastmod": "2024-02-27T11:28:05.476Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/gymshark-66",
+    "lastmod": "2024-02-26T10:08:32.146Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/account-error",
+    "lastmod": "2023-11-16T12:59:43.062Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/job-applicant-privacy-notice",
+    "lastmod": "2023-11-03T14:39:00.835Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/commitment-to-accessibility",
+    "lastmod": "2023-10-05T18:13:22.140Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/smartzer-test",
+    "lastmod": "2023-08-16T12:37:18.961Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/every-strong-belongs",
+    "lastmod": "2023-07-17T16:03:32.054Z",
+    "changefreq": "weekly"
+  },
+  {
+    "url": "https://www.gymshark.com/pages/updated-preferences",
+    "lastmod": "2023-05-31T10:42:13.780Z",
+    "changefreq": "weekly"
+  }
+]

--- a/shopify-scraper/run.py
+++ b/shopify-scraper/run.py
@@ -1,0 +1,40 @@
+"""
+This example run script shows how to run the Shopify scraper defined in ./shopify.py
+It scrapes catalog data and saves it to ./results/
+
+To run this script set the env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+import asyncio
+import json
+from pathlib import Path
+import shopify
+
+output = Path(__file__).parent / "results"
+output.mkdir(exist_ok=True)
+
+
+async def run():
+    shopify.BASE_CONFIG["cache"] = True
+
+    print("running Shopify scrape and saving results to ./results directory")
+
+    catalog = await shopify.scrape_catalog(store_url="https://www.allbirds.com", limit=10, max_pages=2)
+    with open(output / "catalog.json", "w", encoding="utf-8") as f:
+        json.dump(catalog, f, indent=2, ensure_ascii=False)
+
+    products = await shopify.scrape_products(
+        handles=["mens-cruiser-shadow-blue-natural-white-sole"],
+        store_url="https://www.allbirds.com",
+    )
+    with open(output / "product.json", "w", encoding="utf-8") as f:
+        json.dump(products, f, indent=2, ensure_ascii=False)
+
+
+    sitemap = await shopify.scrape_sitemap(sitemap_url="https://www.gymshark.com/sitemap_pages_1.xml")
+    with open(output / "sitemap.json", "w", encoding="utf-8") as f:
+        json.dump(sitemap, f, indent=2, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/shopify-scraper/shopify.py
+++ b/shopify-scraper/shopify.py
@@ -1,0 +1,228 @@
+"""
+This is an example web scraper for Shopify stores.
+
+To run this scraper set env variable $SCRAPFLY_KEY with your scrapfly API key:
+$ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard"
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional, TypedDict
+from urllib.parse import urlparse
+
+from loguru import logger as log
+from scrapfly import ScrapeApiResponse, ScrapeConfig, ScrapflyClient, ScrapflyScrapeError
+
+SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
+
+BASE_CONFIG = {
+    "asp": True,
+    "country": "US",
+}
+
+
+class ShopifyVariant(TypedDict):
+    variant_id: Optional[str]
+    title: Optional[str]
+    sku: Optional[str]
+    price: Optional[str]
+    available: Optional[bool]
+
+
+class ShopifyProduct(TypedDict):
+    store_url: str
+    source_url: str
+    product_id: Optional[str]
+    handle: Optional[str]
+    title: Optional[str]
+    vendor: Optional[str]
+    product_type: Optional[str]
+    variants: List[ShopifyVariant]
+    images: List[str]
+
+
+class SitemapEntry(TypedDict):
+    url: str
+    lastmod: Optional[str]
+    changefreq: Optional[str]
+
+
+def _normalize_store_url(store_url: str) -> str:
+    store_url = store_url.strip()
+    if "://" not in store_url:
+        store_url = f"https://{store_url}"
+    parsed = urlparse(store_url)
+    return f"https://{parsed.netloc}"
+
+
+def _parse_product(raw: Dict[str, Any], store_url: str) -> ShopifyProduct:
+    """build a ShopifyProduct from a raw Shopify product dict"""
+    handle = raw.get("handle")
+    product_id = raw.get("id")
+
+    return {
+        "store_url": store_url,
+        "source_url": f"{store_url}/products/{handle}" if handle else store_url,
+        "product_id": str(product_id) if product_id is not None else None,
+        "handle": handle,
+        "title": raw.get("title"),
+        "vendor": raw.get("vendor"),
+        "product_type": raw.get("product_type"),
+        "variants": [
+            {
+                "variant_id": str(v["id"]) if v.get("id") is not None else None,
+                "title": v.get("title"),
+                "sku": v.get("sku"),
+                "price": v.get("price"),
+                "available": v.get("available"),
+            }
+            for v in raw.get("variants") or []
+            if isinstance(v, dict)
+        ],
+        "images": [img["src"] for img in raw.get("images") or [] if isinstance(img, dict) and img.get("src")],
+    }
+
+
+def _parse_catalog(response: ScrapeApiResponse, store_url: str) -> List[ShopifyProduct]:
+    """parse a /products.json catalog page response"""
+    data = json.loads(response.content)
+    products = data.get("products") if isinstance(data, dict) else None
+    if not products:
+        log.warning("catalog response missing products key")
+        return []
+
+    return [_parse_product(product, store_url) for product in products if isinstance(product, dict)]
+
+
+def _parse_product_json(response: ScrapeApiResponse, store_url: str) -> Optional[ShopifyProduct]:
+    """parse a product from the /products/<handle>.json endpoint response"""
+    data = json.loads(response.content)
+    product = data.get("product") if isinstance(data, dict) else None
+    return _parse_product(product, store_url) if isinstance(product, dict) else None
+
+
+def _parse_product_html(response: ScrapeApiResponse, store_url: str) -> Optional[ShopifyProduct]:
+    """parse a product from the raw HTML product page's JSON-LD data"""
+    ld_json = response.selector.css('script[type="application/ld+json"]::text').get()
+    if not ld_json:
+        log.warning("no JSON-LD product data found in html")
+        return None
+
+    product = json.loads(ld_json)
+    variant_nodes = product.get("hasVariant") or [product]
+    if isinstance(variant_nodes, dict):
+        variant_nodes = [variant_nodes]
+
+    variants = []
+    for v in variant_nodes:
+        offers = v.get("offers") or {}
+        if isinstance(offers, list):
+            offers = offers[0] if offers else {}
+        availability = offers.get("availability")
+        variants.append(
+            {
+                "variant_id": None,
+                "title": v.get("name"),
+                "sku": v.get("sku"),
+                "price": offers.get("price"),
+                "available": ("instock" in availability.lower()) if availability else None,
+            }
+        )
+
+    brand = product.get("brand")
+    url = response.context.get("url", store_url)
+    images = product.get("image")
+    if isinstance(images, str):
+        images = [images]
+
+    return {
+        "store_url": store_url,
+        "source_url": url,
+        "product_id": product.get("productGroupID") or product.get("sku"),
+        "handle": url.split("/products/")[-1].split("?")[0] if "/products/" in url else None,
+        "title": product.get("name"),
+        "vendor": brand.get("name") if isinstance(brand, dict) else brand,
+        "product_type": product.get("category"),
+        "variants": variants,
+        "images": [i for i in (images or []) if isinstance(i, str)],
+    }
+
+
+def _parse_sitemap(response: ScrapeApiResponse) -> List[SitemapEntry]:
+    """parse a Shopify XML sitemap response"""
+    entries: List[SitemapEntry] = []
+    for node in response.selector.xpath("//url | //sitemap"):
+        loc = node.xpath("loc/text()").get()
+        if not loc:
+            continue
+        entries.append(
+            {
+                "url": loc.strip(),
+                "lastmod": node.xpath("lastmod/text()").get(),
+                "changefreq": node.xpath("changefreq/text()").get(),
+            }
+        )
+    return entries
+
+
+async def scrape_sitemap(sitemap_url: str) -> List[SitemapEntry]:
+    """scrape url data from a Shopify XML sitemap"""
+    response = await SCRAPFLY.async_scrape(ScrapeConfig(sitemap_url, asp=False, render_js=False))
+    return _parse_sitemap(response)
+
+
+async def scrape_catalog(
+    store_url: str,
+    limit: Optional[int] = 250,
+    max_pages: Optional[int] = 3,
+) -> List[ShopifyProduct]:
+    """scrape product catalog data from a Shopify store via /products.json"""
+    store_url = _normalize_store_url(store_url)
+    to_scrape = [
+        ScrapeConfig(f"{store_url}/products.json?limit={limit}&page={page}", **BASE_CONFIG)
+        for page in range(1, max_pages + 1)
+    ]
+    results: List[ShopifyProduct] = []
+    async for response in SCRAPFLY.concurrent_scrape(to_scrape):
+        if isinstance(response, ScrapflyScrapeError):
+            log.error(f"failed to scrape catalog page: {response.error}")
+            continue
+        try:
+            results.extend(_parse_catalog(response, store_url))
+        except Exception as e:
+            log.error(f"failed to parse catalog page: {e}")
+    return results
+
+
+async def scrape_products(handles: List[str], store_url: str) -> List[ShopifyProduct]:
+    """scrape individual product data via /products/<handle>.json, falling back to html"""
+    store_url = _normalize_store_url(store_url)
+    results: List[ShopifyProduct] = []
+    json_enabled = True
+
+    for handle in handles:
+        product = None
+
+        if json_enabled:
+            try:
+                response = await SCRAPFLY.async_scrape(
+                    ScrapeConfig(f"{store_url}/products/{handle}.json", asp=False, render_js=False)
+                )
+                product = _parse_product_json(response, store_url)
+            except Exception as e:
+                log.warning(f"json request failed for {handle}: {e}, switching to html for remaining handles")
+                json_enabled = False
+
+        if not product:
+            log.info(f"falling back to html for {handle}")
+            response = await SCRAPFLY.async_scrape(
+                ScrapeConfig(f"{store_url}/products/{handle}", **BASE_CONFIG)
+            )
+            product = _parse_product_html(response, store_url)
+
+        if product:
+            results.append(product)
+        else:
+            log.error(f"failed to scrape product {handle}")
+
+    return results

--- a/shopify-scraper/test.py
+++ b/shopify-scraper/test.py
@@ -1,0 +1,84 @@
+import json
+import os
+from pathlib import Path
+from cerberus import Validator as _Validator
+import pytest
+import pprint
+
+import shopify
+
+pp = pprint.PrettyPrinter(indent=4)
+
+class Validator(_Validator):
+    def _validate_min_presence(self, min_presence, field, value):
+        pass  # required for adding non-standard keys to schema
+
+
+def validate_or_fail(item, validator):
+    if not validator.validate(item):
+        pytest.fail(f"Validation failed for item: {pp.pformat(item)}\nErrors: {validator.errors}")
+
+
+product_schema = {
+    "store_url": {"type": "string"},
+    "source_url": {"type": "string"},
+    "product_id": {"type": "string", "nullable": True},
+    "handle": {"type": "string", "nullable": True},
+    "title": {"type": "string", "nullable": True},
+    "vendor": {"type": "string", "nullable": True},
+    "product_type": {"type": "string", "nullable": True},
+    "variants": {"type": "list"},
+    "images": {"type": "list"},
+}
+
+sitemap_schema = {
+    "url": {"type": "string"},
+    "lastmod": {"type": "string", "nullable": True},
+    "changefreq": {"type": "string", "nullable": True},
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_catalog_scraping():
+    catalog_data = await shopify.scrape_catalog(store_url="https://www.allbirds.com", limit=10, max_pages=2)
+    validator = Validator(product_schema, allow_unknown=True)
+    for item in catalog_data:
+        validate_or_fail(item, validator)
+    assert len(catalog_data) >= 10
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_product_scraping():
+    product_data = await shopify.scrape_products(
+        handles=["gymshark-lift-seamless-sports-bra-sports-bras-pink-ss26-b5c9a-kdfw"],
+        store_url="https://www.gymshark.com",
+    )
+    validator = Validator(product_schema, allow_unknown=True)
+    for item in product_data:
+        validate_or_fail(item, validator)
+    assert len(product_data) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_product_scraping_allbirds():
+    product_data = await shopify.scrape_products(
+        handles=["mens-cruiser-shadow-blue-natural-white-sole"],
+        store_url="https://www.allbirds.com",
+    )
+    validator = Validator(product_schema, allow_unknown=True)
+    for item in product_data:
+        validate_or_fail(item, validator)
+    assert len(product_data) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+async def test_sitemap_scraping():
+    sitemap_data = await shopify.scrape_sitemap(sitemap_url="https://www.gymshark.com/sitemap_pages_1.xml")
+    validator = Validator(sitemap_schema, allow_unknown=True)
+    for item in sitemap_data:
+        validate_or_fail(item, validator)
+    assert len(sitemap_data) >= 10


### PR DESCRIPTION
1. scrape_products: fall back to parsing the HTML if the JSON data is not available, since not all websites expose product JSON (it can be enabled or disabled by the website owner).

There are two test cases:

- allbirds.com: JSON is available, so no fallback is used.
- gymshark.com: No JSON is available, so it falls back to HTML parsing.

2. scrape_catalog: I couldn't find a fallback url that works consistently across all store domains, so I didn't implement one.