### PR TITLE
fix: prevent two IndexError crashes in youtube-scraper

### DIFF
--- a/youtube-scraper/youtube.py
+++ b/youtube-scraper/youtube.py
@@ -183,10 +183,8 @@ def parse_video(response: ScrapeApiResponse) -> Dict:
             "name": video_details.get("author"),
             "identifierId": video_details.get("channelId"),
             "id": channel_id.replace("/", "") if channel_id else None,
-            "verified": (
-                True
-                if verified and [i for i in verified if i["tooltip"] == "Verified"][0]
-                else False
+            "verified": any(
+                i.get("tooltip") == "Verified" for i in (verified or [])
             ),
             "channelUrl": (
                 f"https://www.youtube.com{channel_id}" if channel_id else None
@@ -404,11 +402,19 @@ async def scrape_channel_videos(
     chips = jp_all("$..chipViewModel", initial_script_data)
 
     # there are different continuation tokens based on the sorting order
-    continuation_token = [
-        i["tapCommand"]["innertubeCommand"]["continuationCommand"]["token"]
-        for i in chips
-        if i.get("text") == sort_by
-    ][0]
+    # small channels may have no chips at all; fall back to the page's default token
+    continuation_token = next(
+        (
+            i["tapCommand"]["innertubeCommand"]["continuationCommand"]["token"]
+            for i in chips
+            if i.get("text") == sort_by
+        ),
+        None,
+    )
+    if continuation_token is None:
+        continuation_token = jp_first(
+            "$..continuationCommand.token", initial_script_data
+        )
 
     # 2. call the API to get the video data
     videos = []


### PR DESCRIPTION
## Summary

Two `IndexError` crashes in `youtube-scraper` that nightly tests never catch because they target verified brand channels with full chip rows.

## Fix 1: `parse_video` — artist channel badges (line 188)

**Before:** `[i for i in verified if i["tooltip"] == "Verified"][0]` crashes when a channel has badges but none say "Verified" (e.g. "Official Artist Channel" on Rick Astley). The list comprehension filters everything out, then `[0]` indexes an empty list.

**After:** `any(i.get("tooltip") == "Verified" for i in (verified or []))` — safely checks without crashing on missing `tooltip` keys or non-matching badges.

## Fix 2: `scrape_channel_videos` — small channel chips (lines 405-411)

**Before:** `[... for i in chips if i.get("text") == sort_by][0]` crashes when a small channel renders no chip row at all (0 chips).

**After:** `next((...), None)` with fallback to the page's default `continuationCommand.token` via `jp_first`, so small channels still return their Latest listing.

## Verification

Both fixes are defensive — they handle edge cases that existing test fixtures (verified brand channels with chips) don't cover. The fixes use `any()`/`next()` with safe fallbacks, matching patterns already used elsewhere in the codebase (e.g. `jp_first("$..continuationCommand.token", ...)` at line 201).

Closes #163
