### PR TITLE
[capterra] update pagination handling for category and review scraping

### DIFF
--- a/capterra-scraper/capterra.py
+++ b/capterra-scraper/capterra.py
@@ -35,6 +35,11 @@ class CategoryProduct(TypedDict):
     features: List[str]
 
 
+class CategoryResult(TypedDict):
+    total_pages: int
+    products: List[CategoryProduct]
+
+
 class ReviewRatings(TypedDict):
     overall: Optional[float]
     ease_of_use: Optional[float]
@@ -56,6 +61,11 @@ class Review(TypedDict):
     review_body: Optional[str]
     pros: Optional[str]
     cons: Optional[str]
+
+
+class ReviewResult(TypedDict):
+    total_pages: int
+    reviews: List[Review]
 
 
 def parse_category_page(response: ScrapeApiResponse) -> List[CategoryProduct]:
@@ -137,32 +147,40 @@ def parse_category_page(response: ScrapeApiResponse) -> List[CategoryProduct]:
     return products
 
 
-def _get_total_pages(response: ScrapeApiResponse, href_selector: str) -> int:
-    hrefs = " ".join(response.selector.css(href_selector).getall())
-    pages = [int(n) for n in re.findall(r"page=(\d+)", hrefs)]
-    return max(pages, default=1)
+def _get_total_pages(response: ScrapeApiResponse) -> int:
+    href = response.selector.xpath('//a[.//i[@aria-label="chevron-line-right"]]/@href').get()
+    if not href:
+        return 1
+    match = re.search(r"page=(\d+)", href)
+    return int(match.group(1)) if match else 1
 
 
-async def scrape_category(category: str, max_pages: int = None) -> List[CategoryProduct]:
-    """Scrape category listings with pagination."""
+def _pages_to_scrape(total_pages: int, max_pages: int) -> int:
+    if max_pages < 0:
+        raise ValueError("max_pages must be 0 or greater")
+    if max_pages == 0:
+        return total_pages
+    return min(max_pages, total_pages)
+
+
+async def scrape_category(category: str, max_pages: int) -> CategoryResult:
+    """Scrape category listings with pagination. Pass max_pages=0 to scrape all pages."""
     base_url = f"https://www.capterra.com/{category}/"
     log.info(f"scraping category page {base_url}")
 
     first_page = await SCRAPFLY.async_scrape(ScrapeConfig(base_url, **BASE_CONFIG))
     products = parse_category_page(first_page)
-    total_pages = _get_total_pages(
-        first_page,
-        '[data-testid="pagination-section"] a[href*="page="]::attr(href)',
-    )
+    total_pages = _get_total_pages(first_page)
+    print(f"total_pages: {total_pages}")
+    pages_to_scrape = _pages_to_scrape(total_pages, max_pages)
 
-    if max_pages and max_pages < total_pages:
-        total_pages = max_pages
-
-    if total_pages > 1:
-        log.info(f"scraping category pagination, remaining ({total_pages - 1}) more pages")
+    if pages_to_scrape > 1:
+        log.info(
+            f"scraping category pagination, remaining ({pages_to_scrape - 1}) more pages"
+        )
         to_scrape = [
             ScrapeConfig(f"{base_url}?page={page}", **BASE_CONFIG)
-            for page in range(2, total_pages + 1)
+            for page in range(2, pages_to_scrape + 1)
         ]
         async for response in SCRAPFLY.concurrent_scrape(to_scrape):
             try:
@@ -171,7 +189,10 @@ async def scrape_category(category: str, max_pages: int = None) -> List[Category
                 log.error(f"failed to parse page: {exc}")
 
     log.success(f"scraped {len(products)} products from Capterra category '{category}'")
-    return products
+    return {
+        "total_pages": total_pages,
+        "products": products,
+    }
 
 
 def _parse_rating_value(card, testid: str) -> Optional[float]:
@@ -260,8 +281,8 @@ def parse_review_page(response: ScrapeApiResponse) -> List[Review]:
     return reviews
 
 
-async def scrape_reviews(url: str, max_review_pages: int = None) -> List[Review]:
-    """Scrape paginated product reviews."""
+async def scrape_reviews(url: str, max_review_pages: int) -> ReviewResult:
+    """Scrape paginated product reviews. Pass max_review_pages=0 to scrape all pages."""
     url = url.rstrip("/")
     if not url.endswith("/reviews"):
         url += "/reviews"
@@ -270,16 +291,16 @@ async def scrape_reviews(url: str, max_review_pages: int = None) -> List[Review]
     log.info(f"scraping reviews from {url}")
     first_page = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
     reviews = parse_review_page(first_page)
-    total_pages = _get_total_pages(first_page, '[data-testid="page-item-section"]::attr(href)')
+    total_pages = _get_total_pages(first_page)
+    pages_to_scrape = _pages_to_scrape(total_pages, max_review_pages)
 
-    if max_review_pages and max_review_pages < total_pages:
-        total_pages = max_review_pages
-
-    if total_pages > 1:
-        log.info(f"scraping reviews pagination, remaining ({total_pages - 1}) more pages")
+    if pages_to_scrape > 1:
+        log.info(
+            f"scraping reviews pagination, remaining ({pages_to_scrape - 1}) more pages"
+        )
         to_scrape = [
             ScrapeConfig(f"{url}?page={page}", **BASE_CONFIG)
-            for page in range(2, total_pages + 1)
+            for page in range(2, pages_to_scrape + 1)
         ]
         async for response in SCRAPFLY.concurrent_scrape(to_scrape):
             try:
@@ -288,4 +309,7 @@ async def scrape_reviews(url: str, max_review_pages: int = None) -> List[Review]
                 log.error(f"failed to parse reviews page: {exc}")
 
     log.success(f"scraped {len(reviews)} reviews from {url}")
-    return reviews
+    return {
+        "total_pages": total_pages,
+        "reviews": reviews,
+    }

--- a/capterra-scraper/results/category.json
+++ b/capterra-scraper/results/category.json
@@ -1,369 +1,5 @@
 [
   {
-    "product_id": "5923",
-    "name": "Celoxis",
-    "url": "https://www.capterra.com/p/5923/Celoxis/",
-    "reviews_url": "https://www.capterra.com/p/5923/Celoxis/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4e99765c-75ea-4a05-98ff-4d9a7288e686.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 463,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.5,
-      "features": 4.4,
-      "value_for_money": 4.4
-    },
-    "description": "Celoxis is an all-in-one project management tool with built-in features, customizable reports and fast setup. Zero stress, just results",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "143607",
-    "name": "kintone",
-    "url": "https://www.capterra.com/p/143607/kintone/",
-    "reviews_url": "https://www.capterra.com/p/143607/kintone/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/660e6691-b249-4adc-90b9-38ef1bd4970c.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 153,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.5,
-      "customer_service": 4.6,
-      "features": 4.4,
-      "value_for_money": 4.6
-    },
-    "description": "Think about it. Build it. Kintone's visual application builder lets you create your own project management apps, zero coding required.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "147657",
-    "name": "monday.com AI Work Platform",
-    "url": "https://www.capterra.com/p/147657/monday-com/",
-    "reviews_url": "https://www.capterra.com/p/147657/monday-com/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/464cd3be-e2b8-4f9b-a572-577e31770f58.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 6072,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.4,
-      "features": 4.5,
-      "value_for_money": 4.3
-    },
-    "description": "monday.com centralizes work, and automates tasks, allowing teams to manage the entire project lifecycle in one place.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "79104",
-    "name": "Smartsheet",
-    "url": "https://www.capterra.com/p/79104/Smartsheet/",
-    "reviews_url": "https://www.capterra.com/p/79104/Smartsheet/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/9efb2a2f-43b2-4ebd-bf24-b9bb46bd93c6.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 3524,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.3,
-      "features": 4.3,
-      "value_for_money": 4.4
-    },
-    "description": "Smartsheet is an Intelligent Work Management Platform that revolutionizes how you manage projects, portfolios, and processes.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "76113",
-    "name": "Wrike",
-    "url": "https://www.capterra.com/p/76113/Wrike/",
-    "reviews_url": "https://www.capterra.com/p/76113/Wrike/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b4158bfc-a55c-4d3a-baf8-b0316f604753.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 3021,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.2,
-      "customer_service": 4.3,
-      "features": 4.3,
-      "value_for_money": 4.2
-    },
-    "description": "Wrike is the AI-powered work delivery platform for project management allowing you to plan, execute, and deliver projects on time.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "135757",
-    "name": "NetSuite",
-    "url": "https://www.capterra.com/p/135757/NetSuite/",
-    "reviews_url": "https://www.capterra.com/p/135757/NetSuite/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/76ba5be7-e39f-481e-9045-7c45d7cf6d39.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.2,
-    "review_count": 2049,
-    "rating_breakdown": {
-      "overall": 4.2,
-      "ease_of_use": 4.0,
-      "customer_service": 3.8,
-      "features": 4.2,
-      "value_for_money": 3.9
-    },
-    "description": "NetSuite project management automates project creation and tracking for improved productivity and control for on-time project delivery.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "113540",
-    "name": "Bitrix24",
-    "url": "https://www.capterra.com/p/113540/Bitrix24/",
-    "reviews_url": "https://www.capterra.com/p/113540/Bitrix24/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0d820dd6-6e0b-43de-becb-e9078a2d9fac.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.2,
-    "review_count": 997,
-    "rating_breakdown": {
-      "overall": 4.2,
-      "ease_of_use": 4.0,
-      "customer_service": 4.0,
-      "features": 4.3,
-      "value_for_money": 4.2
-    },
-    "description": "High-end solution designed for sales, collaboration, communication, social networking, and project management.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "184581",
-    "name": "Asana",
-    "url": "https://www.capterra.com/p/184581/Asana-PM/",
-    "reviews_url": "https://www.capterra.com/p/184581/Asana-PM/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b0bf7e60-e572-4090-8dd8-0e950b0ad16d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 13604,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.3,
-      "features": 4.4,
-      "value_for_money": 4.4
-    },
-    "description": "Asana is the OS for human-agent teams — 85% of Fortune 100 trust the Enterprise Work Graph® to deliver 57% more work on time.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "133101",
-    "name": "Premier Construction Software",
-    "url": "https://www.capterra.com/p/133101/Premier/",
-    "reviews_url": "https://www.capterra.com/p/133101/Premier/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/42f8b7b4-9f63-480f-af45-24776128a434.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 288,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.6,
-      "customer_service": 4.8,
-      "features": 4.6,
-      "value_for_money": 4.7
-    },
-    "description": "All-in-one financial & project management construction cloud ERP, providing you with real-time visibility into your business.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "225762",
-    "name": "Accelo",
-    "url": "https://www.capterra.com/p/225762/Accelo/",
-    "reviews_url": "https://www.capterra.com/p/225762/Accelo/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ba280ac6-4280-434a-ae33-7c547b963a2d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 177,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.2,
-      "customer_service": 4.5,
-      "features": 4.4,
-      "value_for_money": 4.3
-    },
-    "description": "Accelo connects project delivery to profitability with AI predicting risks, tracking budgets, and surfacing scope creep in real time.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "169455",
-    "name": "Zoho Projects",
-    "url": "https://www.capterra.com/p/169455/Zoho-Projects/",
-    "reviews_url": "https://www.capterra.com/p/169455/Zoho-Projects/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/90500a0b-eb4b-4bd0-a547-9b65bcc63bf5.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 866,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.2,
-      "features": 4.4,
-      "value_for_money": 4.4
-    },
-    "description": "Zoho Projects is an online project management tool that helps teams plan, track, and collaborate on tasks with ease.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "144020",
-    "name": "Aha!",
-    "url": "https://www.capterra.com/p/144020/Aha/",
-    "reviews_url": "https://www.capterra.com/p/144020/Aha/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/29fbb3ae-ce4d-4596-93d4-5a49d4cfdadc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 561,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.4,
-      "customer_service": 4.8,
-      "features": 4.6,
-      "value_for_money": 4.6
-    },
-    "description": "Aha! Teamwork is the flexible project management tool – choose how you work, complete all tasks, and stay aligned with strategic plans.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "268205",
-    "name": "Adobe Workfront",
-    "url": "https://www.capterra.com/p/268205/Adobe-Workfront/",
-    "reviews_url": "https://www.capterra.com/p/268205/Adobe-Workfront/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/48f98b82-1651-4b2e-ba4d-b9eae6089ac6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 1496,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.1,
-      "customer_service": 4.4,
-      "features": 4.3,
-      "value_for_money": 4.2
-    },
-    "description": "The collaborative work management leader, helping companies plan, execute, and deliver great work and exceptional customer experiences.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
     "product_id": "110832",
     "name": "Kantata",
     "url": "https://www.capterra.com/p/110832/kantata/",
@@ -381,13 +17,41 @@
     "description": "Kantata PSA puts an end to unpredictable projects so professional services teams always deliver amazing.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "79104",
+    "name": "Smartsheet",
+    "url": "https://www.capterra.com/p/79104/Smartsheet/",
+    "reviews_url": "https://www.capterra.com/p/79104/Smartsheet/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/9efb2a2f-43b2-4ebd-bf24-b9bb46bd93c6.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 3538,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.3,
+      "features": 4.3,
+      "value_for_money": 4.4
+    },
+    "description": "Smartsheet is an Intelligent Work Management Platform that revolutionizes how you manage projects, portfolios, and processes.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   },
@@ -409,1749 +73,237 @@
     "description": "Structure: Excel in Project Management. Collaborate, track, and gain insights with the ultimate Jira project management tool.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "169569",
-    "name": "Zoho Sprints",
-    "url": "https://www.capterra.com/p/169569/Zoho-Sprints/",
-    "reviews_url": "https://www.capterra.com/p/169569/Zoho-Sprints/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3dc054ff-c5aa-42b4-923b-07bbe81915fb.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 298,
+    "product_id": "147657",
+    "name": "monday.com AI Work Platform",
+    "url": "https://www.capterra.com/p/147657/monday-com/",
+    "reviews_url": "https://www.capterra.com/p/147657/monday-com/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/464cd3be-e2b8-4f9b-a572-577e31770f58.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 6088,
     "rating_breakdown": {
-      "overall": 4.5,
+      "overall": 4.6,
       "ease_of_use": 4.5,
       "customer_service": 4.4,
-      "features": 4.4,
-      "value_for_money": 4.5
-    },
-    "description": "Zoho Sprints is a free online agile project management tool built for Scrum teams to plan, track and iterate their work in Sprints.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "238666",
-    "name": "Materio",
-    "url": "https://www.capterra.com/p/238666/Materio/",
-    "reviews_url": "https://www.capterra.com/p/238666/Materio/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e465c338-2105-4c96-bf0f-53e0c98e8f1f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.9,
-    "review_count": 42,
-    "rating_breakdown": {
-      "overall": 4.9,
-      "ease_of_use": 4.7,
-      "customer_service": 4.9,
-      "features": 4.6,
-      "value_for_money": 4.7
-    },
-    "description": "The operating system for interior design. One workspace for every phase, every dollar — with QuickBooks sync.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "64490",
-    "name": "Function Point",
-    "url": "https://www.capterra.com/p/64490/Function-Point/",
-    "reviews_url": "https://www.capterra.com/p/64490/Function-Point/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f37a5548-820b-4481-9c26-16e6051a6881.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.3,
-    "review_count": 193,
-    "rating_breakdown": {
-      "overall": 4.3,
-      "ease_of_use": 3.9,
-      "customer_service": 4.5,
-      "features": 4.0,
-      "value_for_money": 4.2
-    },
-    "description": "The all-in-one project management solution for creative agencies, internal teams and professional service firms.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "146933",
-    "name": "Lessons Learned Database",
-    "url": "https://www.capterra.com/p/146933/Lessons-Learned-Database/",
-    "reviews_url": "https://www.capterra.com/p/146933/Lessons-Learned-Database/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/c15e8891-cccc-4a0c-9ac7-2004854519f6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": null,
-    "review_count": null,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 5.0,
-      "customer_service": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0
-    },
-    "description": "A database for storing and searching for lessons learned and best practices.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "134429",
-    "name": "Resource Guru",
-    "url": "https://www.capterra.com/p/134429/Resource-Guru/",
-    "reviews_url": "https://www.capterra.com/p/134429/Resource-Guru/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d009e159-9e1a-436d-9e6e-d0133d163c61.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 540,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.7,
-      "customer_service": 4.7,
-      "features": 4.4,
-      "value_for_money": 4.6
-    },
-    "description": "The blissfully simple resource management tool that helps busy teams schedule projects, balance workloads, and keep teams on track.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "232375",
-    "name": "Birdview",
-    "url": "https://www.capterra.com/p/232375/Birdview/",
-    "reviews_url": "https://www.capterra.com/p/232375/Birdview/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b7c08483-2a84-468b-8fcc-31631dcdb050.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 475,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.5,
-      "features": 4.3,
+      "features": 4.5,
       "value_for_money": 4.3
     },
-    "description": "360-degree view of projects, tasks, finances. Birdview blends adaptable growth, collaboration, and security with insightful analytics.",
+    "description": "monday.com centralizes work, and automates tasks, allowing teams to manage the entire project lifecycle in one place.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "181522",
-    "name": "BlueRithm",
-    "url": "https://www.capterra.com/p/181522/BlueRithm/",
-    "reviews_url": "https://www.capterra.com/p/181522/BlueRithm/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a1571005-0807-4d25-8ddc-c8a9411735b0.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 10,
+    "product_id": "5923",
+    "name": "Celoxis",
+    "url": "https://www.capterra.com/p/5923/Celoxis/",
+    "reviews_url": "https://www.capterra.com/p/5923/Celoxis/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4e99765c-75ea-4a05-98ff-4d9a7288e686.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 546,
     "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.3,
-      "customer_service": 5.0,
-      "features": 4.2,
-      "value_for_money": 4.9
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.5,
+      "features": 4.4,
+      "value_for_money": 4.4
     },
-    "description": "Streamline your commissioning, test and balance, inspections, and testing projects with BlueRithm.",
+    "description": "Celoxis is an all-in-one project management tool with built-in features, customizable reports and fast setup. Zero stress, just results",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "146652",
-    "name": "Airtable",
-    "url": "https://www.capterra.com/p/146652/Airtable/",
-    "reviews_url": "https://www.capterra.com/p/146652/Airtable/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3db6aa4b-f160-410b-85e5-71593a0b271d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "113540",
+    "name": "Bitrix24",
+    "url": "https://www.capterra.com/p/113540/Bitrix24/",
+    "reviews_url": "https://www.capterra.com/p/113540/Bitrix24/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0d820dd6-6e0b-43de-becb-e9078a2d9fac.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.2,
+    "review_count": 1000,
+    "rating_breakdown": {
+      "overall": 4.2,
+      "ease_of_use": 4.0,
+      "customer_service": 4.0,
+      "features": 4.3,
+      "value_for_money": 4.2
+    },
+    "description": "High-end solution designed for sales, collaboration, communication, social networking, and project management.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "159806",
+    "name": "GitLab",
+    "url": "https://www.capterra.com/p/159806/GitLab/",
+    "reviews_url": "https://www.capterra.com/p/159806/GitLab/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0a4c64d3-570d-43a0-9ab9-725c546efdf4.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.6,
-    "review_count": 2238,
+    "review_count": 1224,
     "rating_breakdown": {
       "overall": 4.6,
       "ease_of_use": 4.4,
-      "customer_service": 4.4,
-      "features": 4.5,
+      "customer_service": 4.2,
+      "features": 4.6,
       "value_for_money": 4.5
     },
-    "description": "Manage projects with speed and clarity in Airtable. Centralize work, align teams, and adapt plans in real time with flexible workflows.",
+    "description": "GitLab keeps work items, code, and AI agents in one place, so teams spend less time coordinating and more time building. Learn More.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "160201",
-    "name": "ConstructionOnline",
-    "url": "https://www.capterra.com/p/160201/ConstructionOnline/",
-    "reviews_url": "https://www.capterra.com/p/160201/ConstructionOnline/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/1b41fc61-a961-4474-be20-bcf96a3d1ad1.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 606,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.8,
-      "features": 4.4,
-      "value_for_money": 4.5
-    },
-    "description": "ConstructionOnline is a cloud-based construction management tool that helps professionals complete projects on time and under budget.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "162588",
-    "name": "HoneyBook",
-    "url": "https://www.capterra.com/p/162588/HoneyBook/",
-    "reviews_url": "https://www.capterra.com/p/162588/HoneyBook/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/8c70159d-32c2-43c6-87a7-f1f66d5d622b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "143607",
+    "name": "kintone",
+    "url": "https://www.capterra.com/p/143607/kintone/",
+    "reviews_url": "https://www.capterra.com/p/143607/kintone/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/660e6691-b249-4adc-90b9-38ef1bd4970c.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 683,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.5,
-      "value_for_money": 4.6
-    },
-    "description": "Everything you need to manage projects: pipeline, proposals, contracts, payments, and more. \n\nStart your 7 day free trial today.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "135148",
-    "name": "Agile CRM",
-    "url": "https://www.capterra.com/p/135148/Agile-CRM/",
-    "reviews_url": "https://www.capterra.com/p/135148/Agile-CRM/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4dd8e898-253a-4e64-8f55-73d688838bdb.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.1,
-    "review_count": 524,
-    "rating_breakdown": {
-      "overall": 4.1,
-      "ease_of_use": 4.0,
-      "customer_service": 4.0,
-      "features": 4.1,
-      "value_for_money": 4.1
-    },
-    "description": "Agile CRM is a complete sales, marketing and service suite designed to let SMBs to sell and market like the Fortune 500.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "132230",
-    "name": "Freedcamp",
-    "url": "https://www.capterra.com/p/132230/Freedcamp/",
-    "reviews_url": "https://www.capterra.com/p/132230/Freedcamp/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/399efeb4-e3fa-4aca-8c1b-8b006dcdc3b6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 502,
+    "review_count": 153,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.5,
-      "customer_service": 4.7,
-      "features": 4.4,
-      "value_for_money": 4.7
-    },
-    "description": "The effortless way to get your team organized",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "126797",
-    "name": "JobNimbus",
-    "url": "https://www.capterra.com/p/126797/JobNimbus/",
-    "reviews_url": "https://www.capterra.com/p/126797/JobNimbus/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/83d211e2-7581-45a6-8ff5-caa091bbcecc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 482,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.6,
-      "customer_service": 4.5,
+      "customer_service": 4.6,
       "features": 4.4,
       "value_for_money": 4.6
     },
-    "description": "All-in-one roofing software that helps contractors work smarter, move faster, and grow their business from lead to payment.",
+    "description": "Think about it. Build it. Kintone's visual application builder lets you create your own project management apps, zero coding required.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "136096",
-    "name": "Avaza",
-    "url": "https://www.capterra.com/p/136096/Avaza/",
-    "reviews_url": "https://www.capterra.com/p/136096/Avaza/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0955c8b8-f35d-4229-bbb1-d30f58513f67.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 475,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.5,
-      "value_for_money": 4.7
-    },
-    "description": "A software suite for small professional services organizations with modules for project management, timesheets, expenses & invoicing.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "1404",
-    "name": "Deltek Vision",
-    "url": "https://www.capterra.com/p/1404/Deltek-Vision/",
-    "reviews_url": "https://www.capterra.com/p/1404/Deltek-Vision/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b03aace1-f4c2-42db-a233-4955a1a4bf8c.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.1,
-    "review_count": 473,
-    "rating_breakdown": {
-      "overall": 4.1,
-      "ease_of_use": 3.6,
-      "customer_service": 4.0,
-      "features": 4.0,
-      "value_for_money": 3.7
-    },
-    "description": "Project-based solution for PS firms that combines project accounting, resource management, project mgmt, time/expense and client mgt.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "153475",
-    "name": "FieldPulse",
-    "url": "https://www.capterra.com/p/153475/FieldPulse/",
-    "reviews_url": "https://www.capterra.com/p/153475/FieldPulse/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/fc7db629-f83f-478c-9e4d-8f697f15e439.webp?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 464,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.7,
-      "features": 4.4,
-      "value_for_money": 4.5
-    },
-    "description": "FieldPulse is an FSM software platform that helps service businesses manage scheduling, invoicing, communication, and team operations.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "172519",
-    "name": "Nifty",
-    "url": "https://www.capterra.com/p/172519/Nifty/",
-    "reviews_url": "https://www.capterra.com/p/172519/Nifty/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/53075b74-4942-4c97-a5ca-3a2169181fd9.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 440,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.5,
-      "features": 4.5,
-      "value_for_money": 4.6
-    },
-    "description": "Nifty is one hub for your projects, team, and clients. Tasks, docs, goals, and reporting — without the tool sprawl.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "151667",
-    "name": "Favro",
-    "url": "https://www.capterra.com/p/151667/Favro/",
-    "reviews_url": "https://www.capterra.com/p/151667/Favro/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/513bb28d-8c26-4ce1-8837-ef177a44d519.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "76113",
+    "name": "Wrike",
+    "url": "https://www.capterra.com/p/76113/Wrike/",
+    "reviews_url": "https://www.capterra.com/p/76113/Wrike/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b4158bfc-a55c-4d3a-baf8-b0316f604753.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.4,
-    "review_count": 417,
+    "review_count": 3034,
     "rating_breakdown": {
       "overall": 4.4,
       "ease_of_use": 4.2,
       "customer_service": 4.3,
-      "features": 4.1,
-      "value_for_money": 4.1
-    },
-    "description": "Favro is the #1 app for collaborative planning within and between teams for game studios, fast-moving SaaS and agile companies.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "114491",
-    "name": "ActiveCollab",
-    "url": "https://www.capterra.com/p/114491/Active-Collab/",
-    "reviews_url": "https://www.capterra.com/p/114491/Active-Collab/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5ac2f2b3-e035-4b88-98d5-724c8e04b21f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 414,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.5,
-      "customer_service": 4.4,
-      "features": 4.2,
-      "value_for_money": 4.5
-    },
-    "description": "ActiveCollab is a simple, yet powerful productivity and collaboration workspace helping service businesses thrive.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "166656",
-    "name": "Flowlu",
-    "url": "https://www.capterra.com/p/166656/FLowlu/",
-    "reviews_url": "https://www.capterra.com/p/166656/FLowlu/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/2e45592e-f1b8-4a62-9c2e-1bd35bc46729.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 387,
-    "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.7,
-      "value_for_money": 4.9
-    },
-    "description": "Manage projects effortlessly with Flowlu—track progress, automate workflows, and keep every task, budget, and deadline under control.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "160498",
-    "name": "Shortcut",
-    "url": "https://www.capterra.com/p/160498/Shortcut/",
-    "reviews_url": "https://www.capterra.com/p/160498/Shortcut/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/64ba40c7-c88d-4447-9112-4f637c688bc8.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 363,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.4,
-      "customer_service": 4.6,
-      "features": 4.4,
-      "value_for_money": 4.6
-    },
-    "description": "Shortcut is a fast project management platform built for high performing engineering teams. Free for teams up to 10 users.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "128631",
-    "name": "Podio",
-    "url": "https://www.capterra.com/p/128631/Podio/",
-    "reviews_url": "https://www.capterra.com/p/128631/Podio/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f947c5f5-bd99-4c12-b724-cb06886d4c13.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.3,
-    "review_count": 362,
-    "rating_breakdown": {
-      "overall": 4.3,
-      "ease_of_use": 4.0,
-      "customer_service": 4.0,
-      "features": 4.3,
-      "value_for_money": 4.3
-    },
-    "description": "Podio is a collaborative software platform that helps teams streamline workflows, enhance communication, and advance projects.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "116272",
-    "name": "Daylite for Mac",
-    "url": "https://www.capterra.com/p/116272/Daylite-for-Mac/",
-    "reviews_url": "https://www.capterra.com/p/116272/Daylite-for-Mac/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ca07dfe8-c3e9-49db-8ee8-c8a73118c04b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 361,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.4,
-      "customer_service": 4.6,
-      "features": 4.5,
-      "value_for_money": 4.4
-    },
-    "description": "Daylite helps service-based businesses manage clients, projects, and new client opportunities in one app — driving their growth.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "10533",
-    "name": "Workamajig",
-    "url": "https://www.capterra.com/p/10533/Workamajig/",
-    "reviews_url": "https://www.capterra.com/p/10533/Workamajig/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/421881b6-4f86-4ae9-a596-0f4920b74d82.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 3.8,
-    "review_count": 351,
-    "rating_breakdown": {
-      "overall": 3.8,
-      "ease_of_use": 3.3,
-      "customer_service": 4.0,
-      "features": 3.8,
-      "value_for_money": 3.8
-    },
-    "description": "Workamajig is the #1 project management software for the creative industry. It's an all-in-one solution for agencies and in-house teams",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "206203",
-    "name": "Agiled",
-    "url": "https://www.capterra.com/p/206203/Agiled/",
-    "reviews_url": "https://www.capterra.com/p/206203/Agiled/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b49fc8e8-9267-4c6f-93e1-27bfd97995cc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 350,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.7,
-      "value_for_money": 4.9
-    },
-    "description": "Agiled is an all-in-one software that helps small businesses manage CRM, finance, projects, and documents in one integrated platform.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "224496",
-    "name": "ProjectManager",
-    "url": "https://www.capterra.com/p/224496/ProjectManagercom/",
-    "reviews_url": "https://www.capterra.com/p/224496/ProjectManagercom/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/68efb2db-d64c-467b-9135-9ca35d9b69e7.webp?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.1,
-    "review_count": 339,
-    "rating_breakdown": {
-      "overall": 4.1,
-      "ease_of_use": 4.0,
-      "customer_service": 3.9,
-      "features": 3.9,
-      "value_for_money": 3.7
-    },
-    "description": "Award-winning project & work management software featuring project dashboards, Gantt charts, Kanban boards, and team collaboration.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "157262",
-    "name": "Quickbase",
-    "url": "https://www.capterra.com/p/157262/QuickBase/",
-    "reviews_url": "https://www.capterra.com/p/157262/QuickBase/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d0157b8b-f072-4509-bd88-9963aa9b3fdf.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 331,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.1,
-      "customer_service": 4.3,
-      "features": 4.3,
-      "value_for_money": 4.1
-    },
-    "description": "Quickbase is a no-code operational agility platform that enables organizations to improve operations through insights and automation.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "141243",
-    "name": "ONLYOFFICE Workspace",
-    "url": "https://www.capterra.com/p/141243/ONLYOFFICE/",
-    "reviews_url": "https://www.capterra.com/p/141243/ONLYOFFICE/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b16abad5-1824-4f8a-be40-7c2507d60077.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 324,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.5,
-      "customer_service": 4.2,
-      "features": 4.3,
-      "value_for_money": 4.4
-    },
-    "description": "ONLYOFFICE is a secure online office suite aimed at helping teams in management and collaboration with strong focus on documents.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "168685",
-    "name": "Factorial",
-    "url": "https://www.capterra.com/p/168685/Factorial-HR-Software/",
-    "reviews_url": "https://www.capterra.com/p/168685/Factorial-HR-Software/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/08b856d9-1049-4164-83c6-fc273c2e089e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 315,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.5,
-      "customer_service": 4.2,
-      "features": 4.2,
-      "value_for_money": 4.1
-    },
-    "description": "Factorial is the AI-powered business software that takes care of the time-consuming stuff, like hiring, holidays and payroll.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "227201",
-    "name": "Microsoft Planner",
-    "url": "https://www.capterra.com/p/227201/Microsoft-Planner/",
-    "reviews_url": "https://www.capterra.com/p/227201/Microsoft-Planner/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/952f617a-4c31-4c3c-838b-4477eca81b36.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.3,
-    "review_count": 295,
-    "rating_breakdown": {
-      "overall": 4.3,
-      "ease_of_use": 4.5,
-      "customer_service": 4.2,
-      "features": 4.2,
-      "value_for_money": 4.5
-    },
-    "description": "Microsoft Planner is a new app from Microsoft that helps teams organize their work.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "140681",
-    "name": "Kanbanchi",
-    "url": "https://www.capterra.com/p/140681/Kanbanchi-for-G-Suite/",
-    "reviews_url": "https://www.capterra.com/p/140681/Kanbanchi-for-G-Suite/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4df2a9ef-7d00-43c5-9e5d-17d66c5115b6.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 292,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.2,
-      "value_for_money": 4.3
-    },
-    "description": "Task/Project Management & Collaboration app with Kanban, Gantt Chart & Time Tracker.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "147183",
-    "name": "OpenText HighTail",
-    "url": "https://www.capterra.com/p/147183/Hightail/",
-    "reviews_url": "https://www.capterra.com/p/147183/Hightail/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/09968446-2362-4382-a33c-79dd76aede48.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 290,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.4,
-      "customer_service": 4.3,
-      "features": 4.4,
-      "value_for_money": 4.4
-    },
-    "description": "Hightail is built for managing creative projects, with one place to share files, collect feedback and keep projects moving.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "150647",
-    "name": "Canopy",
-    "url": "https://www.capterra.com/p/150647/Canopy-Tax/",
-    "reviews_url": "https://www.capterra.com/p/150647/Canopy-Tax/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/cd76892f-c11a-4f2d-948a-fd800d702efd.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 286,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.5,
-      "customer_service": 4.5,
       "features": 4.3,
       "value_for_money": 4.2
     },
-    "description": "ll-in-one accounting practice management software. Manage workflows, CRM, billing, and AI tools with one platform and login.",
+    "description": "Wrike is the AI-powered work delivery platform for project management allowing you to plan, execute, and deliver projects on time.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "107931",
-    "name": "ConnectWise PSA",
-    "url": "https://www.capterra.com/p/107931/ConnectWise-Manage/",
-    "reviews_url": "https://www.capterra.com/p/107931/ConnectWise-Manage/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/10b90bed-19f8-42a1-9a8c-7013628708dc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.1,
-    "review_count": 277,
-    "rating_breakdown": {
-      "overall": 4.1,
-      "ease_of_use": 3.7,
-      "customer_service": 3.7,
-      "features": 4.1,
-      "value_for_money": 3.7
-    },
-    "description": "ConnectWise PSA (formerly Manage): Powerful ticketing system with centralized communication & integrates with tools you currently use.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "267175",
-    "name": "Open DevOps",
-    "url": "https://www.capterra.com/p/267175/Open-DevOps/",
-    "reviews_url": "https://www.capterra.com/p/267175/Open-DevOps/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a6dbb336-90fa-43ef-9793-bef5de638968.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "169455",
+    "name": "Zoho Projects",
+    "url": "https://www.capterra.com/p/169455/Zoho-Projects/",
+    "reviews_url": "https://www.capterra.com/p/169455/Zoho-Projects/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/90500a0b-eb4b-4bd0-a547-9b65bcc63bf5.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 273,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.0,
-      "customer_service": 4.1,
-      "features": 4.4,
-      "value_for_money": 4.2
-    },
-    "description": "Atlassian Open DevOps is mission control, providing the flexibility of a custom toolchain with the coordination of an all-in-one.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "186837",
-    "name": "Financial Cents",
-    "url": "https://www.capterra.com/p/186837/Financial-Cents/",
-    "reviews_url": "https://www.capterra.com/p/186837/Financial-Cents/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e21ef758-af80-4b86-85a4-15bb566ad454.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 265,
-    "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.9,
-      "customer_service": 4.7,
-      "features": 4.6,
-      "value_for_money": 4.7
-    },
-    "description": "Scale your accounting firm with one easy-to-use solution. Track client work, collaborate with your staff, and hit your deadlines.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "239335",
-    "name": "Viewpoint Vista",
-    "url": "https://www.capterra.com/p/239335/Vista/",
-    "reviews_url": "https://www.capterra.com/p/239335/Vista/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f1908081-1ac4-4014-93f5-515ba34cf8b3.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 3.8,
-    "review_count": 264,
-    "rating_breakdown": {
-      "overall": 3.8,
-      "ease_of_use": 3.5,
-      "customer_service": 3.4,
-      "features": 3.9,
-      "value_for_money": 3.7
-    },
-    "description": "Viewpoint Vista Construction ERP solution helps contractors increase efficiency and manage the entire business to grow profits.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "142042",
-    "name": "Scoro",
-    "url": "https://www.capterra.com/p/142042/Scoro/",
-    "reviews_url": "https://www.capterra.com/p/142042/Scoro/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5a2e0a6d-dc36-4f90-a38d-4d0ffcda7053.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 262,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.4,
-      "features": 4.4,
-      "value_for_money": 4.3
-    },
-    "description": "Run your consultancy, agency or other professional services business on one integrated platform. Operate and grow profitably.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "126567",
-    "name": "RIB Candy",
-    "url": "https://www.capterra.com/p/126567/Candy/",
-    "reviews_url": "https://www.capterra.com/p/126567/Candy/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/69f1e7bc-038f-4c4a-b7e3-c454ab397895.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 252,
+    "review_count": 870,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.3,
-      "customer_service": 4.6,
-      "features": 4.4,
-      "value_for_money": 4.2
-    },
-    "description": "Estimating & Project Management Software includes QTO, Estimating, Planning, Forecasting, Cash flow, Valuations & EVM.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "77208",
-    "name": "ProWorkflow",
-    "url": "https://www.capterra.com/p/77208/ProWorkflow/",
-    "reviews_url": "https://www.capterra.com/p/77208/ProWorkflow/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/58cbe2e7-fbdb-46fe-b1cf-8fe7e0e4e40c.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 249,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.6,
-      "features": 4.2,
-      "value_for_money": 4.4
-    },
-    "description": "ProWorkflow Nexus helps teams plan, track, and deliver projects with clarity. Featuring tasks, Gantt charts, time tracking, and more.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "228207",
-    "name": "DealRoom",
-    "url": "https://www.capterra.com/p/228207/DealRoom/",
-    "reviews_url": "https://www.capterra.com/p/228207/DealRoom/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d0e084b0-29a4-4051-aed8-d564f027af77.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 247,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.6,
-      "features": 4.3,
-      "value_for_money": 4.4
-    },
-    "description": "Agile M&A Project Management: go beyond a virtual data room with DealRoom's multi-party project management software.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "188157",
-    "name": "Dropbox Paper",
-    "url": "https://www.capterra.com/p/188157/Dropbox-Paper/",
-    "reviews_url": "https://www.capterra.com/p/188157/Dropbox-Paper/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/fc55fe93-b971-48be-b0d6-0bde61d767a4.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 242,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.4,
       "customer_service": 4.2,
-      "features": 4.3,
-      "value_for_money": 4.3
+      "features": 4.4,
+      "value_for_money": 4.4
     },
-    "description": "With Dropbox Paper, you can manage to-do lists, share files, assign due dates, and track time ¿all in one single place.",
+    "description": "Zoho Projects is an online project management tool that helps teams plan, track, and collaborate on tasks with ease.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "178124",
-    "name": "Monograph",
-    "url": "https://www.capterra.com/p/178124/Monograph/",
-    "reviews_url": "https://www.capterra.com/p/178124/Monograph/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/06cbe396-af95-4679-9fc3-aacf7965086e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 236,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.7,
-      "features": 4.1,
-      "value_for_money": 4.3
-    },
-    "description": "Performance management platform for architects and landscape architects built by architects for architects.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "133010",
-    "name": "Streamtime",
-    "url": "https://www.capterra.com/p/133010/Streamtime/",
-    "reviews_url": "https://www.capterra.com/p/133010/Streamtime/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/008f9648-2afe-4966-a767-bd3a7e409cb0.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "144020",
+    "name": "Aha!",
+    "url": "https://www.capterra.com/p/144020/Aha/",
+    "reviews_url": "https://www.capterra.com/p/144020/Aha/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/29fbb3ae-ce4d-4596-93d4-5a49d4cfdadc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 235,
+    "review_count": 564,
     "rating_breakdown": {
       "overall": 4.7,
-      "ease_of_use": 4.7,
+      "ease_of_use": 4.4,
       "customer_service": 4.8,
-      "features": 4.5,
-      "value_for_money": 4.6
-    },
-    "description": "Streamtime is project management for creative teams and businesses. Job planning, time tracking, invoicing and scheduling made easy.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "165004",
-    "name": "Zenkit",
-    "url": "https://www.capterra.com/p/165004/Zenkit/",
-    "reviews_url": "https://www.capterra.com/p/165004/Zenkit/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3ce3db5f-183b-40cc-b056-d8ac633af090.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 235,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.7,
-      "features": 4.5,
-      "value_for_money": 4.6
-    },
-    "description": "Zenkit Projects provides agile and traditional project management software capabilities.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "252371",
-    "name": "Admation",
-    "url": "https://www.capterra.com/p/252371/Admation/",
-    "reviews_url": "https://www.capterra.com/p/252371/Admation/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/1de86f9d-3be3-4445-b5fe-306386d7e85b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 3.6,
-    "review_count": 227,
-    "rating_breakdown": {
-      "overall": 3.6,
-      "ease_of_use": 3.0,
-      "customer_service": 3.6,
-      "features": 3.2,
-      "value_for_money": 3.3
-    },
-    "description": "Marketing project management from brief to approved asset — tasks, schedules, resources, reviews and compliance in one system.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "190126",
-    "name": "Tempo Timesheets",
-    "url": "https://www.capterra.com/p/190126/Tempo/",
-    "reviews_url": "https://www.capterra.com/p/190126/Tempo/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e8b9fa6f-299a-4064-9622-1d4f48a14d09.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 225,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.3,
-      "customer_service": 4.3,
-      "features": 4.1,
-      "value_for_money": 4.1
-    },
-    "description": "Excel in Project Management. AI-driven time-tracking, reliable data, seamless operations. Effortlessly track project time.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "180283",
-    "name": "Sage 300",
-    "url": "https://www.capterra.com/p/180283/Sage-300cloud/",
-    "reviews_url": "https://www.capterra.com/p/180283/Sage-300cloud/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/7112afb8-9da1-4831-b7e3-5155aed46e56.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 3.9,
-    "review_count": 223,
-    "rating_breakdown": {
-      "overall": 3.9,
-      "ease_of_use": 3.8,
-      "customer_service": 3.8,
-      "features": 3.9,
-      "value_for_money": 3.7
-    },
-    "description": "Sage 300cloud is an ideal business management solution for growing service and distribution businesses.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "135461",
-    "name": "Taskworld",
-    "url": "https://www.capterra.com/p/135461/Taskworld/",
-    "reviews_url": "https://www.capterra.com/p/135461/Taskworld/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/29ce2727-b215-4a45-8827-7d30b2e1f2ab.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 219,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.6,
-      "customer_service": 4.5,
-      "features": 4.2,
-      "value_for_money": 4.2
-    },
-    "description": "Taskworld is a project management application that combines visual boards, team messaging and project planning into one easy app.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "150991",
-    "name": "Hive",
-    "url": "https://www.capterra.com/p/150991/Hive/",
-    "reviews_url": "https://www.capterra.com/p/150991/Hive/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b19bbff3-c15c-48fa-8040-2eafb3db6551.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 219,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.4,
-      "customer_service": 4.5,
-      "features": 4.3,
-      "value_for_money": 4.4
-    },
-    "description": "Hive is the only project management platform designed by its users. Because managing your work is a personal thing.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "18542",
-    "name": "Workzone",
-    "url": "https://www.capterra.com/p/18542/Workzone/",
-    "reviews_url": "https://www.capterra.com/p/18542/Workzone/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/dece148b-36b0-4982-b752-39bb2533cfcc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 217,
-    "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.6,
-      "customer_service": 4.9,
       "features": 4.6,
-      "value_for_money": 4.8
-    },
-    "description": "Workzone brings clarity and control to project management with templates, dashboards, and pricing that starts at $6 per user per month.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "189304",
-    "name": "Trackabi",
-    "url": "https://www.capterra.com/p/189304/Trackabi/",
-    "reviews_url": "https://www.capterra.com/p/189304/Trackabi/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f183d093-c32e-4713-b896-ddb5c5ce031e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 217,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.7,
-      "customer_service": 4.4,
-      "features": 4.5,
-      "value_for_money": 4.7
-    },
-    "description": "Automated time tracking and employee monitoring, leave schedules, reports, invoices, and more. Ideal for small & medium-sized companies",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "220249",
-    "name": "Oracle Aconex",
-    "url": "https://www.capterra.com/p/220249/Oracle-Aconex/",
-    "reviews_url": "https://www.capterra.com/p/220249/Oracle-Aconex/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a90788a1-0c78-4bf2-b188-279e278073fc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.4,
-    "review_count": 216,
-    "rating_breakdown": {
-      "overall": 4.4,
-      "ease_of_use": 4.2,
-      "customer_service": 4.3,
-      "features": 4.2,
-      "value_for_money": 4.1
-    },
-    "description": "The #1 platform for digital project delivery and controls that connects teams to build the world. Trusted by 5+ million users globally",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "148476",
-    "name": "Businessmap",
-    "url": "https://www.capterra.com/p/148476/Kanbanize/",
-    "reviews_url": "https://www.capterra.com/p/148476/Kanbanize/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/48ee0fe1-f086-4ddd-a6b8-5e50d8f3f648.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 215,
-    "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.6,
-      "customer_service": 4.7,
-      "features": 4.7,
-      "value_for_money": 4.5
-    },
-    "description": "Businessmap is the most flexible Lean project and portfolio management platform for strategy execution at scale.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "131573",
-    "name": "Prism PPM",
-    "url": "https://www.capterra.com/p/131573/WorkOtter/",
-    "reviews_url": "https://www.capterra.com/p/131573/WorkOtter/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/cc788bdf-c2e5-4dd6-b211-99c47f84aca7.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.9,
-    "review_count": 213,
-    "rating_breakdown": {
-      "overall": 4.9,
-      "ease_of_use": 4.9,
-      "customer_service": 4.9,
-      "features": 4.9,
-      "value_for_money": 4.9
-    },
-    "description": "Prism PPM is purpose-built for project, program, & portfolio management, with advanced analytics. Find us on the 2025 Gartner APMR MQ.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "191454",
-    "name": "Project.co",
-    "url": "https://www.capterra.com/p/191454/Project-co/",
-    "reviews_url": "https://www.capterra.com/p/191454/Project-co/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/833bf572-0ee5-47cc-8a27-5862fcab2d62.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.9,
-    "review_count": 209,
-    "rating_breakdown": {
-      "overall": 4.9,
-      "ease_of_use": 4.9,
-      "customer_service": 4.9,
-      "features": 4.7,
-      "value_for_money": 4.9
-    },
-    "description": "Connect your team with your clients team to chat, share files, manage tasks, make notes, take payments and get work done!",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "156181",
-    "name": "Karbon",
-    "url": "https://www.capterra.com/p/156181/Karbon/",
-    "reviews_url": "https://www.capterra.com/p/156181/Karbon/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5730b928-5380-4227-84df-4798fa9f120a.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 207,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.5,
-      "customer_service": 4.7,
-      "features": 4.5,
-      "value_for_money": 4.5
-    },
-    "description": "Karbon is the #1-ranked premium accounting practice management platform, helping firms of all sizes increase productivity and scale.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "10010752",
-    "name": "ClickTime",
-    "url": "https://www.capterra.com/p/10010752/ClickTime/",
-    "reviews_url": "https://www.capterra.com/p/10010752/ClickTime/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/403c71a5-9598-4969-a24c-04a78127d287.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 207,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.5,
-      "customer_service": 4.7,
-      "features": 4.3,
       "value_for_money": 4.6
     },
-    "description": "Reduce costs, increase project visibility, and stay on budget — with easy timesheets!",
+    "description": "Aha! Teamwork is the flexible project management tool – choose how you work, complete all tasks, and stay aligned with strategic plans.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "162784",
-    "name": "Claris FileMaker",
-    "url": "https://www.capterra.com/p/162784/FileMaker/",
-    "reviews_url": "https://www.capterra.com/p/162784/FileMaker/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/72381ab6-2a4e-495c-9b16-82f76f04ac2a.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.3,
-    "review_count": 207,
-    "rating_breakdown": {
-      "overall": 4.3,
-      "ease_of_use": 4.1,
-      "customer_service": 3.9,
-      "features": 4.3,
-      "value_for_money": 4.0
-    },
-    "description": "Your projects, your way. Build custom project management solutions with the leading low-cod app development platform.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "135980",
-    "name": "Ayoa",
-    "url": "https://www.capterra.com/p/135980/DropTask/",
-    "reviews_url": "https://www.capterra.com/p/135980/DropTask/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/943eb85d-6549-4ed4-aee0-f14b18093c0e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 206,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.3,
-      "customer_service": 4.5,
-      "features": 4.3,
-      "value_for_money": 4.3
-    },
-    "description": "Visual mind mapping meets task management in one accessible workspace that adapts to your thinking style.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "176283",
-    "name": "Visual Planning",
-    "url": "https://www.capterra.com/p/176283/Visual-Planning/",
-    "reviews_url": "https://www.capterra.com/p/176283/Visual-Planning/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f57c117c-d011-4ef0-9eed-0332deee8a0b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 116,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.4,
-      "features": 4.4,
-      "value_for_money": 4.3
-    },
-    "description": "Visual Planning: PM platform for manufacturing, services & engineering teams; track projects, resources & deadlines efficiently.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "211643",
-    "name": "Lucidspark",
-    "url": "https://www.capterra.com/p/211643/LucidSpark/",
-    "reviews_url": "https://www.capterra.com/p/211643/LucidSpark/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ea611411-a932-43ab-8b1d-ed3d6e162227.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.7,
-    "review_count": 384,
-    "rating_breakdown": {
-      "overall": 4.7,
-      "ease_of_use": 4.5,
-      "customer_service": 4.5,
-      "features": 4.5,
-      "value_for_money": 4.4
-    },
-    "description": "Lucidspark is a virtual whiteboard where teams can bring their best ideas to light. Brought to you by the makers of Lucidchart.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2173,97 +325,97 @@
     "description": "PI is a project management software for growing companies that centralizes & automates project work across teams & existing systems.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "125356",
-    "name": "Journyx",
-    "url": "https://www.capterra.com/p/125356/Journyx/",
-    "reviews_url": "https://www.capterra.com/p/125356/Journyx/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e8fcfb17-feab-4c4e-8e49-04fec5fa4e9f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.1,
-    "review_count": 36,
+    "product_id": "146652",
+    "name": "Airtable",
+    "url": "https://www.capterra.com/p/146652/Airtable/",
+    "reviews_url": "https://www.capterra.com/p/146652/Airtable/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3db6aa4b-f160-410b-85e5-71593a0b271d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 2242,
     "rating_breakdown": {
-      "overall": 4.1,
-      "ease_of_use": 4.0,
+      "overall": 4.6,
+      "ease_of_use": 4.4,
       "customer_service": 4.4,
-      "features": 4.1,
-      "value_for_money": 4.2
-    },
-    "description": "Journyx makes it easy to track and manage employee time, expenses, and resources for projects, billing, and payroll, all in one place.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "119702",
-    "name": "Contruent",
-    "url": "https://www.capterra.com/p/119702/Contruent/",
-    "reviews_url": "https://www.capterra.com/p/119702/Contruent/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/9cca5d1c-3fc7-4e40-a333-539c0c8dbaf1.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.2,
-    "review_count": 25,
-    "rating_breakdown": {
-      "overall": 4.2,
-      "ease_of_use": 4.0,
-      "customer_service": 4.4,
-      "features": 4.1,
+      "features": 4.5,
       "value_for_money": 4.5
     },
-    "description": "Contruent is the lifecycle cost management solution that empowers Owners and E&C firms to efficiently deliver complex capital programs.",
+    "description": "Manage projects with speed and clarity in Airtable. Centralize work, align teams, and adapt plans in real time with flexible workflows.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "10036336",
-    "name": "Project Proctor",
-    "url": "https://www.capterra.com/p/10036336/Project-Proctor/",
-    "reviews_url": "https://www.capterra.com/p/10036336/Project-Proctor/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d539326b-d8b4-462b-ac54-606b0126ec8f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "146933",
+    "name": "LessonBridge",
+    "url": "https://www.capterra.com/p/146933/Lessons-Learned-Database/",
+    "reviews_url": "https://www.capterra.com/p/146933/Lessons-Learned-Database/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/c15e8891-cccc-4a0c-9ac7-2004854519f6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": null,
     "review_count": null,
     "rating_breakdown": {
-      "overall": 5.0,
+      "overall": 4.5,
       "ease_of_use": 5.0,
       "customer_service": 5.0,
-      "features": 5.0,
+      "features": 4.0,
       "value_for_money": 5.0
     },
-    "description": "Project management software built for contractors. Track tasks, timelines, subs, and budgets in one platform. iOS and Android.",
+    "description": "A database for storing and searching for lessons learned and best practices.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "181522",
+    "name": "BlueRithm",
+    "url": "https://www.capterra.com/p/181522/BlueRithm/",
+    "reviews_url": "https://www.capterra.com/p/181522/BlueRithm/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a1571005-0807-4d25-8ddc-c8a9411735b0.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.8,
+    "review_count": 10,
+    "rating_breakdown": {
+      "overall": 4.8,
+      "ease_of_use": 4.3,
+      "customer_service": 5.0,
+      "features": 4.2,
+      "value_for_money": 4.9
+    },
+    "description": "Streamline your commissioning, test and balance, inspections, and testing projects with BlueRithm.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   },
@@ -2285,125 +437,181 @@
     "description": "Software ERP for the management of Marinas\nTransform the way your nautical works with our management platform",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "146320",
-    "name": "Planisware Orchestra",
-    "url": "https://www.capterra.com/p/146320/Planisware-Orchestra/",
-    "reviews_url": "https://www.capterra.com/p/146320/Planisware-Orchestra/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/8b585239-8edf-4c9c-beca-7db8d3663518.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.2,
-    "review_count": 19,
+    "product_id": "10036336",
+    "name": "Project Proctor",
+    "url": "https://www.capterra.com/p/10036336/Project-Proctor/",
+    "reviews_url": "https://www.capterra.com/p/10036336/Project-Proctor/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d539326b-d8b4-462b-ac54-606b0126ec8f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": null,
+    "review_count": null,
     "rating_breakdown": {
-      "overall": 4.2,
-      "ease_of_use": 3.9,
-      "customer_service": 4.2,
-      "features": 4.1,
-      "value_for_money": 4.0
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "customer_service": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0
     },
-    "description": "Leading PPM software helping PMOs accelerate and mature project portfolio delivery through real-time project lifecycle visibility.",
+    "description": "Project management software built for contractors. Track tasks, timelines, subs, and budgets in one platform. iOS and Android.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "152769",
-    "name": "eWay-CRM",
-    "url": "https://www.capterra.com/p/152769/eWay-CRM/",
-    "reviews_url": "https://www.capterra.com/p/152769/eWay-CRM/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/96c95171-8a65-4b39-82b8-8606dda3c33f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.5,
-    "review_count": 823,
-    "rating_breakdown": {
-      "overall": 4.5,
-      "ease_of_use": 4.4,
-      "customer_service": 4.6,
-      "features": 4.3,
-      "value_for_money": 4.4
-    },
-    "description": "The best CRM with an  embedded project management module. Keep everything in one software.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "137568",
-    "name": "Quire",
-    "url": "https://www.capterra.com/p/137568/Quire/",
-    "reviews_url": "https://www.capterra.com/p/137568/Quire/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0b498cac-b92e-4c38-bec7-5b21f820afa9.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "product_id": "211643",
+    "name": "Lucidspark",
+    "url": "https://www.capterra.com/p/211643/LucidSpark/",
+    "reviews_url": "https://www.capterra.com/p/211643/LucidSpark/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ea611411-a932-43ab-8b1d-ed3d6e162227.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 388,
+    "review_count": 385,
     "rating_breakdown": {
       "overall": 4.7,
-      "ease_of_use": 4.7,
-      "customer_service": 4.7,
-      "features": 4.6,
-      "value_for_money": 4.5
+      "ease_of_use": 4.5,
+      "customer_service": 4.5,
+      "features": 4.5,
+      "value_for_money": 4.4
     },
-    "description": "Quire stands as the pinnacle of modern project management software, introducing a transformative approach to your workflow.",
+    "description": "Lucidspark is a virtual whiteboard where teams can bring their best ideas to light. Brought to you by the makers of Lucidchart.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "118848",
-    "name": "Business in a Box",
-    "url": "https://www.capterra.com/p/118848/Business-in-a-Box/",
-    "reviews_url": "https://www.capterra.com/p/118848/Business-in-a-Box/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f06a251b-93f2-48d4-b047-665bead80a51.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 50,
+    "product_id": "169569",
+    "name": "Zoho Sprints",
+    "url": "https://www.capterra.com/p/169569/Zoho-Sprints/",
+    "reviews_url": "https://www.capterra.com/p/169569/Zoho-Sprints/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3dc054ff-c5aa-42b4-923b-07bbe81915fb.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 299,
     "rating_breakdown": {
-      "overall": 4.6,
+      "overall": 4.5,
       "ease_of_use": 4.5,
-      "customer_service": 4.5,
+      "customer_service": 4.4,
       "features": 4.4,
-      "value_for_money": 4.7
+      "value_for_money": 4.5
     },
-    "description": "Project management connected to tasks, roles, documents, and communication—keeping projects aligned with business goals.",
+    "description": "Zoho Sprints is a free online agile project management tool built for Scrum teams to plan, track and iterate their work in Sprints.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "64490",
+    "name": "Function Point",
+    "url": "https://www.capterra.com/p/64490/Function-Point/",
+    "reviews_url": "https://www.capterra.com/p/64490/Function-Point/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f37a5548-820b-4481-9c26-16e6051a6881.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.3,
+    "review_count": 193,
+    "rating_breakdown": {
+      "overall": 4.3,
+      "ease_of_use": 3.9,
+      "customer_service": 4.5,
+      "features": 4.0,
+      "value_for_money": 4.2
+    },
+    "description": "The all-in-one project management solution for creative agencies, internal teams and professional service firms.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "232375",
+    "name": "Birdview",
+    "url": "https://www.capterra.com/p/232375/Birdview/",
+    "reviews_url": "https://www.capterra.com/p/232375/Birdview/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b7c08483-2a84-468b-8fcc-31631dcdb050.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 475,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.5,
+      "features": 4.3,
+      "value_for_money": 4.3
+    },
+    "description": "360-degree view of projects, tasks, finances. Birdview blends adaptable growth, collaboration, and security with insightful analytics.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "225762",
+    "name": "Accelo",
+    "url": "https://www.capterra.com/p/225762/Accelo/",
+    "reviews_url": "https://www.capterra.com/p/225762/Accelo/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ba280ac6-4280-434a-ae33-7c547b963a2d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 177,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.2,
+      "customer_service": 4.5,
+      "features": 4.4,
+      "value_for_money": 4.3
+    },
+    "description": "Accelo connects project delivery to profitability with AI predicting risks, tracking budgets, and surfacing scope creep in real time.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   },
@@ -2425,41 +633,1305 @@
     "description": "Take control of your projects and find out where your time is going with customizable workflows and detailed, meaningful reports.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
   {
-    "product_id": "146132",
-    "name": "Aptien",
-    "url": "https://www.capterra.com/p/146132/Aptien/",
-    "reviews_url": "https://www.capterra.com/p/146132/Aptien/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/6c6c32f5-30d4-4ed5-bc0d-f2be65f52ca2.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.8,
-    "review_count": 30,
+    "product_id": "134429",
+    "name": "Resource Guru",
+    "url": "https://www.capterra.com/p/134429/Resource-Guru/",
+    "reviews_url": "https://www.capterra.com/p/134429/Resource-Guru/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d009e159-9e1a-436d-9e6e-d0133d163c61.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 540,
     "rating_breakdown": {
-      "overall": 4.8,
-      "ease_of_use": 4.8,
+      "overall": 4.7,
+      "ease_of_use": 4.7,
       "customer_service": 4.7,
-      "features": 4.7,
-      "value_for_money": 4.7
+      "features": 4.4,
+      "value_for_money": 4.6
     },
-    "description": "Project Collaboration Management Software. Keep your project teams coordinated, wherever you are.",
+    "description": "The blissfully simple resource management tool that helps busy teams schedule projects, balance workloads, and keep teams on track.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "160201",
+    "name": "ConstructionOnline",
+    "url": "https://www.capterra.com/p/160201/ConstructionOnline/",
+    "reviews_url": "https://www.capterra.com/p/160201/ConstructionOnline/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/1b41fc61-a961-4474-be20-bcf96a3d1ad1.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 608,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.8,
+      "features": 4.4,
+      "value_for_money": 4.5
+    },
+    "description": "ConstructionOnline is a centralized, cloud-based construction project management platform built for the full project lifecycle.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "132230",
+    "name": "Freedcamp",
+    "url": "https://www.capterra.com/p/132230/Freedcamp/",
+    "reviews_url": "https://www.capterra.com/p/132230/Freedcamp/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/399efeb4-e3fa-4aca-8c1b-8b006dcdc3b6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 502,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.5,
+      "customer_service": 4.7,
+      "features": 4.4,
+      "value_for_money": 4.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "225612",
+    "name": "Deltek Vantagepoint",
+    "url": "https://www.capterra.com/p/225612/Vantagepoint/",
+    "reviews_url": "https://www.capterra.com/p/225612/Vantagepoint/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/9b16f652-f738-45a1-b173-b04ba4d590e8.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.0,
+    "review_count": 489,
+    "rating_breakdown": {
+      "overall": 4.0,
+      "ease_of_use": 3.6,
+      "customer_service": 4.0,
+      "features": 4.0,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "153475",
+    "name": "FieldPulse",
+    "url": "https://www.capterra.com/p/153475/FieldPulse/",
+    "reviews_url": "https://www.capterra.com/p/153475/FieldPulse/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/fc7db629-f83f-478c-9e4d-8f697f15e439.webp?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 488,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.5,
+      "customer_service": 4.7,
+      "features": 4.4,
+      "value_for_money": 4.5
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "126797",
+    "name": "JobNimbus",
+    "url": "https://www.capterra.com/p/126797/JobNimbus/",
+    "reviews_url": "https://www.capterra.com/p/126797/JobNimbus/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/83d211e2-7581-45a6-8ff5-caa091bbcecc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 482,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.6,
+      "customer_service": 4.5,
+      "features": 4.4,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "136096",
+    "name": "Avaza",
+    "url": "https://www.capterra.com/p/136096/Avaza/",
+    "reviews_url": "https://www.capterra.com/p/136096/Avaza/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0955c8b8-f35d-4229-bbb1-d30f58513f67.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 475,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.5,
+      "value_for_money": 4.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "172519",
+    "name": "Nifty",
+    "url": "https://www.capterra.com/p/172519/Nifty/",
+    "reviews_url": "https://www.capterra.com/p/172519/Nifty/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/53075b74-4942-4c97-a5ca-3a2169181fd9.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 440,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.5,
+      "customer_service": 4.5,
+      "features": 4.5,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "151667",
+    "name": "Favro",
+    "url": "https://www.capterra.com/p/151667/Favro/",
+    "reviews_url": "https://www.capterra.com/p/151667/Favro/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/513bb28d-8c26-4ce1-8837-ef177a44d519.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 417,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.2,
+      "customer_service": 4.3,
+      "features": 4.1,
+      "value_for_money": 4.1
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "114491",
+    "name": "ActiveCollab",
+    "url": "https://www.capterra.com/p/114491/Active-Collab/",
+    "reviews_url": "https://www.capterra.com/p/114491/Active-Collab/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5ac2f2b3-e035-4b88-98d5-724c8e04b21f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 414,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.5,
+      "customer_service": 4.4,
+      "features": 4.2,
+      "value_for_money": 4.5
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "166656",
+    "name": "Flowlu",
+    "url": "https://www.capterra.com/p/166656/FLowlu/",
+    "reviews_url": "https://www.capterra.com/p/166656/FLowlu/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/2e45592e-f1b8-4a62-9c2e-1bd35bc46729.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.8,
+    "review_count": 387,
+    "rating_breakdown": {
+      "overall": 4.8,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.7,
+      "value_for_money": 4.9
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "160498",
+    "name": "Shortcut",
+    "url": "https://www.capterra.com/p/160498/Shortcut/",
+    "reviews_url": "https://www.capterra.com/p/160498/Shortcut/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/64ba40c7-c88d-4447-9112-4f637c688bc8.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 363,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.4,
+      "customer_service": 4.6,
+      "features": 4.4,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "128631",
+    "name": "Podio",
+    "url": "https://www.capterra.com/p/128631/Podio/",
+    "reviews_url": "https://www.capterra.com/p/128631/Podio/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f947c5f5-bd99-4c12-b724-cb06886d4c13.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.3,
+    "review_count": 363,
+    "rating_breakdown": {
+      "overall": 4.3,
+      "ease_of_use": 4.0,
+      "customer_service": 4.1,
+      "features": 4.3,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "116272",
+    "name": "Daylite for Mac",
+    "url": "https://www.capterra.com/p/116272/Daylite-for-Mac/",
+    "reviews_url": "https://www.capterra.com/p/116272/Daylite-for-Mac/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/ca07dfe8-c3e9-49db-8ee8-c8a73118c04b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 361,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.4,
+      "customer_service": 4.6,
+      "features": 4.5,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "10533",
+    "name": "Workamajig",
+    "url": "https://www.capterra.com/p/10533/Workamajig/",
+    "reviews_url": "https://www.capterra.com/p/10533/Workamajig/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/421881b6-4f86-4ae9-a596-0f4920b74d82.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 3.8,
+    "review_count": 351,
+    "rating_breakdown": {
+      "overall": 3.8,
+      "ease_of_use": 3.3,
+      "customer_service": 4.0,
+      "features": 3.8,
+      "value_for_money": 3.8
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "206203",
+    "name": "Agiled",
+    "url": "https://www.capterra.com/p/206203/Agiled/",
+    "reviews_url": "https://www.capterra.com/p/206203/Agiled/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b49fc8e8-9267-4c6f-93e1-27bfd97995cc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 350,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.7,
+      "value_for_money": 4.9
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "224496",
+    "name": "ProjectManager",
+    "url": "https://www.capterra.com/p/224496/ProjectManagercom/",
+    "reviews_url": "https://www.capterra.com/p/224496/ProjectManagercom/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/68efb2db-d64c-467b-9135-9ca35d9b69e7.webp?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.1,
+    "review_count": 339,
+    "rating_breakdown": {
+      "overall": 4.1,
+      "ease_of_use": 4.0,
+      "customer_service": 3.9,
+      "features": 3.9,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "157262",
+    "name": "Quickbase",
+    "url": "https://www.capterra.com/p/157262/QuickBase/",
+    "reviews_url": "https://www.capterra.com/p/157262/QuickBase/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d0157b8b-f072-4509-bd88-9963aa9b3fdf.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 333,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.1,
+      "customer_service": 4.3,
+      "features": 4.3,
+      "value_for_money": 4.1
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "141243",
+    "name": "ONLYOFFICE Workspace",
+    "url": "https://www.capterra.com/p/141243/ONLYOFFICE/",
+    "reviews_url": "https://www.capterra.com/p/141243/ONLYOFFICE/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b16abad5-1824-4f8a-be40-7c2507d60077.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 324,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.5,
+      "customer_service": 4.2,
+      "features": 4.3,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "168685",
+    "name": "Factorial",
+    "url": "https://www.capterra.com/p/168685/Factorial-HR-Software/",
+    "reviews_url": "https://www.capterra.com/p/168685/Factorial-HR-Software/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/08b856d9-1049-4164-83c6-fc273c2e089e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.3,
+    "review_count": 318,
+    "rating_breakdown": {
+      "overall": 4.3,
+      "ease_of_use": 4.5,
+      "customer_service": 4.2,
+      "features": 4.2,
+      "value_for_money": 4.1
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "227201",
+    "name": "Microsoft Planner",
+    "url": "https://www.capterra.com/p/227201/Microsoft-Planner/",
+    "reviews_url": "https://www.capterra.com/p/227201/Microsoft-Planner/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/952f617a-4c31-4c3c-838b-4477eca81b36.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.3,
+    "review_count": 295,
+    "rating_breakdown": {
+      "overall": 4.3,
+      "ease_of_use": 4.5,
+      "customer_service": 4.2,
+      "features": 4.2,
+      "value_for_money": 4.5
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "140681",
+    "name": "Kanbanchi",
+    "url": "https://www.capterra.com/p/140681/Kanbanchi-for-G-Suite/",
+    "reviews_url": "https://www.capterra.com/p/140681/Kanbanchi-for-G-Suite/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4df2a9ef-7d00-43c5-9e5d-17d66c5115b6.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 292,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.2,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "147183",
+    "name": "OpenText HighTail",
+    "url": "https://www.capterra.com/p/147183/Hightail/",
+    "reviews_url": "https://www.capterra.com/p/147183/Hightail/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/09968446-2362-4382-a33c-79dd76aede48.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 290,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.4,
+      "customer_service": 4.3,
+      "features": 4.4,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "150647",
+    "name": "Canopy",
+    "url": "https://www.capterra.com/p/150647/Canopy-Tax/",
+    "reviews_url": "https://www.capterra.com/p/150647/Canopy-Tax/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/cd76892f-c11a-4f2d-948a-fd800d702efd.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 286,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.5,
+      "customer_service": 4.5,
+      "features": 4.3,
+      "value_for_money": 4.2
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "107931",
+    "name": "ConnectWise PSA",
+    "url": "https://www.capterra.com/p/107931/ConnectWise-Manage/",
+    "reviews_url": "https://www.capterra.com/p/107931/ConnectWise-Manage/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/10b90bed-19f8-42a1-9a8c-7013628708dc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.1,
+    "review_count": 280,
+    "rating_breakdown": {
+      "overall": 4.1,
+      "ease_of_use": 3.7,
+      "customer_service": 3.7,
+      "features": 4.1,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "267175",
+    "name": "Open DevOps",
+    "url": "https://www.capterra.com/p/267175/Open-DevOps/",
+    "reviews_url": "https://www.capterra.com/p/267175/Open-DevOps/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a6dbb336-90fa-43ef-9793-bef5de638968.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 273,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.0,
+      "customer_service": 4.1,
+      "features": 4.4,
+      "value_for_money": 4.2
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "186837",
+    "name": "Financial Cents",
+    "url": "https://www.capterra.com/p/186837/Financial-Cents/",
+    "reviews_url": "https://www.capterra.com/p/186837/Financial-Cents/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e21ef758-af80-4b86-85a4-15bb566ad454.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.8,
+    "review_count": 268,
+    "rating_breakdown": {
+      "overall": 4.8,
+      "ease_of_use": 4.9,
+      "customer_service": 4.7,
+      "features": 4.6,
+      "value_for_money": 4.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "239335",
+    "name": "Viewpoint Vista",
+    "url": "https://www.capterra.com/p/239335/Vista/",
+    "reviews_url": "https://www.capterra.com/p/239335/Vista/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f1908081-1ac4-4014-93f5-515ba34cf8b3.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 3.8,
+    "review_count": 265,
+    "rating_breakdown": {
+      "overall": 3.8,
+      "ease_of_use": 3.5,
+      "customer_service": 3.4,
+      "features": 3.9,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "142042",
+    "name": "Scoro",
+    "url": "https://www.capterra.com/p/142042/Scoro/",
+    "reviews_url": "https://www.capterra.com/p/142042/Scoro/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5a2e0a6d-dc36-4f90-a38d-4d0ffcda7053.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 262,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.4,
+      "features": 4.4,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "126567",
+    "name": "RIB Candy",
+    "url": "https://www.capterra.com/p/126567/Candy/",
+    "reviews_url": "https://www.capterra.com/p/126567/Candy/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/69f1e7bc-038f-4c4a-b7e3-c454ab397895.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 252,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.6,
+      "features": 4.4,
+      "value_for_money": 4.2
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "77208",
+    "name": "ProWorkflow",
+    "url": "https://www.capterra.com/p/77208/ProWorkflow/",
+    "reviews_url": "https://www.capterra.com/p/77208/ProWorkflow/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/58cbe2e7-fbdb-46fe-b1cf-8fe7e0e4e40c.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 249,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.6,
+      "features": 4.2,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "228207",
+    "name": "DealRoom",
+    "url": "https://www.capterra.com/p/228207/DealRoom/",
+    "reviews_url": "https://www.capterra.com/p/228207/DealRoom/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d0e084b0-29a4-4051-aed8-d564f027af77.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 247,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.5,
+      "customer_service": 4.6,
+      "features": 4.3,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "188157",
+    "name": "Dropbox Paper",
+    "url": "https://www.capterra.com/p/188157/Dropbox-Paper/",
+    "reviews_url": "https://www.capterra.com/p/188157/Dropbox-Paper/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/fc55fe93-b971-48be-b0d6-0bde61d767a4.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 242,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.4,
+      "customer_service": 4.2,
+      "features": 4.3,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "133010",
+    "name": "Streamtime",
+    "url": "https://www.capterra.com/p/133010/Streamtime/",
+    "reviews_url": "https://www.capterra.com/p/133010/Streamtime/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/008f9648-2afe-4966-a767-bd3a7e409cb0.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 236,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.7,
+      "customer_service": 4.8,
+      "features": 4.5,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "178124",
+    "name": "Monograph",
+    "url": "https://www.capterra.com/p/178124/Monograph/",
+    "reviews_url": "https://www.capterra.com/p/178124/Monograph/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/06cbe396-af95-4679-9fc3-aacf7965086e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 236,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.7,
+      "features": 4.1,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "165004",
+    "name": "Zenkit",
+    "url": "https://www.capterra.com/p/165004/Zenkit/",
+    "reviews_url": "https://www.capterra.com/p/165004/Zenkit/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/3ce3db5f-183b-40cc-b056-d8ac633af090.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 235,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.5,
+      "customer_service": 4.7,
+      "features": 4.5,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "180283",
+    "name": "Sage 300",
+    "url": "https://www.capterra.com/p/180283/Sage-300cloud/",
+    "reviews_url": "https://www.capterra.com/p/180283/Sage-300cloud/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/7112afb8-9da1-4831-b7e3-5155aed46e56.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.0,
+    "review_count": 227,
+    "rating_breakdown": {
+      "overall": 4.0,
+      "ease_of_use": 3.8,
+      "customer_service": 3.8,
+      "features": 3.9,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "252371",
+    "name": "Admation",
+    "url": "https://www.capterra.com/p/252371/Admation/",
+    "reviews_url": "https://www.capterra.com/p/252371/Admation/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/1de86f9d-3be3-4445-b5fe-306386d7e85b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 3.6,
+    "review_count": 227,
+    "rating_breakdown": {
+      "overall": 3.6,
+      "ease_of_use": 3.0,
+      "customer_service": 3.6,
+      "features": 3.2,
+      "value_for_money": 3.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "190126",
+    "name": "Tempo Timesheets",
+    "url": "https://www.capterra.com/p/190126/Tempo/",
+    "reviews_url": "https://www.capterra.com/p/190126/Tempo/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e8b9fa6f-299a-4064-9622-1d4f48a14d09.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 225,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.3,
+      "customer_service": 4.3,
+      "features": 4.1,
+      "value_for_money": 4.1
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "135461",
+    "name": "Taskworld",
+    "url": "https://www.capterra.com/p/135461/Taskworld/",
+    "reviews_url": "https://www.capterra.com/p/135461/Taskworld/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/29ce2727-b215-4a45-8827-7d30b2e1f2ab.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 219,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.6,
+      "customer_service": 4.5,
+      "features": 4.2,
+      "value_for_money": 4.2
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "150991",
+    "name": "Hive",
+    "url": "https://www.capterra.com/p/150991/Hive/",
+    "reviews_url": "https://www.capterra.com/p/150991/Hive/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b19bbff3-c15c-48fa-8040-2eafb3db6551.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 219,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.4,
+      "customer_service": 4.5,
+      "features": 4.3,
+      "value_for_money": 4.4
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "18542",
+    "name": "Workzone",
+    "url": "https://www.capterra.com/p/18542/Workzone/",
+    "reviews_url": "https://www.capterra.com/p/18542/Workzone/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/dece148b-36b0-4982-b752-39bb2533cfcc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.8,
+    "review_count": 218,
+    "rating_breakdown": {
+      "overall": 4.8,
+      "ease_of_use": 4.6,
+      "customer_service": 4.9,
+      "features": 4.6,
+      "value_for_money": 4.8
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "189304",
+    "name": "Trackabi",
+    "url": "https://www.capterra.com/p/189304/Trackabi/",
+    "reviews_url": "https://www.capterra.com/p/189304/Trackabi/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f183d093-c32e-4713-b896-ddb5c5ce031e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 217,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.7,
+      "customer_service": 4.4,
+      "features": 4.5,
+      "value_for_money": 4.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "220249",
+    "name": "Oracle Aconex",
+    "url": "https://www.capterra.com/p/220249/Oracle-Aconex/",
+    "reviews_url": "https://www.capterra.com/p/220249/Oracle-Aconex/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/a90788a1-0c78-4bf2-b188-279e278073fc.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 217,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.2,
+      "customer_service": 4.3,
+      "features": 4.2,
+      "value_for_money": 4.1
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "148476",
+    "name": "Businessmap",
+    "url": "https://www.capterra.com/p/148476/Kanbanize/",
+    "reviews_url": "https://www.capterra.com/p/148476/Kanbanize/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/48ee0fe1-f086-4ddd-a6b8-5e50d8f3f648.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.8,
+    "review_count": 215,
+    "rating_breakdown": {
+      "overall": 4.8,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.7,
+      "value_for_money": 4.5
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "131573",
+    "name": "Prism PPM",
+    "url": "https://www.capterra.com/p/131573/WorkOtter/",
+    "reviews_url": "https://www.capterra.com/p/131573/WorkOtter/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/cc788bdf-c2e5-4dd6-b211-99c47f84aca7.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.9,
+    "review_count": 213,
+    "rating_breakdown": {
+      "overall": 4.9,
+      "ease_of_use": 4.9,
+      "customer_service": 4.9,
+      "features": 4.9,
+      "value_for_money": 4.9
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "191454",
+    "name": "Project.co",
+    "url": "https://www.capterra.com/p/191454/Project-co/",
+    "reviews_url": "https://www.capterra.com/p/191454/Project-co/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/833bf572-0ee5-47cc-8a27-5862fcab2d62.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.9,
+    "review_count": 209,
+    "rating_breakdown": {
+      "overall": 4.9,
+      "ease_of_use": 4.9,
+      "customer_service": 4.9,
+      "features": 4.7,
+      "value_for_money": 4.9
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "156181",
+    "name": "Karbon",
+    "url": "https://www.capterra.com/p/156181/Karbon/",
+    "reviews_url": "https://www.capterra.com/p/156181/Karbon/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/5730b928-5380-4227-84df-4798fa9f120a.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 208,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.5,
+      "value_for_money": 4.5
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "162784",
+    "name": "Claris FileMaker",
+    "url": "https://www.capterra.com/p/162784/FileMaker/",
+    "reviews_url": "https://www.capterra.com/p/162784/FileMaker/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/72381ab6-2a4e-495c-9b16-82f76f04ac2a.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.3,
+    "review_count": 208,
+    "rating_breakdown": {
+      "overall": 4.3,
+      "ease_of_use": 4.1,
+      "customer_service": 3.9,
+      "features": 4.3,
+      "value_for_money": 4.0
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "10010752",
+    "name": "ClickTime",
+    "url": "https://www.capterra.com/p/10010752/ClickTime/",
+    "reviews_url": "https://www.capterra.com/p/10010752/ClickTime/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/403c71a5-9598-4969-a24c-04a78127d287.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.6,
+    "review_count": 207,
+    "rating_breakdown": {
+      "overall": 4.6,
+      "ease_of_use": 4.5,
+      "customer_service": 4.7,
+      "features": 4.3,
+      "value_for_money": 4.6
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "135980",
+    "name": "Ayoa",
+    "url": "https://www.capterra.com/p/135980/DropTask/",
+    "reviews_url": "https://www.capterra.com/p/135980/DropTask/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/943eb85d-6549-4ed4-aee0-f14b18093c0e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 206,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.3,
+      "customer_service": 4.5,
+      "features": 4.3,
+      "value_for_money": 4.3
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "212111",
+    "name": "Dynamics 365 Business Central",
+    "url": "https://www.capterra.com/p/212111/Dynamics-365-Business-Central/",
+    "reviews_url": "https://www.capterra.com/p/212111/Dynamics-365-Business-Central/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/6a5f4d71-316e-4b79-9518-ef650a8ff931.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.1,
+    "review_count": 206,
+    "rating_breakdown": {
+      "overall": 4.1,
+      "ease_of_use": 3.7,
+      "customer_service": 3.7,
+      "features": 4.0,
+      "value_for_money": 3.7
+    },
+    "description": "What is this product about?",
+    "features": []
+  },
+  {
+    "product_id": "162588",
+    "name": "HoneyBook",
+    "url": "https://www.capterra.com/p/162588/HoneyBook/",
+    "reviews_url": "https://www.capterra.com/p/162588/HoneyBook/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/8c70159d-32c2-43c6-87a7-f1f66d5d622b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 685,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.6,
+      "customer_service": 4.7,
+      "features": 4.5,
+      "value_for_money": 4.6
+    },
+    "description": "Everything you need to manage projects: pipeline, proposals, contracts, payments, and more. \n\nStart your 7 day free trial today.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "135757",
+    "name": "NetSuite",
+    "url": "https://www.capterra.com/p/135757/NetSuite/",
+    "reviews_url": "https://www.capterra.com/p/135757/NetSuite/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/76ba5be7-e39f-481e-9045-7c45d7cf6d39.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.2,
+    "review_count": 2059,
+    "rating_breakdown": {
+      "overall": 4.2,
+      "ease_of_use": 4.0,
+      "customer_service": 3.8,
+      "features": 4.2,
+      "value_for_money": 3.9
+    },
+    "description": "NetSuite project management automates project creation and tracking for improved productivity and control for on-time project delivery.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "176283",
+    "name": "Visual Planning",
+    "url": "https://www.capterra.com/p/176283/Visual-Planning/",
+    "reviews_url": "https://www.capterra.com/p/176283/Visual-Planning/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f57c117c-d011-4ef0-9eed-0332deee8a0b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 118,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.4,
+      "features": 4.4,
+      "value_for_money": 4.3
+    },
+    "description": "Visual Planning: PM platform for manufacturing, services & engineering teams; track projects, resources & deadlines efficiently.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "133101",
+    "name": "Premier Construction Software",
+    "url": "https://www.capterra.com/p/133101/Premier/",
+    "reviews_url": "https://www.capterra.com/p/133101/Premier/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/42f8b7b4-9f63-480f-af45-24776128a434.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 288,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.6,
+      "customer_service": 4.8,
+      "features": 4.6,
+      "value_for_money": 4.7
+    },
+    "description": "All-in-one financial & project management construction cloud ERP, providing you with real-time visibility into your business.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "268205",
+    "name": "Adobe Workfront",
+    "url": "https://www.capterra.com/p/268205/Adobe-Workfront/",
+    "reviews_url": "https://www.capterra.com/p/268205/Adobe-Workfront/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/48f98b82-1651-4b2e-ba4d-b9eae6089ac6.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.4,
+    "review_count": 1499,
+    "rating_breakdown": {
+      "overall": 4.4,
+      "ease_of_use": 4.1,
+      "customer_service": 4.4,
+      "features": 4.3,
+      "value_for_money": 4.2
+    },
+    "description": "The collaborative work management leader, helping companies plan, execute, and deliver great work and exceptional customer experiences.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "85434",
+    "name": "SpiraTeam",
+    "url": "https://www.capterra.com/p/85434/SpiraTeam/",
+    "reviews_url": "https://www.capterra.com/p/85434/SpiraTeam/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/6e1f5434-9572-4c04-a19a-deef75fadc7e.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.2,
+    "review_count": 98,
+    "rating_breakdown": {
+      "overall": 4.2,
+      "ease_of_use": 4.0,
+      "customer_service": 4.6,
+      "features": 4.4,
+      "value_for_money": 4.6
+    },
+    "description": "SpiraTeam streamlines your ALM with AI automation, 100% traceability, and Agile-ready workflows for faster, risk-free project delivery.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "152769",
+    "name": "eWay-CRM",
+    "url": "https://www.capterra.com/p/152769/eWay-CRM/",
+    "reviews_url": "https://www.capterra.com/p/152769/eWay-CRM/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/96c95171-8a65-4b39-82b8-8606dda3c33f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 825,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.6,
+      "features": 4.3,
+      "value_for_money": 4.4
+    },
+    "description": "The best CRM with an  embedded project management module. Keep everything in one software.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "146320",
+    "name": "Planisware Orchestra",
+    "url": "https://www.capterra.com/p/146320/Planisware-Orchestra/",
+    "reviews_url": "https://www.capterra.com/p/146320/Planisware-Orchestra/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/8b585239-8edf-4c9c-beca-7db8d3663518.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.2,
+    "review_count": 19,
+    "rating_breakdown": {
+      "overall": 4.2,
+      "ease_of_use": 3.9,
+      "customer_service": 4.2,
+      "features": 4.1,
+      "value_for_money": 4.0
+    },
+    "description": "Leading PPM software helping PMOs accelerate and mature project portfolio delivery through real-time project lifecycle visibility.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "125356",
+    "name": "Journyx",
+    "url": "https://www.capterra.com/p/125356/Journyx/",
+    "reviews_url": "https://www.capterra.com/p/125356/Journyx/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e8fcfb17-feab-4c4e-8e49-04fec5fa4e9f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.1,
+    "review_count": 36,
+    "rating_breakdown": {
+      "overall": 4.1,
+      "ease_of_use": 4.0,
+      "customer_service": 4.4,
+      "features": 4.1,
+      "value_for_money": 4.2
+    },
+    "description": "Journyx makes it easy to track and manage employee time, expenses, and resources for projects, billing, and payroll, all in one place.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "119702",
+    "name": "Contruent",
+    "url": "https://www.capterra.com/p/119702/Contruent/",
+    "reviews_url": "https://www.capterra.com/p/119702/Contruent/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/9cca5d1c-3fc7-4e40-a333-539c0c8dbaf1.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.2,
+    "review_count": 25,
+    "rating_breakdown": {
+      "overall": 4.2,
+      "ease_of_use": 4.0,
+      "customer_service": 4.4,
+      "features": 4.1,
+      "value_for_money": 4.5
+    },
+    "description": "Contruent is the lifecycle cost management solution that empowers Owners and E&C firms to efficiently deliver complex capital programs.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "238666",
+    "name": "Materio",
+    "url": "https://www.capterra.com/p/238666/Materio/",
+    "reviews_url": "https://www.capterra.com/p/238666/Materio/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e465c338-2105-4c96-bf0f-53e0c98e8f1f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.9,
+    "review_count": 42,
+    "rating_breakdown": {
+      "overall": 4.9,
+      "ease_of_use": 4.7,
+      "customer_service": 4.9,
+      "features": 4.6,
+      "value_for_money": 4.7
+    },
+    "description": "The operating system for interior design. One workspace for every phase, every dollar — with QuickBooks sync.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "137568",
+    "name": "Quire",
+    "url": "https://www.capterra.com/p/137568/Quire/",
+    "reviews_url": "https://www.capterra.com/p/137568/Quire/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0b498cac-b92e-4c38-bec7-5b21f820afa9.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.7,
+    "review_count": 389,
+    "rating_breakdown": {
+      "overall": 4.7,
+      "ease_of_use": 4.7,
+      "customer_service": 4.7,
+      "features": 4.6,
+      "value_for_money": 4.5
+    },
+    "description": "Quire brings complex projects under control so teams can stay aligned, act early, and keep delivery moving.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   },
@@ -2470,7 +1942,7 @@
     "reviews_url": "https://www.capterra.com/p/211559/Trello/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/415abb34-71b7-4fa2-8dc4-1211cac6e655.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 23555,
+    "review_count": 23588,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.5,
@@ -2481,13 +1953,13 @@
     "description": "Trello is an intuitive project management tool that creates a shared perspective for your team across the entirety of any project.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2498,7 +1970,7 @@
     "reviews_url": "https://www.capterra.com/p/19319/JIRA/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/e1b492c5-8a97-4b86-a422-d317b2480afa.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.4,
-    "review_count": 15414,
+    "review_count": 15450,
     "rating_breakdown": {
       "overall": 4.4,
       "ease_of_use": 4.1,
@@ -2509,13 +1981,13 @@
     "description": "Jira is a project management tool for all teams to collaboratively plan, track, and manage projects, customize workflows, and more.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2526,7 +1998,7 @@
     "reviews_url": "https://www.capterra.com/p/56808/Basecamp/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/24d9f42f-a929-46b7-80e5-fc75ed573cb4.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.3,
-    "review_count": 14427,
+    "review_count": 14434,
     "rating_breakdown": {
       "overall": 4.3,
       "ease_of_use": 4.3,
@@ -2537,13 +2009,41 @@
     "description": "Trusted by millions, Basecamp puts everything you need to get work done in one place.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "184581",
+    "name": "Asana",
+    "url": "https://www.capterra.com/p/184581/Asana-PM/",
+    "reviews_url": "https://www.capterra.com/p/184581/Asana-PM/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b0bf7e60-e572-4090-8dd8-0e950b0ad16d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.5,
+    "review_count": 13635,
+    "rating_breakdown": {
+      "overall": 4.5,
+      "ease_of_use": 4.4,
+      "customer_service": 4.3,
+      "features": 4.4,
+      "value_for_money": 4.4
+    },
+    "description": "85% of the Fortune 100 run projects in Asana. Deliver 57% more work on time with AI-powered planning, automation, and coordination.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   },
@@ -2554,7 +2054,7 @@
     "reviews_url": "https://www.capterra.com/p/169607/Clockify/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/f5157b6b-4b64-4b26-9928-cdc78f98b182.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.8,
-    "review_count": 9248,
+    "review_count": 9258,
     "rating_breakdown": {
       "overall": 4.8,
       "ease_of_use": 4.8,
@@ -2565,13 +2065,13 @@
     "description": "Manage projects with time tracking, scheduling, budgeting, planning and reporting options in one software available across devices.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2593,13 +2093,13 @@
     "description": "Bring your teams work together, and unify your workflow. Create, collaborate, and store information all in one place.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2610,7 +2110,7 @@
     "reviews_url": "https://www.capterra.com/p/129067/GitHub/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d0cfa614-0cde-454f-b5f0-aed4c83f6a76.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.8,
-    "review_count": 6187,
+    "review_count": 6193,
     "rating_breakdown": {
       "overall": 4.8,
       "ease_of_use": 4.4,
@@ -2621,13 +2121,13 @@
     "description": "GitHub enables development teams to collaborate, and review and manage code within a DevOps pipeline and built-in code security.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2638,7 +2138,7 @@
     "reviews_url": "https://www.capterra.com/p/158833/ClickUp/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/60da54ff-60b7-4bec-9ece-19887f60a886.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.6,
-    "review_count": 4602,
+    "review_count": 4616,
     "rating_breakdown": {
       "overall": 4.6,
       "ease_of_use": 4.3,
@@ -2649,13 +2149,13 @@
     "description": "ClickUp is the world’s first Converged AI Workspace, bringing together all work apps, data, and workflows.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2666,7 +2166,7 @@
     "reviews_url": "https://www.capterra.com/p/136446/Confluence/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/c59cf6b8-ebd8-4c69-8658-9435f095413a.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 3695,
+    "review_count": 3711,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.3,
@@ -2677,13 +2177,13 @@
     "description": "Confluence makes project management easier by keeping track of milestones and timelines all in one place.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2694,7 +2194,7 @@
     "reviews_url": "https://www.capterra.com/p/158456/JotForm-4-0/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/fba1007d-abcd-4fe1-aeb3-964fd08702cb.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 2904,
+    "review_count": 2917,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.7,
@@ -2705,13 +2205,13 @@
     "description": "Jotform Boards is a task management solution that makes it easy to capture and resolve customer and client requests.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2722,7 +2222,7 @@
     "reviews_url": "https://www.capterra.com/p/186596/Notion/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/926fd60f-776a-41e5-9660-57c112abf44d.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 2768,
+    "review_count": 2795,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.4,
@@ -2733,13 +2233,13 @@
     "description": "Notion is the only project management software that connects your notes, projects, and wiki in one tool.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2750,7 +2250,7 @@
     "reviews_url": "https://www.capterra.com/p/56250/Procore/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b547ce2a-0241-4b1c-bfa8-4d6a8967d3cd.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 2663,
+    "review_count": 2673,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.4,
@@ -2761,13 +2261,13 @@
     "description": "Procore construction management software handles construction projects, resources, people, and financials from planning to closeout.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2778,7 +2278,7 @@
     "reviews_url": "https://www.capterra.com/p/149339/Todoist-for-Business/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/bd3ede5d-ab39-4984-8bdd-23d0f39ad778.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.6,
-    "review_count": 2648,
+    "review_count": 2657,
     "rating_breakdown": {
       "overall": 4.6,
       "ease_of_use": 4.6,
@@ -2789,13 +2289,13 @@
     "description": "Todoist helps small teams plan, organize, and deliver projects with clarity and focus, all in one simple workspace.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2806,7 +2306,7 @@
     "reviews_url": "https://www.capterra.com/p/70092/Buildertrend/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/755680d8-3cf8-4553-aab3-4dcd91f5d340.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 2485,
+    "review_count": 2486,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.4,
@@ -2817,13 +2317,13 @@
     "description": "Buildertrend is construction software for builders, remodelers, and contractors to track leads, projects, materials and finances.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2834,7 +2334,7 @@
     "reviews_url": "https://www.capterra.com/p/218046/Autodesk-Construction-Cloud/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/b1347be5-c9e0-43b8-b580-4d55494b1ebe.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.3,
-    "review_count": 2207,
+    "review_count": 2210,
     "rating_breakdown": {
       "overall": 4.3,
       "ease_of_use": 4.2,
@@ -2845,13 +2345,13 @@
     "description": "Keep construction projects on track. Improve collaboration and empower teams to leverage current information. Reduce rework and risk.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2873,13 +2373,13 @@
     "description": "ClockShark is the leading mobile GPS time tracking & scheduling software for local construction, field service, and contractors.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2890,7 +2390,7 @@
     "reviews_url": "https://www.capterra.com/p/128955/Miro/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4bc94550-fdfe-4ab2-a711-1c0eb512c391.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 1692,
+    "review_count": 1698,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.5,
@@ -2901,13 +2401,13 @@
     "description": "Meet project milestones in Miro, the #1 online collaborative whiteboard platform where teams get work done.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2929,13 +2429,13 @@
     "description": "Resource management software for delivery teams—plan capacity, staff projects, and track delivery performance in one place.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2946,7 +2446,7 @@
     "reviews_url": "https://www.capterra.com/p/132376/Hubstaff/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/aaac16f3-d85a-4597-a31c-6205c39cadc2.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 1609,
+    "review_count": 1611,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.4,
@@ -2957,13 +2457,13 @@
     "description": "Hubstaff has trusted time tracking and project management for remote and field teams. Scheduling, invoicing, reporting, payroll, more.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -2974,7 +2474,7 @@
     "reviews_url": "https://www.capterra.com/p/135618/Odoo/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/17efceca-38ea-4e7e-83dc-2cdd9fb0987f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.2,
-    "review_count": 1314,
+    "review_count": 1319,
     "rating_breakdown": {
       "overall": 4.2,
       "ease_of_use": 4.0,
@@ -2985,41 +2485,13 @@
     "description": "Odoo is an all-in-one open-source business platform for CRM, Sales, Accounting, Website, eCommerce, POS, Inventory, HR, and more.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
-      "Time & Expense Tracking"
-    ]
-  },
-  {
-    "product_id": "159806",
-    "name": "GitLab",
-    "url": "https://www.capterra.com/p/159806/GitLab/",
-    "reviews_url": "https://www.capterra.com/p/159806/GitLab/reviews/",
-    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/0a4c64d3-570d-43a0-9ab9-725c546efdf4.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
-    "rating": 4.6,
-    "review_count": 1223,
-    "rating_breakdown": {
-      "overall": 4.6,
-      "ease_of_use": 4.4,
-      "customer_service": 4.2,
-      "features": 4.6,
-      "value_for_money": 4.5
-    },
-    "description": "GitLab keeps work items, code, and AI agents in one place, so teams spend less time coordinating and more time building. Learn More.",
-    "features": [
-      "Access Controls/Permissions",
-      "Collaboration Tools",
-      "Commenting/Notes",
-      "Multiple Projects",
-      "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3041,13 +2513,13 @@
     "description": "MeisterTask is a web-based task and project management tool that is perfect for agile project management.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3069,13 +2541,13 @@
     "description": "All-in-one solution for construction & design with AI tools to win projects, manage clients & teams, and run an efficient business.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3086,7 +2558,7 @@
     "reviews_url": "https://www.capterra.com/p/173614/Any-do/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/452debc4-40c0-426e-9275-c73f10091998.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 1036,
+    "review_count": 1081,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.8,
@@ -3097,13 +2569,13 @@
     "description": "A simple and comprehensive project management tool offering detailed task tracking, timeline management, and resource allocation.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3125,13 +2597,13 @@
     "description": "\"Easy to use time tracker\" since 2002. Teams log time, leaders see exactly where it went, and projects get profitable.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3142,7 +2614,7 @@
     "reviews_url": "https://www.capterra.com/p/120390/Teamwork-Projects/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/c364f868-9af6-4e74-932f-9af84f48b6d7.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 940,
+    "review_count": 941,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.3,
@@ -3153,13 +2625,13 @@
     "description": "Teamwork.com is the only platform built for scaling client work. The best balance of functionality, price, and ease of use.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3170,7 +2642,7 @@
     "reviews_url": "https://www.capterra.com/p/175027/Figma/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/18df3d15-0497-4661-b2e1-bfeba3a21cd2.jpeg?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.7,
-    "review_count": 868,
+    "review_count": 874,
     "rating_breakdown": {
       "overall": 4.7,
       "ease_of_use": 4.5,
@@ -3181,13 +2653,13 @@
     "description": "Cloud-based and on-premise platform that enables businesses to create custom designs, share prototypes among team members.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3198,7 +2670,7 @@
     "reviews_url": "https://www.capterra.com/p/141096/BQE-Software/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/2a6d189c-62c6-45a7-bcad-aeae738925a3.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 787,
+    "review_count": 789,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.4,
@@ -3209,13 +2681,13 @@
     "description": "Project management for architects, engineers, CPAs, consultants, lawyers, and other professional services.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3237,13 +2709,13 @@
     "description": "Paymo allows you to manage projects, track work time, invoice your clients, and measure profitability from the same platform.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3265,13 +2737,13 @@
     "description": "dotloop is a real estate software aiding professionals in closing deals with eSignature, document sharing, and compliance automation.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3293,13 +2765,13 @@
     "description": "LiquidPlanner is the only Project Management solution with predictive scheduling to dynamically adapt to change and manage uncertainty.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3310,7 +2782,7 @@
     "reviews_url": "https://www.capterra.com/p/131076/BigTime/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/d2ce783e-db55-4da2-8cac-4ddd21aee442.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.6,
-    "review_count": 658,
+    "review_count": 661,
     "rating_breakdown": {
       "overall": 4.6,
       "ease_of_use": 4.5,
@@ -3321,13 +2793,13 @@
     "description": "BigTime streamlines projects, optimizes utilization, accelerates payments, and supports scalable growth for services organizations.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3349,13 +2821,13 @@
     "description": "Process Street is a Project Management platform that uses AI to run repeatable workflows with consistency, control, and audit readiness",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3366,7 +2838,7 @@
     "reviews_url": "https://www.capterra.com/p/75598/Harvest/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/2bfb6d75-5e50-4317-8d9d-1f0c9ed8617f.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.6,
-    "review_count": 647,
+    "review_count": 650,
     "rating_breakdown": {
       "overall": 4.6,
       "ease_of_use": 4.6,
@@ -3377,13 +2849,13 @@
     "description": "Harvest time tracking makes it easy to capture time, gain insights from past projects, and get paid for your team’s work.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3405,13 +2877,13 @@
     "description": "Copper helps you connect with leads, win deals, deliver projects and create repeat clients. All in one easy-to-use tool.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3422,7 +2894,7 @@
     "reviews_url": "https://www.capterra.com/p/142293/GanttPRO/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/dfc81976-a164-4c75-8de8-a315be85fa57.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.8,
-    "review_count": 549,
+    "review_count": 554,
     "rating_breakdown": {
       "overall": 4.8,
       "ease_of_use": 4.8,
@@ -3433,13 +2905,13 @@
     "description": "Online project management tool based on Gantt charts. Intuitive interface, nice UX/UI design, powerful features at affordable prices.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3450,24 +2922,24 @@
     "reviews_url": "https://www.capterra.com/p/129984/Time-Doctor/reviews/",
     "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/884511e8-1bf1-4ea7-94b0-6968634f900b.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
     "rating": 4.5,
-    "review_count": 545,
+    "review_count": 547,
     "rating_breakdown": {
       "overall": 4.5,
       "ease_of_use": 4.5,
       "customer_service": 4.4,
       "features": 4.4,
-      "value_for_money": 4.4
+      "value_for_money": 4.3
     },
     "description": "Empower better performance with Time Doctor’s workday analytics that’s helped 200k+ users boost productivity by 22% on average.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
       "Time & Expense Tracking"
     ]
   },
@@ -3489,13 +2961,41 @@
     "description": "Project time tracking platform helping mid-market and enterprise organizations manage time, projects, & workforce operations.",
     "features": [
       "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
       "Collaboration Tools",
       "Commenting/Notes",
+      "Document Management",
       "Multiple Projects",
       "Prioritization",
-      "Project Planning/Scheduling",
-      "Reporting/Project Tracking",
-      "Task Management",
+      "Time & Expense Tracking"
+    ]
+  },
+  {
+    "product_id": "135148",
+    "name": "Agile CRM",
+    "url": "https://www.capterra.com/p/135148/Agile-CRM/",
+    "reviews_url": "https://www.capterra.com/p/135148/Agile-CRM/reviews/",
+    "logo": "https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/4dd8e898-253a-4e64-8f55-73d688838bdb.png?auto=format%2Ccompress&fit=max&w=256&q=75&ch=Width%2CDPR",
+    "rating": 4.1,
+    "review_count": 525,
+    "rating_breakdown": {
+      "overall": 4.1,
+      "ease_of_use": 4.0,
+      "customer_service": 4.0,
+      "features": 4.1,
+      "value_for_money": 4.1
+    },
+    "description": "Agile CRM is a complete sales, marketing and service suite designed to let SMBs to sell and market like the Fortune 500.",
+    "features": [
+      "Access Controls/Permissions",
+      "Billing & Invoicing",
+      "Calendar Management",
+      "Collaboration Tools",
+      "Commenting/Notes",
+      "Document Management",
+      "Multiple Projects",
+      "Prioritization",
       "Time & Expense Tracking"
     ]
   }

--- a/capterra-scraper/results/reviews.json
+++ b/capterra-scraper/results/reviews.json
@@ -1,23 +1,23 @@
 [
   {
-    "title": "\"Great for project management\"",
-    "date": "May 25, 2026",
-    "reviewer_name": "Gabby W.",
-    "reviewer_role": "Founder",
-    "reviewer_industry": "E-Learning",
+    "title": "\"An easy to use project management tool\"",
+    "date": "July 12, 2026",
+    "reviewer_name": "Ben E.",
+    "reviewer_role": "Marketing and communications executive",
+    "reviewer_industry": "Non-Profit Organization Management",
     "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fbce0e8f82b12743306493a5941fed9b4e8a904fdfb925a0ba086ed7698bc0c05.jpeg&w=256&q=75",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fafdbb6f14fd120dd2da50abeb9e880845ff6dde99f6d33a015c445e5460c313f.jpeg&w=256&q=75",
     "ratings": {
       "overall": 5.0,
       "ease_of_use": 5.0,
       "features": 5.0,
       "value_for_money": 5.0,
-      "customer_service": null,
-      "likelihood_to_recommend": 10
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
     },
-    "review_body": "I’ve had a very positive experience with Trello overall. It’s a simple and effective project management tool that makes it easy to organize tasks, content, and workflows visually. I especially like the drag-and-drop board system because it helps keep projects clear and easy to manage without feeling overwhelming. It works well for both personal organization and team collaboration.",
-    "pros": "Pros:\n\nVery easy to learn and use, even for beginners\nClean visual layout with boards, lists, and cards\nGreat for task management, content planning, and team collaboration\nHelpful integrations and automation features through Power-Ups\nFlexible enough for both simple projects and more detailed workflows",
-    "cons": "Cons:\n\nCan feel limited for larger or more complex project management needs\nSome useful features are locked behind paid plans\nManaging many boards at once can become cluttered\nReporting and analytics tools are more basic than some competitors"
+    "review_body": "While using Trello to manage and organise different projects, I have always found it very easy to use, especially when working with other people on different projects.",
+    "pros": "Trello is a very useful tool to utilise for project management as it will allow anyone to easily manage their tasks. Having a board that can be moved for each task and assigned to different individuals is the best way to manage a project across people in different areas. \n\nIt is great value for money as you can use a free version and still be able to do lots with the project management system.",
+    "cons": "Trello is very easy to use but if you want to set up automated tasks and integrate it with different systems, then it will be more limited in this area as there are not a lot of features that can be used for integration."
   },
   {
     "title": "\"The magical visual simplicity for my straightforward workflows\"",
@@ -40,1064 +40,24 @@
     "cons": "This simplicity, which is its strength, is also its main limitation. As soon as a project begins to grow with hundreds of tasks or complex dependencies between them, Trello very quickly shows its limits. The screen becomes overcrowded and unreadable, and the lack of a native Gantt chart or advanced performance reports is deeply felt. To work around this, you have to install add-ons (called \"Power-Ups\"), but their integration can sometimes clutter the interface or require extra subscriptions that spoil the baseline experience."
   },
   {
-    "title": "\"Flexible Project Management\"",
-    "date": "June 11, 2026",
-    "reviewer_name": "Michael O.",
-    "reviewer_role": "Communications Manager",
-    "reviewer_industry": "Wholesale",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
+    "title": "\"Average project management software \"",
+    "date": "August 1, 2026",
+    "reviewer_name": "Shawna S.",
+    "reviewer_role": "Head of marketing",
+    "reviewer_industry": "Real Estate",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F56dec8f9c279eb31632bc0fc01847221bc974a30a77356e155d988e8f5a68ea2.jpeg&w=256&q=75",
     "ratings": {
       "overall": 3.0,
       "ease_of_use": 3.0,
-      "features": 4.0,
-      "value_for_money": null,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "Trello is a solid project management tool that works well for organizing tasks and keeping projects moving. That said, there can be a learning curve, and some workflows feel less streamlined than competing products.",
-    "pros": "Trello offers a lot of flexibility for managing projects and tasks. I like the visual board layout and how easy it is to organize work into lists and cards. It's also helpful for tracking progress and collaborating with team members.",
-    "cons": "Compared to some other project management tools, Trello can feel a little confusing and convoluted, especially when projects become more complex."
-  },
-  {
-    "title": "\"Great simple project management service\"",
-    "date": "March 11, 2026",
-    "reviewer_name": "Achirachaya T.",
-    "reviewer_role": "Software Engineer",
-    "reviewer_industry": "Investment Management",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F1f4def974f2fba1870d20f42d37b73257dc6e9ccd6cef28f01f528ef54709e63.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": null,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "It is a nice simple project management tool, with great uptime and stability (I don't remember developers broke any single thing inside it so far)",
-    "pros": "Generous free version, big quantity of different plugins, and simple idea behind and intuitive interface. I never had a problem of searching certain functionality for long time like with many other project management tools.",
-    "cons": "When there are a lot of cards interface becomes quite laggy and it is hard to use it, so you cant use one board to work and collect ideas in the same time for example."
-  },
-  {
-    "title": "\"Great for organizing team workflows.\"",
-    "date": "June 11, 2026",
-    "reviewer_name": "Eric P.",
-    "reviewer_role": "ERP Supervisor",
-    "reviewer_industry": "Leisure, Travel & Tourism",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 4.0,
-      "features": 5.0,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "I think Trello is a great software for team task management and scheduling, particularly in our mid-sized business where we're handling several campaigns and operations at a time. Easy to use and customer service has been quick to respond when we have contacted them a few times. However, it may need to be integrated with other tools for more in-depth analytics or when scaling up.",
-    "pros": "Since the adoption of Trello, we feel like we have a much easier way to manage our marketing planning and preparations for traveling events. The visual boards come in very handy when it comes to task allocation between departments, particularly if you have to book water park maintenance with promotions during the summer. Automating repetitive tasks saves us time and the calendar view helps with syncing up campaigns with timelines.",
-    "cons": "The downside of Trello is that it doesn't offer as many reporting features as might be preferred for task tracking. Having to extract data for reviews or to measure workflow bottlenecks as an ERP Supervisor is often something I have to do, and the tools that Trello have in this area do not seem very useful. Also, when managing multiple boards, keeping an overview can get a bit chaotic without integrations."
-  },
-  {
-    "title": "\"Good enough for monitoring board meetings but inadequate otherwise.\"",
-    "date": "May 16, 2026",
-    "reviewer_name": "Alexandre D.",
-    "reviewer_role": "Secretary General",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": null,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Trello serves the purpose as an administrative tool for a mid-sized technology company, but just about. While it is good enough for basic activities, it simply cannot handle our projects' interdependency and their board documents' versioning process.",
-    "pros": "The card system works fine in terms of monitoring the actions that the board takes along with any governance. I can assign different cards to individual managers within various departments and get an overview of pending activities. Activity streams help me monitor all the activity carried out by individual employees in case of audits. Butler automation assists in saving time in terms of repeated governance actions.",
-    "cons": "There are no Gantt charts, making it impossible to monitor our reporting deadlines on a quarterly basis. The free plan allows for 10 boards at most, making it inadequate since we need to manage multiple board committees. The integration process with the document repository in SharePoint poses an issue."
-  },
-  {
-    "title": "\"Trello allows for Project Management Across Organizations\"",
-    "date": "May 10, 2026",
-    "reviewer_name": "Michelle R.",
-    "reviewer_role": "Member at Large",
-    "reviewer_industry": "Program Development",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F88032b1fa4e24dbd874c156e479636202517bc9c727a0e7dad30d38ad4f6d874.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 4.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Trello was excellent. We received a 1-hour tutorial which allowed us to understand all the features and think through how to use the functions to best suit our own personal working styles and communication styles.",
-    "pros": "Trello is excellent for project management and communicating with team members as well as organizing timelines and sharing project deliverables. It allows users to have their own to-do lists, as well as incorporate team members and collaboratives into the task activities.",
-    "cons": "For new users, some technical assistance is required to understand how to best use Trello for the project goals and communications."
-  },
-  {
-    "title": "\"Trello is very usefull\"",
-    "date": "May 14, 2026",
-    "reviewer_name": "seppe H.",
-    "reviewer_role": "CEO",
-    "reviewer_industry": "Computer Software",
-    "reviewer_usage_duration": "I used a free trial",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F834b4dee437c93ddafba77da927fb813ff1edf1262c6295e26bf8a11cfa18a8b.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 4.0,
       "features": 3.0,
-      "value_for_money": 2.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 6
-    },
-    "review_body": "Trello is the ultimate \"Goldilocks\" tool—it’s not as intimidating as Jira, but more powerful than a simple to-do list. My experience has been overwhelmingly positive for creative workflows and small-team coordination. While it’s not the best fit for massive, multi-layered corporate infrastructure, it excels at keeping daily tasks organized, visible, and—dare I say—actually fun to manage.",
-    "pros": "The visual simplicity is Trello's superpower. The Kanban-style interface makes it incredibly satisfying to drag a card from \"Doing\" to \"Done.\" It has a very low barrier to entry, meaning you can get a team up and running in minutes without needing a PhD in project management. The flexibility of \"Power-Ups\" also allows you to customize the board just enough without cluttering the UI.",
-    "cons": "It struggles with \"Board Bloat.\" Once a project scales beyond a certain level of complexity, the horizontal scrolling becomes a chore and cards start to feel buried. It also lacks robust native reporting and dependency tracking (like Gantt charts) in the base version, which often forces you to rely on third-party integrations for features that should probably be built-in."
-  },
-  {
-    "title": "\"Easy to use \"",
-    "date": "May 23, 2026",
-    "reviewer_name": "Nicola R.",
-    "reviewer_role": "Business Owner",
-    "reviewer_industry": "Human Resources",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F1284a684e1d9f423f666bc6ff292199d21f550f085494f4486748790a46fae76.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 3.0,
-      "value_for_money": 4.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "Easy to use and makes total sense with the structure.  It is a nice, visual tool for me. Liked the simplicity.",
-    "pros": "There is a free version, but when using it for projects, it can be somewhat limiting. I started with Trello and love the design of the cards and found it very simple to use",
-    "cons": "Probably felt more old-fashioned than other project management tools, but it did what I needed to track projects."
-  },
-  {
-    "title": "\"Solid And Reliable Solution Keeping Projects On Track.\"",
-    "date": "June 19, 2026",
-    "reviewer_name": "Petru T.",
-    "reviewer_role": "Developer",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "Less than 6 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F18c69ba4368e1fe5b6ad4a5e30831a6f5794e443dff4a35104f26a4916c61521.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "My overall experience with Trello has been suprisingly lightweight in a good way.Really simple to use and effective , provides a wide variety of customization options and is great to use in our day to day operations and meetings.",
-    "pros": "What I like most about Trello is how fast it can organize and turn thoughts into something visual ,structured with KPI monitoring systems in place.",
-    "cons": "What I like least about Trello is that it can require certain workarounds for deeper hierarchy boards and nuanced tracking."
-  },
-  {
-    "title": "\"Good tool for collaborative work!\"",
-    "date": "February 15, 2026",
-    "reviewer_name": "Elena T.",
-    "reviewer_role": "Creative copywriter",
-    "reviewer_industry": "Marketing and Advertising",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fbba03b6992a302eeef4b723d573181d71a5c4eb1f99be9b2174cdfb171e74ae7.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "I've been using trello even begore Atlassian bought it. The kanban methodology is still nowadaya the BEST for my content planning. My clients are super happy with because it's super easy to use and leave feedback.",
-    "pros": "What I like the most is that I can visually see all my content plan and info (peding tasks, leave comenta feedback). Also the calendar view is super useful and easy to use Ford my clients. Plus it's free. Of course It has a paid plan, but the free versión is enough.",
-    "cons": "I don't like that you need a paid plan Ford Some basic automations or integrations. That's my only con, because it's not cheap."
-  },
-  {
-    "title": "\"Keeps our team moving without overcomplicating things\"",
-    "date": "September 12, 2025",
-    "reviewer_name": "Carl F.",
-    "reviewer_role": "Owner",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "We use Trello every day to track jobs, bids, and follow-ups. It’s simple enough that nobody resists using it, but flexible enough that we’ve built boards for estimating, project management, and sales. For a growing shop like ours, that balance of structure + ease has been critical.",
-    "pros": "New hires understand it within minutes, and the visual layout makes it easy to see bottlenecks at a glance. It also plays nicely with Gmail, n8n, and QuickBooks, so we’ve been able to automate a lot of repetitive steps without needing heavy IT support.",
-    "cons": "Reporting feels limited unless you start adding Power-Ups, and once you’re looking for more advanced automation or dashboards, it can feel a little basic."
-  },
-  {
-    "title": "\"Simple yet very flexible organisation tool\"",
-    "date": "September 8, 2025",
-    "reviewer_name": "Edward K.",
-    "reviewer_role": "App Integration Specialist",
-    "reviewer_industry": "Computer Software",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fa8f3d8560b060c0a217dec24f5ea64b905285b59501bde439a36b5273d721549.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "I've been using Trello for well over a decade. The free version has gone through several iterations, but still represents good value for money - especially in an agency / consulting setup where per-seat pricing for occasional client use is cost prohibitive. I find my clients love the ease of use compared with alternatives.",
-    "pros": "Simplicity and flexibility. It's easy to get started, and can support a number of different scenarios from project management to knowledge bases to calendars.",
-    "cons": "The user account management can be a challenge. I often find client users forgetting how they signed-up and so being unable to log in or receive notifications."
-  },
-  {
-    "title": "\"Wonderful Platform!\"",
-    "date": "April 21, 2026",
-    "reviewer_name": "Heather M.",
-    "reviewer_role": "Online Platform Coordinator",
-    "reviewer_industry": "Mental Health Care",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Trello has helped our team as a whole in so many ways! It has been a wonderful addition to help us navigate through our daily duties by letting us see at a glance what is happening and what needs to be completed.",
-    "pros": "What I liked most about Trello is its simplicity and visual approach to project management. The board and card system makes it easy to organize tasks, track progress, and quickly understand what's going on at a glance.",
-    "cons": "Absolutely Nothing! Trello is everything it is setup to be, its perfect the way it is! We, as a team, have had nothing but positive feedback when it comes to Trello."
-  },
-  {
-    "title": "\"Trello is your best friend for organizing your life.\"",
-    "date": "January 21, 2026",
-    "reviewer_name": "Jasmine L.",
-    "reviewer_role": "Director",
-    "reviewer_industry": "Research",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Love it love it love it!!! I use it for work, my personal life and tracking my future goals all in one place, very adaptable.",
-    "pros": "Its an immensely useful tool with a range of additional options to organise items. It's extremely easy to use and very flexible to create lists with images, text, labels, even numbers to score how important a task is. It makes it really easy to track tasks, you can tick as complete or archive them so they aren't visible but still remain. It's highly responsive, you can swiftly move tasks across lists and it performs really well with lots of information on one board. I feel as though I get a very full experience as a free customer so it's very good value for money when you can get a great insight into capabilities before looking to upgrade.",
-    "cons": "I wish I could move lists across boards and change the width of the task boxes, but I do like that it's aesthetic, just wanting to get a bigger picture of the list without scrolling up and down. Maybe zoom in on one list at a time function ?"
-  },
-  {
-    "title": "\"Trello: Great for Quick Wins, Overwhelming for Everything Else\"",
-    "date": "November 10, 2025",
-    "reviewer_name": "Willy H.",
-    "reviewer_role": "IT PM",
-    "reviewer_industry": "Insurance",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F08771defd7f31909c293cd8f5365894171f9635c35492d33500fa1acd368d79f.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
+      "value_for_money": 3.0,
       "customer_service": 3.0,
       "likelihood_to_recommend": 5
     },
-    "review_body": "My experience with Trello has been genuinely great, as long as I keep it simple.\n\nIt's my go-to tool for things like personal to-do lists, planning a quick social media calendar, or handling small projects with a defined beginning and end. The fact that I can instantly see where every task is—just by glancing at the board—is what keeps me coming back. It’s the closest thing to a truly digital, zero-friction whiteboard, and that visual clarity is a huge win.",
-    "pros": "I genuinely love how visual Trello is. The whole \"Boards, Lists, and Cards\" system makes it feel like you're moving virtual sticky notes around. I can see exactly where a project stands in about two seconds flat—no hunting through a dense spreadsheet or a cluttered inbox. It's fantastic for getting a quick, high-level view of the entire workflow.",
-    "cons": "While the visual aspect is a huge pro, it's also the main con. Once a board has, say, 10+ lists and 50+ active cards, it can feel overwhelming and crowded. It's easy for important tasks to get visually lost. Trello is brilliant for simple, contained projects, but for massive, enterprise-level planning, it starts to feel a bit too much like a huge, intimidating wall of digital stickies."
-  },
-  {
-    "title": "\"Simple and effective tool for task management\"",
-    "date": "April 18, 2026",
-    "reviewer_name": "MARWA B.",
-    "reviewer_role": "Desinger",
-    "reviewer_industry": "Commercial Real Estate",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F6e93a0d4095ad358c6d3851d06fde92ab3a7b855e6b50ef7f9011447899514da.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Overall, my experience with Trello has been very positive. It’s a great tool for organizing tasks and staying productive, especially for simple workflows or small teams. However, for more advanced project management needs, it may feel limited. It’s best suited for users who want something simple, visual, and easy to manage.",
-    "pros": "Trello is very easy to use and has a clean, visual interface. The drag-and-drop system makes organizing tasks simple and intuitive. I like how I can quickly create boards, lists, and cards to track my work. It’s great for both personal use and small team collaboration, and the free version already offers a lot of useful features",
-    "cons": "Trello can become messy when managing large or complex projects. It lacks advanced features like detailed reporting, timelines, or Gantt charts. Also, some useful features like automation and advanced views are only available in paid plans."
-  },
-  {
-    "title": "\"My Go‑To App for Organized, Collaborative Project Management\"",
-    "date": "January 16, 2026",
-    "reviewer_name": "Vicky L.",
-    "reviewer_role": "Marketing Specialist",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "My overall experience has been great, as this is one of my main work tools and I use it daily. I have not had any major issues in my 3 years using this app.",
-    "pros": "Trello has been my favorite project management app; it keeps my projects organized and on track. My team has the easy ability to know what is going on with my projects. Collaborating within the app and communicating are simple; we can discuss valuable information and give easy feedback about projects. I also enjoy using deadlines, calendar, and analytics features. Tagging and sorting by color options are helpful to keep team boards extremely organized.",
-    "cons": "Analytics features could perform a bit better, but it's not a huge deal; most of app's features are great for daily use."
-  },
-  {
-    "title": "\"Works way better than the spreadsheets\"",
-    "date": "January 14, 2026",
-    "reviewer_name": "Shawn N.",
-    "reviewer_role": "Chief Executive Officer",
-    "reviewer_industry": "Marketing and Advertising",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Had these monstrous Excel sheets that were a disaster but this does inventory data and doesn’t blow up. Team public don’t know what they’re doing I suppose. So happy I no longer now have to stare at Google docs all day because database stuff actually connects.",
-    "pros": "Guess tagging is working enough for me to call out my team (without getting up from my desk). The boards allow you to do things with out coding which is nice because I don’t have time for coding. Got some automations that are still working and was surprised email to task thing actually landed where it was supposed to. I mainly Use Trello browser and haven’t crashed computer today. Flicker light in cubicle giving me headache now.",
-    "cons": "Mobile app is utter disaster and can’t locate copy/paste button when at the deli. Slow. Exporting files has been like pulling teeth with the wrong formats and I hate how pricing all changed for admin seats without anyone saying anything to us."
-  },
-  {
-    "title": "\"Mortgage Broker\"",
-    "date": "April 21, 2026",
-    "reviewer_name": "Addy B.",
-    "reviewer_role": "Mortgage Broker",
-    "reviewer_industry": "Banking",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F882802d930259eb7707e57b9afd065dac2f2344b9128fcbc2b80f168d061041d.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 4.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "It's been great thus far.  No complaints.  I have not had any major issues that I cannot fix or chat with AI/service.",
-    "pros": "Trello is very user friendly.  It keeps me organized.  I like how I can share my boards easily, but if I don't want to, I don't have to.  I can integrate w/ many other programs that I use regularly.",
-    "cons": "Not everyone uses it.  It is pricey compared to others for what it offers.  Some find other solutions more affordable."
-  },
-  {
-    "title": "\"Need to manage a project? Use trello at every step \"",
-    "date": "December 26, 2025",
-    "reviewer_name": "Lisa P.",
-    "reviewer_role": "Content marketing coordinator",
-    "reviewer_industry": "Retail",
-    "reviewer_usage_duration": "Less than 6 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fe05de9402dc038b5bb71ed71b26f73303ab65661e6d995e23f6bbc090e1526f8.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 1.0,
-      "customer_service": 1.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Absolutely necessary to use project management tools if you're working with multiple teams, across different time zones. Helpful to navigate a project from start to finish (color coding was helpful for ownership)!",
-    "pros": "We used it as a collaboration tool for a website build. It was a great visual representation of where each stage of the project was developing and what was stuck, or what needed review or auditing.",
-    "cons": "A bit hard to know who owned each step of the task. Hard to access the search feature if you were looking for a keyword (or if you didn't recall if it was considered a task or a project)"
-  },
-  {
-    "title": "\"Trello - the easiest project tracking and management tool to use \"",
-    "date": "July 9, 2025",
-    "reviewer_name": "Maurice B.",
-    "reviewer_role": "Business Support",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Out of all the Atlassian products this is my favourite. I use Trello in a personal capacity also, including for holding my shopping list on the mobile app.",
-    "pros": "The ease of use and how well it integrates with other software tools used in the business including Jira and Hubspot",
-    "cons": "The lack of \"features\" in the free version. Once you have trailed premium it is tough to use basic. Apart from that it is my go to software."
-  },
-  {
-    "title": "\"Excellent task management tool with basic features\"",
-    "date": "March 4, 2026",
-    "reviewer_name": "Prachi P.",
-    "reviewer_role": "Senior Manager",
-    "reviewer_industry": "Management Consulting",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Excellent tool for basic task management and tracking for a team. Easy to setup and use, even if on free tier.",
-    "pros": "Easy to use. Simple interface to track tasks for a team with the ability to assign tasks. Very easy to set up and use for different teams. Easily available. Basic useful functionality available for free.",
-    "cons": "Lack of reporting features, graphs and charts. Can sometimes get cumbersome if there are multiple boards."
-  },
-  {
-    "title": "\"Simple way to stay organized\"",
-    "date": "August 9, 2025",
-    "reviewer_name": "Zeynep Dilara B.",
-    "reviewer_role": "Software engineer",
-    "reviewer_industry": "Education Management",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F78228f9f78ec03bf0a016801ac97b30be2fe0e68db76383e2446783a42ad4303.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Trello has helped me keep track of tasks and deadlines without feeling overwhelming. It’s clear, visual, and easy to update, which makes staying organized much less stressful.",
-    "pros": "Trello is very easy to set up and use. The boards, lists, and cards make it simple to track tasks visually, and it’s flexible enough for both personal and team projects. The drag-and-drop interface is intuitive",
-    "cons": "It can feel a bit basic and inadequate for complex projects, and some advanced features require a paid plan."
-  },
-  {
-    "title": "\"The best tool for managing both personal and professional projects.\"",
-    "date": "July 1, 2025",
-    "reviewer_name": "Danielli S.",
-    "reviewer_role": "Architect",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 4.0,
-      "customer_service": null,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "I truly like and have been using Trello for over 10 years. It’s a tool I rely on heavily for both personal and professional projects, not only for organization, but also for planning and management. It has been with me since college, through my postgraduate studies, during trips, and in architectural projects.",
-    "pros": "What I liked most about Trello is its ability to be customized and adapted to different types of projects. It allows for traceability of information through due dates, timelines, and notifications. Additionally, the tool offers many visual presentation options, ranging from extremely minimalist/functional to decorative/instructional.",
-    "cons": "There is a limitation regarding the function and layout of the cards, as boards always start with the same default list configuration in the initial Kanban view. Therefore, a real customization is only possible through power-ups or paid features."
-  },
-  {
-    "title": "",
-    "date": null,
-    "reviewer_name": "",
-    "reviewer_role": null,
-    "reviewer_industry": null,
-    "reviewer_usage_duration": null,
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": null,
-      "ease_of_use": null,
-      "features": null,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": null
-    },
-    "review_body": null,
-    "pros": null,
-    "cons": null
-  },
-  {
-    "title": "",
-    "date": null,
-    "reviewer_name": "",
-    "reviewer_role": null,
-    "reviewer_industry": null,
-    "reviewer_usage_duration": null,
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": null,
-      "ease_of_use": null,
-      "features": null,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": null
-    },
-    "review_body": null,
-    "pros": null,
-    "cons": null
-  },
-  {
-    "title": "\"Organizzare e ricordare in un unica piattaforma\"",
-    "date": "March 1, 2026",
-    "reviewer_name": "Kristian A.",
-    "reviewer_role": "Consulente esterno",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fe8374a664fe331e6ecb61475f3eae32ff8922625a1bb373da73e93f5c4b44488.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 4.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Il capo ufficio lo utilizza per ricordare a tutti noi collaboratori diversi appuntamenti e tenere una memo e storicità di chiamate e comunicazioni con i clienti",
-    "pros": "Una bella piattaforma per sincronizzare gli appuntamenti e tenere i reminder a schermo. Avrei migliorato alcuni aspetti grafici e semplificato alcune disposizioni rendendolo un pò più semplice.",
-    "cons": "All inizio era un pò complesso, ci sono voluti 4 mesi per utilizzarlo al massimo delle funzionalità. Un buon prodotto per le aziende con più di 4 dipendenti"
-  },
-  {
-    "title": "\"Great Tool for Staying Organized and On Track\"",
-    "date": "December 26, 2025",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "Senior software engineer",
-    "reviewer_industry": "Financial Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "My overall experience with Trello has been great. It keeps our team organized, reduces back-and-forth messages, and makes tracking work incredibly clear. The drag-and-drop boards, checklists, and integrations make it easy to manage projects without over-complicating things.",
-    "pros": "Easy member assign to the specific card and can move the card based on the status of card so that it can be tracked easily. We get notified if card move to other status. Effort estimation also can be done on the card to track the effort given for each card. Cost is low and good customer support,",
-    "cons": "Notifications can be overwhelming and sometimes easy to miss at the same time. It’s not always clear what actually needs attention.\nTrello is great for tasks, but reporting and progress tracking are weak. It’s hard to see big-picture status across multiple boards."
-  },
-  {
-    "title": "\"Simple, Visual, and Great for Team Collaboration\"",
-    "date": "February 26, 2026",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "App Developer",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 4.0,
-      "features": 4.0,
-      "value_for_money": 3.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Trello is intuitive and easy to use, great for simple task tracking and collaboration, but limited for complex workflows.",
-    "pros": "I liked Trello’s intuitive drag-and-drop boards, visual task tracking, and simple collaboration that makes projects easy to manage and share.",
-    "cons": "Trello can feel limited for complex projects—reporting, dependencies, and advanced workflows often require paid plans or add-ons."
-  },
-  {
-    "title": "\"My go to tool for day to day live both business and personal\"",
-    "date": "September 7, 2025",
-    "reviewer_name": "Paul T.",
-    "reviewer_role": "Managing Director",
-    "reviewer_industry": "Marketing and Advertising",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "I've used a number of project management softwares and while others are likely more appropriate for true project approaches, I find Trello absolutely game changing. I've been able to go from general to do lists, email inbox overflow, post in notes and specific project objectives into one unified place with complete organisation. It's my go to tool both professional and personal.",
-    "pros": "The best features of Trello for me are email to board (allowing you to send tasks right from your inbox). The AI catches most of the detail, preserves the original email and marks up dates. I love the views - tabular, calendar and general kanban. Extremely useful for different case uses. I love the automations, allowing me to renew weekly/monthly tasks where I can set the target dates to recur in a week, one month etc. I also love the calendar subscription mode allowing me to populate my diary/calendar with task and objectives. Support from their success team is also great.",
-    "cons": "I think it may be a bit simple, for very complicated tethered projects. I don't really deal with this type of work, in fairness. However I think it's devastating in it's simplicity and with add ons you could make it do the truly challenging stuff. I haven't found any cons for my use cases."
-  },
-  {
-    "title": "\"Intuitive and flexible task management platform\"",
-    "date": "December 21, 2025",
-    "reviewer_name": "Rene M.",
-    "reviewer_role": "Solution Architect",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Overall, my experience with Trello has been extremely positive. As an IT manager overseeing distributed teams, Trello has helped us maintain clear communication and track progress effectively on offshore projects. The ease of use and quick adoption by team members have made it a staple in our daily workflow, and it continues to support our agile, collaborative approach.",
-    "pros": "Trello is a versatile and intuitive tool for managing tasks and projects. Its card-based interface and boards make it easy to visualize workflows and collaborate with team members across departments and locations. The flexibility of creating lists, labels, and checklists allows for customizing processes to suit any team's needs, and integrations with other tools enhance productivity.",
-    "cons": "Some advanced project management features such as detailed reporting or resource management are limited compared to more comprehensive platforms. It can require additional power-ups or integrations to achieve certain functionalities, which might increase complexity or cost. The simplicity of Trello's structure may not fit complex enterprise workflows out-of-the-box."
-  },
-  {
-    "title": "\"Why the change?\"",
-    "date": "October 27, 2025",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "Designer",
-    "reviewer_industry": "Apparel & Fashion",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": 5
-    },
-    "review_body": "I used to love it and it supported and made my and my colleagues life so much easier but since the last update we all use it less",
-    "pros": "It’s so visual and simple. Moving cards feels just like sticky notes on a wall. It’s perfect for seeing the status of a design project fast, and it’s easy for the whole team to use.",
-    "cons": "Reporting and viewing timelines is limited on the free plan and the last update made me completely stop using it. I cannot see the list of all my projects at once, terrible."
-  },
-  {
-    "title": "\"Easy to use customizable communication \"",
-    "date": "December 31, 2025",
-    "reviewer_name": "Denise C.",
-    "reviewer_role": "Senior HR Manager",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Great experience. Easy to use. No training needed. Allows for easy collaboration. Can set up preferred notifications.",
-    "pros": "Very easy to use. Clear concise displays. Customizable. Can setup notifications for new comments, content, etc.",
-    "cons": "Wish there were a few more options for customizing theme, colors, etc. Otherwise overall a good easy to use platform."
-  },
-  {
-    "title": "\"Trello is a handy software and great tool to manage progress and track tasks\"",
-    "date": "September 3, 2025",
-    "reviewer_name": "Wilberth A.",
-    "reviewer_role": "Operation manager",
-    "reviewer_industry": "Computer Software",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Trello is a handy tool for managing teams with multiple members, though the free version works best for small to medium projects. I’ve used it extensively for IT projects and find it excellent for tracking task progress. It’s also great for client collaboration: you can assign tasks to both your team and customers and control visibility as needed.",
-    "pros": "Trello is very user-friendly, allowing you to manage multiple team members and gain a clear overview of your project. It also helps track customer tasks and facilitates collaboration. One of its key features is team-collaboration software, which keeps your team updated effortlessly.",
-    "cons": "n my opinion, the main drawbacks are the limited number of projects you can track, difficulty switching between projects, and potential storage constraints."
-  },
-  {
-    "title": "\"Useful & easy to use low-cost tool for managing our marketing comms/content calendar\"",
-    "date": "March 18, 2026",
-    "reviewer_name": "Tom L.",
-    "reviewer_role": "Marketing Director",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F76ceef97af0fdb8d01c5bcc52c46ae3b19297910af0c4c57e891923a6751a7de.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Useful low-cost tool for managing our marketing comms/content calendar - easy to use and update as well as share with relevant stakeholders",
-    "pros": "Useful collaboration tool for the marketing team to manage our content and comms calendar - the calendar power up in particular is easy to manage within the team, and share across the wider business to give visibility on our activity",
-    "cons": "The UI can sometimes be a little obtuse and settings which were once saved become undone. Quite random and not a major issue but can be frustrating nonetheless."
-  },
-  {
-    "title": "\"Simple, Visual, and Effective\"",
-    "date": "February 21, 2026",
-    "reviewer_name": "Yann S.",
-    "reviewer_role": "Psychotherapist",
-    "reviewer_industry": "Health, Wellness and Fitness",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ff30275bd4b879de0cb2d44fca8b18b7991ff09eab3ee607f4249e41e28857e77.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 2.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Trello remains excellent for organising work in a very simple and visual way. However, for larger teams it might be too basic.",
-    "pros": "Trello stands out for its easy to use. The card and board system is intuitive and makes task tracking visually clear enough. About the features it covers the essential well such as: task lists, due dates, labels and file attachments are easy to manage. Process automation through Butler is useful addition for all repetitive actions like moving cards or sending some reminders. Value for money is great for small team and individuals. The performance and speed are smooth",
-    "cons": "The customer support is sufficient however mostly self service. Get ready to rely heavily on documentation."
-  },
-  {
-    "title": "\"Task Superhero\"",
-    "date": "April 3, 2026",
-    "reviewer_name": "Haley S.",
-    "reviewer_role": "HR Manager",
-    "reviewer_industry": "Food & Beverages",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb79e25104b5f736fd57b6ed1a488b7fbdb01c60616c9e7f3081da8a2ffb0eb6d.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 4.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Our entire executive team uses Trello and it has created alignment, clarification, and assurance that tasks and projects are not falling through the cracks. The reminders and the ability to tag other Trello users who have linked boards are excellent for ensuring that all parties know the tasks that need to be completed and who is responsible for what portion and the deadline.",
-    "pros": "Trello's automated features help easily track high priority tasks, loop in team members, and track completion of large projects.",
-    "cons": "It took some time to really understand all of the features of Trello. The system does have helpful tips on a list so that you can easily reference how to use different tools and automations, which is helpful. It is beginner friendly for the basics, but the more advanced features had a learning curve."
-  },
-  {
-    "title": "\"The Perfect Balance of Visual Simplicity & Automation Power r\"",
-    "date": "April 28, 2026",
-    "reviewer_name": "Kira H.",
-    "reviewer_role": "Administrator",
-    "reviewer_industry": "Marketing and Advertising",
-    "reviewer_usage_duration": "Less than 6 months",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 4.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "My overall experience with Trello has been incredibly positive, primarily because it strikes a rare balance between radical simplicity and backend power. I use it as a central 'command center' for my projects. While it doesn't have the rigid structure of more traditional project management software,that flexibility is actually its greatest asset. By leaning heavily into the But!er automation, I've managed to cut my administrative time in half. It's reliable, stable platform that turns a messy brainstorm into a structured,actionable plan in minutes. Its the first tool I open every morning to ground myself in what actually needs to get done.",
-    "pros": "The Butler Automation is a game changer! I've set up rules so that when i move a card to a specific column, it automatically tags the right team member and sets a due date for two days out. I like having a virtual assistant that handles all the \"Busy work\" in the background, which allows me to focus on the actual tasks instead of just managing them.",
-    "cons": "The automation is top-- tier, Trello can feel a bit limited when a project requires deep hierarchies or complex task dependencies.Because everything is card-based, its hard to visualize how one delayed tasks impacts the rest of a massive timeline with out adding extra Power -Ups. I love the simplicity,but for high- level engineering or construction- style projects, i wish there were more native 'parent-child' task relationships built-in without needing external plugins."
-  },
-  {
-    "title": "\"Simple yet Powerful Project Management Tool\"",
-    "date": "April 10, 2026",
-    "reviewer_name": "Abishek T.",
-    "reviewer_role": "Student",
-    "reviewer_industry": "Education Management",
-    "reviewer_usage_duration": "I used a free trial",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Overall, Trello is an excellent tool for individuals and small teams looking for a simple and effective way to manage tasks and projects. While it may lack some advanced capabilities required for large-scale project management, its ease of use and flexibility make it a great choice for everyday productivity.",
-    "pros": "1. Very easy to use and visually appealing\n2. Great for organizing tasks and workflows\n3. Useful automation features\n4. Good performance and reliability\n5. Generous free plan",
-    "cons": "1. Limited advanced features compared to more complex tools\n2. Customer support could be better\n3. Can become cluttered with large projects"
-  },
-  {
-    "title": "\"Highly Versatile and Intuitive Tool for Visual Project Management\"",
-    "date": "April 23, 2026",
-    "reviewer_name": "Greg W.",
-    "reviewer_role": "Senior Learning Technologist",
-    "reviewer_industry": "Hospitality",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fc4071abf0e0ed0d693c981baa5486d03960d48d736c9af81d1747ec75bd9d65c.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Trello is a reliable and versatile tool that excels at making work visible. It has been a staple for managing everything from daily administrative tasks to large-scale initiatives. While it lacks some of the deep analytical power of enterprise-grade software, its ease of use and low barrier to entry make it an excellent choice for collaborative teams.",
-    "pros": "The visual nature of the Kanban boards provides immediate clarity on project status. It is incredibly intuitive for onboarding new team members, and the flexibility of the cards allows for a high degree of customization—especially when using Power-Ups to bridge the gap between simple task tracking and more complex project management.",
-    "cons": "As boards grow in complexity, they can become cluttered and difficult to navigate. The native reporting and high-level dashboard features are somewhat limited compared to more robust project management tools, often requiring third-party integrations or manual workarounds to get a truly 'birds-eye' view of multiple workstreams."
-  },
-  {
-    "title": "\"Excelente para gestionar proyectos\"",
-    "date": "May 26, 2026",
-    "reviewer_name": "Luis Antonio S.",
-    "reviewer_role": "Ingenieria de sistemas e informatica",
-    "reviewer_industry": "Construction",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F68cb557603ac1845db3454fee29dc707403c1792ef2fdc6d7ad8c277d1ad34d7.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 4.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "He podido trabajar en proyectos individuales como también en proyectos con equipos, la cual Trello me ayudó a gestionarlo y mantener una buena organización con el equipo.",
-    "pros": "Poder organizar proyectos y compartilos con el equipo de trabajo, trazar objetivos con fechas estimadas.",
-    "cons": "Hay opciones muy interesantes pero cuentan con un pago de por medio y que en la versión básica no se pueda exportar un excel para guarar los trabajos relaizados"
-  },
-  {
-    "title": "\"So you don't forget anything Trello \"",
-    "date": "February 4, 2026",
-    "reviewer_name": "Andres F.",
-    "reviewer_role": "it tech",
-    "reviewer_industry": "Import and Export",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ffba0a2045d035fb54ef7faa6d82bed67a853010677a35934d207663cc8ef2f30.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "So far, it has worked well for me. I've been using it for a long time, For the companies I have worked for, Bioej has worked well and helps a lot with day-to-day tasks.",
-    "pros": "offers a wide variety of features that greatly benefit the end user because it works perfectly so you don't forget anything",
-    "cons": "The truth is very intuitive,  Finally, to date, I haven't had any problems with Trello. Everything seems to be working well."
-  },
-  {
-    "title": "\"Feedback is positive anyway \"",
-    "date": "February 22, 2026",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "Owner",
-    "reviewer_industry": "Arts and Crafts",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 3
-    },
-    "review_body": "Great great great. I can slinky advise it to all who need this kind of automations with very professional and timely service.",
-    "pros": "It is absolutely worth money spent ! Very quick and qualified customer support can’t be noticed positively, very easy to use, it has many features that improve overall experience. Task tracking is common for this industry nad it helps to improve performance and speed of the performance.  It helped a lot with process automation during usage of this technology",
-    "cons": "Sometimes it has bags that really boring sometimes, but it was quickly solved by customer support and performed at its best"
-  },
-  {
-    "title": "\"Super handy project management tool for remote teams\"",
-    "date": "May 18, 2026",
-    "reviewer_name": "Daniel C.",
-    "reviewer_role": "Automation Engineer",
-    "reviewer_industry": "Health, Wellness and Fitness",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Great - genuinely useful for organising projects, teams ad workloads. Only minor gripes with its ease of integration with our workflow.",
-    "pros": "Project management/team colloboration\n\nAs a remote team, being able to organise tasks into their actual state remotely is a lifesaver- approvals; easy. In progress; visible at a glance. Responsible person; visible immediately.",
-    "cons": "Automated reminders and timers were not easy to set up. How we used it relied on users logging into trello to keep an eye on their tasks - when using multiple other tools this was a little cumbersome."
-  },
-  {
-    "title": "\"A fab bit if software you didnt kniw you needed til you use it\"",
-    "date": "October 15, 2025",
-    "reviewer_name": "Craig B.",
-    "reviewer_role": "Managing director",
-    "reviewer_industry": "Entertainment",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Very user friendly. No training needed. It nakes our day to day work easy to layout especially when working individually away from colleagues.",
-    "pros": "We use the free package which has everything we need so its great value for money. Very easy to use and set up. We use it to track day to day tasks and individual projects can be shared amongst staff and clients so tasks dont get missed. The drag and drop is a great feature is ideal to see at what stage each task is. The abillity to colour code and add files/images to each task helps us keep all our orojects in one place.",
-    "cons": "For what we use, there are no cons. It meets all our needs. Not sure what other benefits there ate to the software so maybe some promotional trials of extra features would be useful."
-  },
-  {
-    "title": "\"Great Starter Tool for Project Management\"",
-    "date": "April 30, 2026",
-    "reviewer_name": "Marvin S.",
-    "reviewer_role": "Lead Developer",
-    "reviewer_industry": "Computer Software",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 3.0,
-      "value_for_money": 5.0,
-      "customer_service": null,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Overall a great solution for individuals and Teams working on a projects.\nI would definitely recommend it for getting started, but for bigger teams or several teams working on different projects it gets challenging",
-    "pros": "Trellos ease of use and intuitiveness is a real upside, it easy to get started with and immediately helpful. Its excelent for organizing a single project, track its tasks and progress. Adding on a few simple plugins and it was a real treat to use.",
-    "cons": "Unfortunately while it worked great for tracking individual projects it kinda fell short in beeing able to overall organize our team over several projects. There was just too much stuff that needed to live outside of a simple kanban and we started adding on more and more external tools not integrated with Trello which bloated the workflow."
-  },
-  {
-    "title": "\"Trello - for all of your project management needs.\"",
-    "date": "January 2, 2026",
-    "reviewer_name": "Danielle M.",
-    "reviewer_role": "Vice President",
-    "reviewer_industry": "Automotive",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 4.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "My experience has been positive all around! I plan to continue to use it and would recommend it to anyone needing a task-tracking platform.",
-    "pros": "Trello is a very user-friendly platform that helps me keep track of candidates in the hiring process. I've tried using a few platforms, but Trello is the only one that I haven't had any issues with. I also like that they've continued to roll out new features so I feel like I'm always staying current with the times!",
-    "cons": "This is minor but the ONLY thing I can think of is that it's not easy to go from Trello to Trello so for example I use it for hiring but I also use it to keep track of storage units we rent and those are two different dashboards and I have trouble toggling between the two. But it's really not that big of a deal."
-  },
-  {
-    "title": "\"Good user friendly project management software \"",
-    "date": "June 10, 2026",
-    "reviewer_name": "Shawntel M.",
-    "reviewer_role": "Digital marketing Officer",
-    "reviewer_industry": "Marketing and Advertising",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "It was a good experience. It’s a good app for teams because there are many collaboration features but I can see where it could be overwhelming for personal projects",
-    "pros": "I loved how easy it was to use and understand and that a lot of things were editable. I loved that you could drag and drop instead of having to go through all the different steps",
-    "cons": "While I was using it the notifications weren’t always consistent. Sometimes they would come late or not at all or not with the full info"
-  },
-  {
-    "title": "\"Great features with the free plan.\"",
-    "date": "August 28, 2025",
-    "reviewer_name": "Clara R.",
-    "reviewer_role": "QA Manager",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "It is great, I use a free plan for retrospectives and project planing and it is really useful, can't complain.",
-    "pros": "Great open source tool for Kanban boards, easy to use and the free version for small project is amazing. The features like templates provided by defaults makes really easy to start a new board.",
-    "cons": "It could be great if we can customize more the aspect and flows of the status and the boards, that can allow more capacity and project diversity."
-  },
-  {
-    "title": "\"Get Organized Fast- Great Productivity Tool With Checklists For Teams\"",
-    "date": "March 3, 2026",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "Director of Sales and Marketing",
-    "reviewer_industry": "Internet",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": null,
-    "pros": "Trello has a very user friendly design. It's easy to get organized- fast. Checklists are really handy per project or task. This is especially helpful when collaborating with team mates and assigning responsibilities.",
-    "cons": "I don't think I've used Trello to its full potential. I wonder if it's more powerful than I think. Maybe there are more advanced automation options to help me be even more productive. I'm not searching for this info- so would be nice if there were some in-app notifications, popups, or like a bar up top maybe highlighting a webinar or training resources for users."
-  },
-  {
-    "title": "\"Simple, Visual, and Perfect for Small Teams\"",
-    "date": "January 13, 2026",
-    "reviewer_name": "Verified Reviewer",
-    "reviewer_role": "Product Manager",
-    "reviewer_industry": "Hospital & Health Care",
-    "reviewer_usage_duration": "Less than 6 months",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 2.0,
-      "ease_of_use": 5.0,
-      "features": 3.0,
-      "value_for_money": 4.0,
-      "customer_service": 3.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Overall, Trello has been great for keeping our team aligned without a steep learning curve. It removed a lot of friction getting people on the same page since the interface is intuitive enough that team members with different comfort levels with tools can use it without much training. Tasks don't slip through the cracks as much anymore since everything's visible in one place instead of scattered across emails and spreadsheets. That said, it works best for smaller teams managing simpler projects. If you need time tracking, reporting on closed tasks, or managing complex workflows, you'll probably find it limiting and end up layering on third-party integrations to fill the gaps.",
-    "pros": "The visual drag-and-drop interface is hard to beat. I can move cards between lists and immediately see where things stand without opening them. The board layout makes it super easy to understand what's in progress, what's coming next, and what's done. I also appreciate how flexible it is, we started with one board to track blog post ideas, then expanded to handle our entire onboarding process and client deliverables, all using the same basic setup. The automations for recurring tasks are really useful too, especially being able to set tasks to renew weekly or monthly with automatic due dates.",
-    "cons": "As we've grown and added more boards, it's become harder to see the big picture. There's no easy way to get a unified view across multiple boards to see high-level status. We find ourselves constantly switching between boards and losing context about which board something was on. Also, the free version has some frustrating limitations around attachment sizes and automation features. If you want calendar views or more advanced automations, you have to jump to a paid plan pretty quickly."
-  },
-  {
-    "title": "",
-    "date": null,
-    "reviewer_name": "",
-    "reviewer_role": null,
-    "reviewer_industry": null,
-    "reviewer_usage_duration": null,
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": null,
-      "ease_of_use": null,
-      "features": null,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": null
-    },
-    "review_body": null,
-    "pros": null,
-    "cons": null
-  },
-  {
-    "title": "",
-    "date": null,
-    "reviewer_name": "",
-    "reviewer_role": null,
-    "reviewer_industry": null,
-    "reviewer_usage_duration": null,
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": null,
-      "ease_of_use": null,
-      "features": null,
-      "value_for_money": null,
-      "customer_service": null,
-      "likelihood_to_recommend": null
-    },
-    "review_body": null,
-    "pros": null,
-    "cons": null
-  },
-  {
-    "title": "\"Trello is Built for Collaboration\"",
-    "date": "April 30, 2026",
-    "reviewer_name": "Kaleb V.",
-    "reviewer_role": "Clinic Director",
-    "reviewer_industry": "Hospital & Health Care",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F4f2c3aaba208c09bd00075c4423a46c95ecf8e11e52bd671fe5a7a7c4ef3262c.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 3.0,
-      "customer_service": 2.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "I've used Trello for so many projects and will continue to coordinate with team members across distances and time zones. Intuitive interface, collaborative design, this is an amazing way to keep everyone moving in the right direction.",
-    "pros": "Trello is an incredibly intuitive, versatile, multi-functional, and collaborative way for me to coordinate projects across multiple platforms. I manage multiple teams across different industries, some of which don't consider themselves \"tech savvy\". They've had no trouble adopting this system to update everyone in live time, as easily as posting a sticky note on a whiteboard. Storing documents, images, project details in a centralized place makes it easy to share critical project infrastructure.",
-    "cons": "I was logged out frequently, and sometimes my email account was not recoverable. Since it is paired under the \"Atlassian\" brands, their customer service was unable to resolve my issue and I had to recreate accounts, boards, and projects."
+    "review_body": "Overall, it gets the job done, but there are other project management software tools out there that do a far better job",
+    "pros": "I liked that it was an option in an ever growing project management market for digital tools within a team of more than five however it could still use much improvement for me to give it a five",
+    "cons": "What i liked Least about Trella was that it seemed like it was still in Beta mode it has a ways to go before I would rank it a five out of five"
   },
   {
     "title": "\"Great for professional and personal use\"",
@@ -1120,211 +80,31 @@
     "cons": "I didn’t have much luck with the integrations that I tried to use… for example, I tried to use one to make Gantt charts for a presentation I was doing on a project. I eventually just took to Google Sheets instead."
   },
   {
-    "title": "\"A Lightweight, High-Performance Solution for Streamlined Workflows\"",
-    "date": "May 7, 2026",
-    "reviewer_name": "Diego G.",
-    "reviewer_role": "Project Manager",
-    "reviewer_industry": "Retail",
+    "title": "\"Great for organizing team workflows.\"",
+    "date": "June 11, 2026",
+    "reviewer_name": "Eric P.",
+    "reviewer_role": "ERP Supervisor",
+    "reviewer_industry": "Leisure, Travel & Tourism",
     "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F42ab650add55c113898dca30839b2f96097f3c72402a167a815f213c821baeea.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "My overall experience with Trello has been defined by agility and visual clarity. It is an exceptional tool for maintaining high team velocity without the burden of a steep learning curve. The UI/UX is arguably the most user-friendly in the space, which made our Onboarding process seamless and allowed the team to focus on execution rather than tool management.\n\nWhile it lacks some of the deep analytical depth of more complex platforms, its Performance and reliable Integrations provide a solid foundation for tracking linear rollout phases. We have found the AI / Intelligence features (Butler) to be a subtle but effective way to handle repetitive administrative tasks. From a business perspective, the Pricing / ROI is excellent for projects that require a lightweight, high-speed coordination engine rather than a heavy data-processing machine. It remains my go-to solution for maintaining transparency and simplicity in fast-moving technical environments.",
-    "pros": "What I like best about Trello is its exceptional UI/UX, which remains one of the most intuitive in the market. This simplicity drastically reduces the time spent on Onboarding, allowing new team members to become productive almost instantly.\n\nFrom a technical standpoint, the Performance is consistently smooth, and the platform’s Integrations—via Power-Ups—allow us to connect our essential tools without cluttering the workspace. We have also started to see the benefits of their AI / Intelligence features (Butler), which help automate repetitive tasks and suggest smarter workflows.\n\nOverall, Trello offers a very high ROI due to its competitive Pricing model; it provides exactly the right amount of structure for agile coordination without the administrative complexity of larger platforms, making it an incredibly cost-effective solution for our team's daily operations.",
-    "cons": "What I dislike about Trello is its limited scalability for highly complex projects. While the UI/UX is great for simple tasks, the platform struggles when you need to manage deep hierarchies or cross-board dependencies. The AI / Intelligence features, though helpful, feel less integrated compared to more robust competitors.\n\nFurthermore, while the Pricing is attractive for small teams, the ROI can diminish as you scale, because you often need multiple paid Integrations (Power-Ups) to achieve basic reporting or Gantt functionality. I also find that the Performance can lag when a board becomes heavily populated with cards and attachments, and the Support for lower-tier plans can be slower than what I’ve experienced elsewhere. For a high-stakes rollout, the lack of advanced native analytical features is its biggest drawback."
-  },
-  {
-    "title": "\"Simple visual boards that keep our property management tasks on track.\"",
-    "date": "April 12, 2026",
-    "reviewer_name": "Kartikeya G.",
-    "reviewer_role": "Property Management",
-    "reviewer_industry": "Real Estate",
-    "reviewer_usage_duration": "I used a free trial",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fee0eeb110b94c123ce010e5103091fdeb13c2cb1c83d928aaccde5f2fe141565.jpeg&w=256&q=75",
+    "reviewer_avatar": null,
     "ratings": {
       "overall": 4.0,
       "ease_of_use": 4.0,
       "features": 5.0,
-      "value_for_money": 3.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "I use Trello at Minikaal Corporation, a small residential property management company, to keep track of leasing, maintenance, and back‑office tasks across our units. The board‑list‑card layout maps very naturally to our workflows (New Leads → Showings → Applications → Leases, or Open Ticket → In Progress → Awaiting Vendor → Completed), so the team can see status at a glance without digging through spreadsheets or email chains. Overall, Trello is an excellent fit for small property management and operations teams that need a visual, flexible system more powerful than sticky notes and email, but lighter than a full project management suite. It has become our go‑to place to see “what’s on deck” across leasing, maintenance, and admin, and I’d happily recommend it to other real estate or service businesses looking for a simple way to organize their work.",
-    "pros": "The biggest pros for us are how easy it is to set up new boards, customize lists, and add checklists, due dates, and attachments to each card. A new virtual assistant or contractor can understand our boards in minutes, and features like labels, comments, and simple Butler automations help ensure follow‑ups and recurring tasks don’t slip through the cracks. Trello also plays nicely with Google Workspace, so we can link Docs and Sheets, and use it alongside tools like Slack, Zoom, and email for day‑to‑day coordination.",
-    "cons": "On the downside, Trello’s native reporting and time‑based views are fairly light, so for portfolio‑level KPIs or more complex project tracking we still lean on spreadsheets or other tools. As boards grow large, it can also feel a bit cluttered without clear conventions for naming cards and archiving old work, which means you need some discipline in how you design and maintain your boards"
-  },
-  {
-    "title": "\"Trabajando de forma visual y ordenada\"",
-    "date": "April 5, 2026",
-    "reviewer_name": "Magno Gabriel H.",
-    "reviewer_role": "Asistente de producción",
-    "reviewer_industry": "Food Production",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F3fb6b62816d9045aa67a7cb22fc6be1d1a3f99b7e8d3d17cae5008a205d59a05.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Utilizo Trello de manera diaria para organizar tareas de mi ntorno laboral y académico de forma práctica. Me parace una herramienta fácil de implementar.",
-    "pros": "Trello oferece una gran facilidad para organizar tareas de manera visual. Facilita el seguimiento de proyectos mediante el uso de tableros, listas y targetas. Además, es muy útil para priorizar tareas, asignar responsabilidades y mantener todo ordenado en un solo lugar.",
-    "cons": "Suele limitarse cuando se gestiona proyectos más grandes y complejos, ya que no posee funcionalidades más avanzadas que que solo es manejable con la versión de pago."
-  },
-  {
-    "title": "\"Un outil intuitif et complet pour la gestion de projet\"",
-    "date": "May 4, 2026",
-    "reviewer_name": "Julien B.",
-    "reviewer_role": "Responsable social media",
-    "reviewer_industry": "Transportation/Trucking/Railroad",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F3cf0724d6b85169db79ba7a6d3dd67a02396fc34c8384754130457498a6ac514.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 9
-    },
-    "review_body": "Nous utilisons actuellement la version gratuite avec une équipe de 6 personnes. Nous avons donc un tableau commun pour nos objectifs collectifs, mais aussi des tableaux individuels pour avancer sur nos propres tâches. Honnêtement, c'est vraiment un outil intuitif pour tout le monde.",
-    "pros": "Trello à le mérite d'être extrêmement complet, même en version gratuite. Il contient à peu près tous les outils qui sont utiles à la gestion de projet et on notera que l'interface a vraiment été pensée pour nous faciliter la vie. C'est clair, rapide et efficace.",
-    "cons": "La structure reste parfois un peu rigide dans sa version gratuite. Ils manquent certaines options qui permettraient vraiment d'aller plus loin dans l'attribution des tâches. J'ai aussi l'impression que les images insérées dans les cartes sont compressées, ce qui, en fonction des besoins, peut-être problématique"
-  },
-  {
-    "title": "\"Ottimo programma per gestione di piccoli progetti\"",
-    "date": "April 20, 2026",
-    "reviewer_name": "Samuele R.",
-    "reviewer_role": "CEO e CTO",
-    "reviewer_industry": "Computer Software",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F20d9fad4f2aa035136d1fb4e6554a2800b299151f20201d6f4cbf4fca9270adf.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 3.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "Con Trello ho sviluppato in modo efficiente i progetti di piccola scala che avevo in mente di fare. Lo ritengo meno adatto a progetti grandi perché offre poche possibilità di aggiungere appunti, risorse ecc in modo organizzato. Tuttavia, per to-do più belli visivamente è un ottimo strumento.",
-    "pros": "Di Trello mi è piaciuta la semplicità di utilizzo, l'interfaccia pulita e semplice, e la versatilità dello strumento in diversi tipi di progetti.",
-    "cons": "Trello è un programma delle volte fin troppo semplice, l'interfaccia non è modernissima, e apprezzerei più funzionalità per organizzare i miei progetti. La sola visualizzazione Kanban non è sempre sufficiente."
-  },
-  {
-    "title": "\"Excellent for visual project tracking, but lacks deep analytical reporting\"",
-    "date": "June 16, 2026",
-    "reviewer_name": "Mantesh C.",
-    "reviewer_role": "Assistant Digital Marketing Manager",
-    "reviewer_industry": "Mechanical or Industrial Engineering",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
+      "value_for_money": null,
+      "customer_service": null,
       "likelihood_to_recommend": 8
     },
-    "review_body": "The overall experiance about the trello is amazing. Trello is a highly reliable and best tool for managing daily workflows, task management, and keeping teams aligned. It excels at breaking down multi-step processes into clear, actionable visual stages.",
-    "pros": "As per my personal experience, the User Interface and the Kanban-style layout are incredibly intuitive. It takes a fraction of a second to onboard a beginner team member because everything operates via a simple \"drag-and-drop\" interface. I love how flexible the cards are-you can dump links, attachments, checklists, and assign deadlines all in one place.",
-    "cons": "I used lots of time trello in my day-to-day activities. The least like tings is once a project expands beyond a certain specific size, the boards can become cluttered and overwhelming to look at. The built-in facilities, like reporting and automations (Butler) are fine for basic tasks, but if you want to look at high-level portfolio views, resource allocation, or complex dependency mapping, Trello starts to feel a bit too lightweight."
+    "review_body": "I think Trello is a great software for team task management and scheduling, particularly in our mid-sized business where we're handling several campaigns and operations at a time. Easy to use and customer service has been quick to respond when we have contacted them a few times. However, it may need to be integrated with other tools for more in-depth analytics or when scaling up.",
+    "pros": "Since the adoption of Trello, we feel like we have a much easier way to manage our marketing planning and preparations for traveling events. The visual boards come in very handy when it comes to task allocation between departments, particularly if you have to book water park maintenance with promotions during the summer. Automating repetitive tasks saves us time and the calendar view helps with syncing up campaigns with timelines.",
+    "cons": "The downside of Trello is that it doesn't offer as many reporting features as might be preferred for task tracking. Having to extract data for reviews or to measure workflow bottlenecks as an ERP Supervisor is often something I have to do, and the tools that Trello have in this area do not seem very useful. Also, when managing multiple boards, keeping an overview can get a bit chaotic without integrations."
   },
   {
-    "title": "\"Simple and visual Task Management, Best for basic Team Collaboration\"",
-    "date": "April 16, 2026",
-    "reviewer_name": "Sandra J.",
-    "reviewer_role": "Science Communication Technician",
-    "reviewer_industry": "Biotechnology",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ffe0f47c7fd59460c237e904497bfe1ae22882c35bae098bafee403913e41aeb6.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Trello makes it easy and smooth to mange tasks and simple project with great visual organization. It's simple to use and work well for teams that don't need a lot of automation or advanced controls. But it becomes limiting when the project gets more complicated and the need for reports grows.",
-    "pros": "Trello is very easy to use because its interface is clean and simple. Anyone can start managing tasks right away. It has boards and cards that make it easy to see how tasks are going, which makes it easier to understands how the project is going. Collaboration is easy, so team can stay on the same page without any problems. In general, it's light, quick and dependable for basic project management needs.",
-    "cons": "Trello's advanced feature are limited, especially for managing complicated projects and automating processes, which makes it hard to grow. Customer service can seem slow or less proactive when it comes to fixing bigger problems. Compared to more advanced tools, it doesn't have very good reporting and analytics."
-  },
-  {
-    "title": "\"Visualize Your Success\"",
-    "date": "February 12, 2026",
-    "reviewer_name": "Ahmed A.",
-    "reviewer_role": "Marketing Officer",
-    "reviewer_industry": "Computer Networking",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fffe659f3fe3570cc8b45cf163ebd3b4cb52e14850b6d505baf31d817fb3511fc.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Highly practical and efficient; it turns project complexity into a simple, easy-to-track visual workflow, though it can become overwhelming when tasks pile up excessively.",
-    "pros": "Trello’s standout feature is its intuitive visual interface, which makes tracking complex projects effortless through a simple drag-and-drop system. I highly value its extreme flexibility for customizing workflows and the powerful \"Butler\" automation that handles repetitive tasks seamlessly.",
-    "cons": "The biggest downside is that boards become cluttered and hard to manage as projects grow large, making it less ideal for complex team workflows. Additionally, many essential views like Calendar and Timeline are locked behind paid tiers, limiting the functionality of the free version."
-  },
-  {
-    "title": "\"Reliable Task Tracking and Collaboration Made Easy\"",
-    "date": "January 29, 2026",
-    "reviewer_name": "Kapil S.",
-    "reviewer_role": "Project manager",
-    "reviewer_industry": "Insurance",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F2b7e6a06fe3cf433c7619e0dedee6d71eac4adfac32d31cb3fd3ea6a3304c62a.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 3.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 8
-    },
-    "review_body": "Overall, my experience with Trello has been very positive. It is a reliable and user-friendly tool that simplifies task tracking and improves team collaboration. The visual layout makes it easy to organize work, monitor progress, and stay aligned with deadlines. Trello works especially well for small to medium-sized projects and teams that value simplicity and flexibility. While it may have limitations for highly complex project management needs, it delivers strong value for money and consistently supports efficient, organized workflows.",
-    "pros": "Trello provides excellent value for money, especially for small to mid-sized teams looking for a reliable task and project management tool. The platform is very easy to use, with an intuitive drag-and-drop interface that requires minimal training. Task tracking is clear and visual, making it simple to monitor progress across different stages of work.\nTrello’s features, such as boards, lists, cards, due dates, and checklists, support efficient workflow management. Process automation through Butler helps reduce manual effort and improves productivity. The calendar view is useful for managing deadlines and planning work in advance. Additionally, customer support resources and documentation are helpful for resolving queries quickly. Overall, Trello is a flexible, user-friendly tool that enhances collaboration and organization.",
-    "cons": "While Trello is easy to use and visually intuitive, it can feel very limited for complex projects that require advanced reporting that has dependencies, or require detailed workflow analytics. Managing large-scale projects with multiple boards can become difficult, as there is no built-in hierarchical structure. Some advanced features and automation options are only available in paid plans, which may impact value for money for growing teams. Additionally, customization options for dashboards and reports are relatively basic compared to more robust project management tools."
-  },
-  {
-    "title": "\"Expensive to do list\"",
-    "date": "March 9, 2026",
-    "reviewer_name": "Jenifer M.",
-    "reviewer_role": "Events Coordinator",
-    "reviewer_industry": "Events Services",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 2.0,
-      "ease_of_use": 3.0,
-      "features": 3.0,
-      "value_for_money": 1.0,
-      "customer_service": 2.0,
-      "likelihood_to_recommend": 2
-    },
-    "review_body": "Very expensive to implement for a pretty product that says can be a great management tool, but you can only organize it vertically or horizontally. Needs to be built out more and not have everyone working out of a tiny square. It is more of a fancy elaborate check list/to do list. Do not use for project management.",
-    "pros": "The prettiness, it's a pretty product, it's a good checklist. Can replace your post it nots and make it digital but there are other free apps for this too.",
-    "cons": "Not as effective in project management as ASANA or other project management systems. It cannot support an organization's yearly marketing plan. Too much information in one place, can't organize it so that it is manageable."
-  },
-  {
-    "title": "\"Trelllo - Easy Peasy Usage\"",
-    "date": "March 18, 2026",
-    "reviewer_name": "Anne O.",
-    "reviewer_role": "Senior Developer",
-    "reviewer_industry": "Insurance",
+    "title": "\"A Wonderful Tool\"",
+    "date": "July 8, 2026",
+    "reviewer_name": "Alexis B.",
+    "reviewer_role": "Cultural Director Of Cinema And Live Performance",
+    "reviewer_industry": "Government Administration",
     "reviewer_usage_duration": "2+ years",
     "reviewer_avatar": null,
     "ratings": {
@@ -1335,89 +115,109 @@
       "customer_service": 5.0,
       "likelihood_to_recommend": 10
     },
-    "review_body": "It's a very useful tool. It's a great way to track projects and share where you are in a project with the rest of the team. It has awesome tools so you can track and check off different tasks on a project. I love that you can communicate with other people. It's a good way to track projects without having to go back and search through hundreds of emails -- everything is located in one convenient location. I won't go back to tracking projects by spreadsheets after this!",
-    "pros": "It's easy to plan projects and see where they are in the process. I'm a visual learner so I like to see where a project is. I also like that you other team members can see the progress of a particular project and I can communicate with team members using the Trello cards. Easy peasy!",
-    "cons": "Once a team member accidentally erased a card, but she was able to restore it after she looked up how to do it. It would be nice to have an extra warning before a Trello card is deleted."
+    "review_body": "All in all,Trello has been reliable in assigning tasks ,tracking deadlines and allow team collaboration with a shared board that facilitate clear communication.",
+    "pros": "Easy to navigate and performs reliably.Provides versatile customization features suc as color coding,templates and labels that suit different types of projects. Simple to assign tasks and track deadlines .",
+    "cons": "Trello is amazing in all its purposes and is affordable in terms of price,so far haven't faced any big challenge ."
   },
   {
-    "title": "\"Review of Trello over 2 years of usage\"",
-    "date": "April 1, 2026",
-    "reviewer_name": "Rakhi V.",
-    "reviewer_role": "QA Lead",
-    "reviewer_industry": "Information Technology and Services",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 4.0,
-      "value_for_money": 4.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "It’s a reliable, easy-to-use tool for organizing work and keeping teams aligned, especially for smaller projects or simple workflows. While it isn’t always the best fit for more complex tracking or analytics, it’s excellent for clarity, speed, and day-to-day task management.",
-    "pros": "Trello is simple and visual  boards, lists, and cards make it easy to see what’s going on at a glance without needing training. It’s also great for lightweight collaboration because it’s quick to add tasks, assign owners, and move work along, which makes it feel less heavy than more complex project tools",
-    "cons": "Trello can start to feel a bit limited—tracking dependencies, reporting, or more complex workflows often needs add-ons or workarounds. It can also get messy if a board isn’t maintained consistently, since cards pile up and it becomes harder to tell what’s truly important versus just “still sitting there.”"
-  },
-  {
-    "title": "\"Easy, Customizable, Effective Task Management \"",
-    "date": "December 22, 2025",
-    "reviewer_name": "Jen P.",
-    "reviewer_role": "Director of Tutor Development and Operations",
-    "reviewer_industry": "E-Learning",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": null,
-    "ratings": {
-      "overall": 4.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Overall, I have a very positive view of Trello. It is a very flexible software that can be customized to fit just about any need. The add-ons such as the day counter and automations make it even more adaptable.",
-    "pros": "I love how Trello is easy to use and super customizable! The templates make it super easy to get started and all the add on automations are incredibly helpful for keeping tasks organized. I also LOVE the shortcuts to add cards from any where on your computer. The free version is SUCH a great value!",
-    "cons": "Trello seems to use quite a bit of memory and sometimes slows down my computer if I have several applications open which means I have to close it at times."
-  },
-  {
-    "title": "\"The perfect visual tool for simple and effective task tracking\"",
-    "date": "December 30, 2025",
-    "reviewer_name": "Camilo I.",
-    "reviewer_role": "Project Manager",
-    "reviewer_industry": "Translation and Localization",
-    "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb6095fe64d6684bb5ac53d0f5af20e8a36a88b77ff7326488c1fc817d8dd9181.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 10
-    },
-    "review_body": "Overall, my experience with Trello has been excellent for daily organization and team collaboration. It is the most user-friendly way to manage a to-do list or a creative pipeline without the overhead of more complex software. It might not be the best fit for highly technical or massive projects, but for staying organized and seeing progress at a glance, it's my favorite choice.",
-    "pros": "What I like most is the visual simplicity. The Kanban board layout is incredibly intuitive—I can see exactly where every project stands just by looking at the cards. It’s one of the few tools where I didn't need a tutorial to get started; the drag-and-drop interface makes organizing tasks feel natural and fast.",
-    "cons": "While the simplicity is a strength, it can feel a bit limited for complex projects. It's hard to get a bird's-eye view of work happening across multiple boards, and things like task dependencies or advanced reporting usually require extra 'Power-Ups.' It’s great for straightforward workflows, but it can get a little cluttered as the team grows."
-  },
-  {
-    "title": "\"One of the best for basic project management.\"",
-    "date": "February 5, 2026",
+    "title": "\"Makes things simple!\"",
+    "date": "July 26, 2026",
     "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "Content Specialist",
+    "reviewer_industry": "Non-Profit Organization Management",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 3.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": null,
+    "pros": "I like the workflow and how we can set things up to demonstrate the products individual creative assets have made. I think that Trello is better at presenting a calendar and timeline-like view better than any other software",
+    "cons": "I don't like that due dates are a bit hidden from view in the desktop version. Also, I've had issues with content not saving automatically, and having to redo work if it's placed in the description."
+  },
+  {
+    "title": "\"Great software to use\"",
+    "date": "July 14, 2026",
+    "reviewer_name": "Aneesa A.",
+    "reviewer_role": "UX UI",
+    "reviewer_industry": "Financial Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F948dd602de25aad80255766d4192ea52695a72af064e9329e3f544ae7c53efb1.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 4.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": null,
+    "pros": "What I like most about Trello, especially when working with different teams, I can keep track and make notes of where everyone is up to. The ease of use of creating and moving things around makes my life easier.",
+    "cons": "What I least like about Trello is that when we do have a large workflow, it can look very cluttered on the page"
+  },
+  {
+    "title": "\"Solid And Reliable Solution Keeping Projects On Track.\"",
+    "date": "June 19, 2026",
+    "reviewer_name": "Petru T.",
     "reviewer_role": "Developer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F18c69ba4368e1fe5b6ad4a5e30831a6f5794e443dff4a35104f26a4916c61521.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "My overall experience with Trello has been suprisingly lightweight in a good way.Really simple to use and effective , provides a wide variety of customization options and is great to use in our day to day operations and meetings.",
+    "pros": "What I like most about Trello is how fast it can organize and turn thoughts into something visual ,structured with KPI monitoring systems in place.",
+    "cons": "What I like least about Trello is that it can require certain workarounds for deeper hierarchy boards and nuanced tracking."
+  },
+  {
+    "title": "\"The right tool for small to medium projects\"",
+    "date": "June 27, 2026",
+    "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "Software developer",
+    "reviewer_industry": "Computer Software",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 4.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 3.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": null,
+    "pros": "It is easy to use and powerful enough for my use-case. I'm using it to develop my SAAS business, and personal projects.",
+    "cons": "I wanted more integrations with ai like MCP and I'm starting to see the limitations as the projects grow in complexity and we need to manage multiple people."
+  },
+  {
+    "title": "\"Good tool for collaborative work!\"",
+    "date": "February 15, 2026",
+    "reviewer_name": "Elena T.",
+    "reviewer_role": "Creative copywriter",
     "reviewer_industry": "Marketing and Advertising",
     "reviewer_usage_duration": "2+ years",
-    "reviewer_avatar": null,
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fbba03b6992a302eeef4b723d573181d71a5c4eb1f99be9b2174cdfb171e74ae7.jpeg&w=256&q=75",
     "ratings": {
       "overall": 5.0,
       "ease_of_use": 5.0,
-      "features": 4.0,
+      "features": 5.0,
       "value_for_money": 5.0,
       "customer_service": 5.0,
-      "likelihood_to_recommend": 9
+      "likelihood_to_recommend": 7
     },
-    "review_body": "We needed a fairly basic, but easy to use and understand, project management service to help keep projects moving forward.  After playing with other services, we ended up going back to Trello, which we had used briefly at the beginning of the process, and haven't looked back.",
-    "pros": "The amount of functionality available to small teams for free is tremendous. Straightforward and easy to understand for even the biggest luddite.",
-    "cons": "I'm not sure I'd even call it a con, but some of the better features (unlimited boards, especially) require a paid plan."
+    "review_body": "I've been using trello even begore Atlassian bought it. The kanban methodology is still nowadaya the BEST for my content planning. My clients are super happy with because it's super easy to use and leave feedback.",
+    "pros": "What I like the most is that I can visually see all my content plan and info (peding tasks, leave comenta feedback). Also the calendar view is super useful and easy to use Ford my clients. Plus it's free. Of course It has a paid plan, but the free versión is enough.",
+    "cons": "I don't like that you need a paid plan Ford Some basic automations or integrations. That's my only con, because it's not cheap."
   },
   {
     "title": "\"Go-to Simple Project Tracking Tool\"",
@@ -1440,24 +240,104 @@
     "cons": "For power users, Trello can be a little too simple of a tool. This can be somewhat remedied by the addition of plugins, but it doesn't cover all the bases a power user might want."
   },
   {
-    "title": "\"Trello is perfect for organizing all of your tasks\"",
-    "date": "November 26, 2025",
-    "reviewer_name": "Julia G.",
-    "reviewer_role": "Dance Teacher and Choreographer",
-    "reviewer_industry": "Recreational Facilities and Services",
-    "reviewer_usage_duration": "1-2 years",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F79d88f1ad0fb6bf8dc7320fae95cf8b6c71193c3d653bc73c287b2427227e6ee.jpeg&w=256&q=75",
+    "title": "\"My go to tool for day to day live both business and personal\"",
+    "date": "September 7, 2025",
+    "reviewer_name": "Paul T.",
+    "reviewer_role": "Managing Director",
+    "reviewer_industry": "Marketing and Advertising",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "I've used a number of project management softwares and while others are likely more appropriate for true project approaches, I find Trello absolutely game changing. I've been able to go from general to do lists, email inbox overflow, post in notes and specific project objectives into one unified place with complete organisation. It's my go to tool both professional and personal.",
+    "pros": "The best features of Trello for me are email to board (allowing you to send tasks right from your inbox). The AI catches most of the detail, preserves the original email and marks up dates. I love the views - tabular, calendar and general kanban. Extremely useful for different case uses. I love the automations, allowing me to renew weekly/monthly tasks where I can set the target dates to recur in a week, one month etc. I also love the calendar subscription mode allowing me to populate my diary/calendar with task and objectives. Support from their success team is also great.",
+    "cons": "I think it may be a bit simple, for very complicated tethered projects. I don't really deal with this type of work, in fairness. However I think it's devastating in it's simplicity and with add ons you could make it do the truly challenging stuff. I haven't found any cons for my use cases."
+  },
+  {
+    "title": "\"Simple visual boards that keep our property management tasks on track.\"",
+    "date": "April 12, 2026",
+    "reviewer_name": "Kartikeya G.",
+    "reviewer_role": "Property Management",
+    "reviewer_industry": "Real Estate",
+    "reviewer_usage_duration": "I used a free trial",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fee0eeb110b94c123ce010e5103091fdeb13c2cb1c83d928aaccde5f2fe141565.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 4.0,
+      "features": 5.0,
+      "value_for_money": 3.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 7
+    },
+    "review_body": "I use Trello at Minikaal Corporation, a small residential property management company, to keep track of leasing, maintenance, and back‑office tasks across our units. The board‑list‑card layout maps very naturally to our workflows (New Leads → Showings → Applications → Leases, or Open Ticket → In Progress → Awaiting Vendor → Completed), so the team can see status at a glance without digging through spreadsheets or email chains. Overall, Trello is an excellent fit for small property management and operations teams that need a visual, flexible system more powerful than sticky notes and email, but lighter than a full project management suite. It has become our go‑to place to see “what’s on deck” across leasing, maintenance, and admin, and I’d happily recommend it to other real estate or service businesses looking for a simple way to organize their work.",
+    "pros": "The biggest pros for us are how easy it is to set up new boards, customize lists, and add checklists, due dates, and attachments to each card. A new virtual assistant or contractor can understand our boards in minutes, and features like labels, comments, and simple Butler automations help ensure follow‑ups and recurring tasks don’t slip through the cracks. Trello also plays nicely with Google Workspace, so we can link Docs and Sheets, and use it alongside tools like Slack, Zoom, and email for day‑to‑day coordination.",
+    "cons": "On the downside, Trello’s native reporting and time‑based views are fairly light, so for portfolio‑level KPIs or more complex project tracking we still lean on spreadsheets or other tools. As boards grow large, it can also feel a bit cluttered without clear conventions for naming cards and archiving old work, which means you need some discipline in how you design and maintain your boards"
+  },
+  {
+    "title": "\"Reliable Task Tracking and Collaboration Made Easy\"",
+    "date": "January 29, 2026",
+    "reviewer_name": "Kapil S.",
+    "reviewer_role": "Project manager",
+    "reviewer_industry": "Insurance",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F2b7e6a06fe3cf433c7619e0dedee6d71eac4adfac32d31cb3fd3ea6a3304c62a.jpeg&w=256&q=75",
     "ratings": {
       "overall": 5.0,
       "ease_of_use": 5.0,
       "features": 4.0,
-      "value_for_money": 4.0,
+      "value_for_money": 3.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Overall, my experience with Trello has been very positive. It is a reliable and user-friendly tool that simplifies task tracking and improves team collaboration. The visual layout makes it easy to organize work, monitor progress, and stay aligned with deadlines. Trello works especially well for small to medium-sized projects and teams that value simplicity and flexibility. While it may have limitations for highly complex project management needs, it delivers strong value for money and consistently supports efficient, organized workflows.",
+    "pros": "Trello provides excellent value for money, especially for small to mid-sized teams looking for a reliable task and project management tool. The platform is very easy to use, with an intuitive drag-and-drop interface that requires minimal training. Task tracking is clear and visual, making it simple to monitor progress across different stages of work.\nTrello’s features, such as boards, lists, cards, due dates, and checklists, support efficient workflow management. Process automation through Butler helps reduce manual effort and improves productivity. The calendar view is useful for managing deadlines and planning work in advance. Additionally, customer support resources and documentation are helpful for resolving queries quickly. Overall, Trello is a flexible, user-friendly tool that enhances collaboration and organization.",
+    "cons": "While Trello is easy to use and visually intuitive, it can feel very limited for complex projects that require advanced reporting that has dependencies, or require detailed workflow analytics. Managing large-scale projects with multiple boards can become difficult, as there is no built-in hierarchical structure. Some advanced features and automation options are only available in paid plans, which may impact value for money for growing teams. Additionally, customization options for dashboards and reports are relatively basic compared to more robust project management tools."
+  },
+  {
+    "title": "\"Trello is your best friend for organizing your life.\"",
+    "date": "January 21, 2026",
+    "reviewer_name": "Jasmine L.",
+    "reviewer_role": "Director",
+    "reviewer_industry": "Research",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
       "customer_service": 5.0,
       "likelihood_to_recommend": 10
     },
-    "review_body": "It has been wonderful! It has made organization and task tracking so much easier and keeps everything in one place.",
-    "pros": "I love how organized it is and how clearly each section is separated. It is easy to see every piece of information I need and keep track of all of my tasks.",
-    "cons": "Sometimes I found it a bit difficult to find how to delete a comment or a card on a board. I had to search around for it for a while."
+    "review_body": "Love it love it love it!!! I use it for work, my personal life and tracking my future goals all in one place, very adaptable.",
+    "pros": "Its an immensely useful tool with a range of additional options to organise items. It's extremely easy to use and very flexible to create lists with images, text, labels, even numbers to score how important a task is. It makes it really easy to track tasks, you can tick as complete or archive them so they aren't visible but still remain. It's highly responsive, you can swiftly move tasks across lists and it performs really well with lots of information on one board. I feel as though I get a very full experience as a free customer so it's very good value for money when you can get a great insight into capabilities before looking to upgrade.",
+    "cons": "I wish I could move lists across boards and change the width of the task boxes, but I do like that it's aesthetic, just wanting to get a bigger picture of the list without scrolling up and down. Maybe zoom in on one list at a time function ?"
+  },
+  {
+    "title": "\"One of the best for basic project management.\"",
+    "date": "February 5, 2026",
+    "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "Developer",
+    "reviewer_industry": "Marketing and Advertising",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "We needed a fairly basic, but easy to use and understand, project management service to help keep projects moving forward.  After playing with other services, we ended up going back to Trello, which we had used briefly at the beginning of the process, and haven't looked back.",
+    "pros": "The amount of functionality available to small teams for free is tremendous. Straightforward and easy to understand for even the biggest luddite.",
+    "cons": "I'm not sure I'd even call it a con, but some of the better features (unlimited boards, especially) require a paid plan."
   },
   {
     "title": "\"Great software for understanding group taks\"",
@@ -1480,24 +360,224 @@
     "cons": "Although the layout is a major positive for understanding tasks, it can look overwhelming when there is many tasks on there. This makes it hard to understand what needs doing"
   },
   {
-    "title": "\"Sencillo, visual y efectivo para el seguimiento de proyectos internos\"",
-    "date": "June 12, 2026",
-    "reviewer_name": "Tsvetelina B.",
-    "reviewer_role": "Customer Success Manager",
-    "reviewer_industry": "Banking",
+    "title": "\"My Go‑To App for Organized, Collaborative Project Management\"",
+    "date": "January 16, 2026",
+    "reviewer_name": "Vicky L.",
+    "reviewer_role": "Marketing Specialist",
+    "reviewer_industry": "Construction",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "My overall experience has been great, as this is one of my main work tools and I use it daily. I have not had any major issues in my 3 years using this app.",
+    "pros": "Trello has been my favorite project management app; it keeps my projects organized and on track. My team has the easy ability to know what is going on with my projects. Collaborating within the app and communicating are simple; we can discuss valuable information and give easy feedback about projects. I also enjoy using deadlines, calendar, and analytics features. Tagging and sorting by color options are helpful to keep team boards extremely organized.",
+    "cons": "Analytics features could perform a bit better, but it's not a huge deal; most of app's features are great for daily use."
+  },
+  {
+    "title": "\"Simple, Visual, and Great for Team Collaboration\"",
+    "date": "February 26, 2026",
+    "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "App Developer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 4.0,
+      "features": 4.0,
+      "value_for_money": 3.0,
+      "customer_service": 3.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Trello is intuitive and easy to use, great for simple task tracking and collaboration, but limited for complex workflows.",
+    "pros": "I liked Trello’s intuitive drag-and-drop boards, visual task tracking, and simple collaboration that makes projects easy to manage and share.",
+    "cons": "Trello can feel limited for complex projects—reporting, dependencies, and advanced workflows often require paid plans or add-ons."
+  },
+  {
+    "title": "\"Works way better than the spreadsheets\"",
+    "date": "January 14, 2026",
+    "reviewer_name": "Shawn N.",
+    "reviewer_role": "Chief Executive Officer",
+    "reviewer_industry": "Marketing and Advertising",
     "reviewer_usage_duration": "2+ years",
     "reviewer_avatar": null,
     "ratings": {
       "overall": 5.0,
       "ease_of_use": 5.0,
       "features": 4.0,
-      "value_for_money": 5.0,
-      "customer_service": 4.0,
-      "likelihood_to_recommend": 8
+      "value_for_money": 4.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
     },
-    "review_body": "Trello es una herramienta excelente para el seguimiento de proyectos internos donde prima la simplicidad y la visibilidad rápida del estado de las iniciativas. Su curva de aprendizaje prácticamente inexistente lo hace ideal para equipos multidisciplinares. No es la solución más potente del mercado, pero para la mayoría de casos de uso del día a día cumple con creces y aporta mucho orden sin añadir complejidad operativa.",
-    "pros": "La visualización en formato Kanban hace que el seguimiento de proyectos internos sea inmediato y sin fricción. Es muy fácil de adoptar por cualquier perfil del equipo, sin necesidad de formación previa. Las tarjetas permiten centralizar toda la información relevante de cada iniciativa (descripción, adjuntos, fechas límite, responsables) en un solo lugar, lo que reduce enormemente la cantidad de información por email o chat.",
-    "cons": "Para proyectos con dependencias complejas entre tareas, Trello se queda corto frente a herramientas más avanzadas como Jira. La gestión de permisos por tablero puede resultar algo rígida en organizaciones con muchos equipos, y las funcionalidades de reporting nativo son bastante básicas, lo que obliga a apoyarse en integraciones externas para obtener métricas útiles."
+    "review_body": "Had these monstrous Excel sheets that were a disaster but this does inventory data and doesn’t blow up. Team public don’t know what they’re doing I suppose. So happy I no longer now have to stare at Google docs all day because database stuff actually connects.",
+    "pros": "Guess tagging is working enough for me to call out my team (without getting up from my desk). The boards allow you to do things with out coding which is nice because I don’t have time for coding. Got some automations that are still working and was surprised email to task thing actually landed where it was supposed to. I mainly Use Trello browser and haven’t crashed computer today. Flicker light in cubicle giving me headache now.",
+    "cons": "Mobile app is utter disaster and can’t locate copy/paste button when at the deli. Slow. Exporting files has been like pulling teeth with the wrong formats and I hate how pricing all changed for admin seats without anyone saying anything to us."
+  },
+  {
+    "title": "\"Intuitive and flexible task management platform\"",
+    "date": "December 21, 2025",
+    "reviewer_name": "Rene M.",
+    "reviewer_role": "Solution Architect",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Overall, my experience with Trello has been extremely positive. As an IT manager overseeing distributed teams, Trello has helped us maintain clear communication and track progress effectively on offshore projects. The ease of use and quick adoption by team members have made it a staple in our daily workflow, and it continues to support our agile, collaborative approach.",
+    "pros": "Trello is a versatile and intuitive tool for managing tasks and projects. Its card-based interface and boards make it easy to visualize workflows and collaborate with team members across departments and locations. The flexibility of creating lists, labels, and checklists allows for customizing processes to suit any team's needs, and integrations with other tools enhance productivity.",
+    "cons": "Some advanced project management features such as detailed reporting or resource management are limited compared to more comprehensive platforms. It can require additional power-ups or integrations to achieve certain functionalities, which might increase complexity or cost. The simplicity of Trello's structure may not fit complex enterprise workflows out-of-the-box."
+  },
+  {
+    "title": "\"Task Superhero\"",
+    "date": "April 3, 2026",
+    "reviewer_name": "Haley S.",
+    "reviewer_role": "HR Manager",
+    "reviewer_industry": "Food & Beverages",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb79e25104b5f736fd57b6ed1a488b7fbdb01c60616c9e7f3081da8a2ffb0eb6d.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 4.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Our entire executive team uses Trello and it has created alignment, clarification, and assurance that tasks and projects are not falling through the cracks. The reminders and the ability to tag other Trello users who have linked boards are excellent for ensuring that all parties know the tasks that need to be completed and who is responsible for what portion and the deadline.",
+    "pros": "Trello's automated features help easily track high priority tasks, loop in team members, and track completion of large projects.",
+    "cons": "It took some time to really understand all of the features of Trello. The system does have helpful tips on a list so that you can easily reference how to use different tools and automations, which is helpful. It is beginner friendly for the basics, but the more advanced features had a learning curve."
+  },
+  {
+    "title": "\"Need to manage a project? Use trello at every step \"",
+    "date": "December 26, 2025",
+    "reviewer_name": "Lisa P.",
+    "reviewer_role": "Content marketing coordinator",
+    "reviewer_industry": "Retail",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fe05de9402dc038b5bb71ed71b26f73303ab65661e6d995e23f6bbc090e1526f8.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 1.0,
+      "customer_service": 1.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Absolutely necessary to use project management tools if you're working with multiple teams, across different time zones. Helpful to navigate a project from start to finish (color coding was helpful for ownership)!",
+    "pros": "We used it as a collaboration tool for a website build. It was a great visual representation of where each stage of the project was developing and what was stuck, or what needed review or auditing.",
+    "cons": "A bit hard to know who owned each step of the task. Hard to access the search feature if you were looking for a keyword (or if you didn't recall if it was considered a task or a project)"
+  },
+  {
+    "title": "\"Highly Versatile and Intuitive Tool for Visual Project Management\"",
+    "date": "April 23, 2026",
+    "reviewer_name": "Greg W.",
+    "reviewer_role": "Senior Learning Technologist",
+    "reviewer_industry": "Hospitality",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fc4071abf0e0ed0d693c981baa5486d03960d48d736c9af81d1747ec75bd9d65c.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Trello is a reliable and versatile tool that excels at making work visible. It has been a staple for managing everything from daily administrative tasks to large-scale initiatives. While it lacks some of the deep analytical power of enterprise-grade software, its ease of use and low barrier to entry make it an excellent choice for collaborative teams.",
+    "pros": "The visual nature of the Kanban boards provides immediate clarity on project status. It is incredibly intuitive for onboarding new team members, and the flexibility of the cards allows for a high degree of customization—especially when using Power-Ups to bridge the gap between simple task tracking and more complex project management.",
+    "cons": "As boards grow in complexity, they can become cluttered and difficult to navigate. The native reporting and high-level dashboard features are somewhat limited compared to more robust project management tools, often requiring third-party integrations or manual workarounds to get a truly 'birds-eye' view of multiple workstreams."
+  },
+  {
+    "title": "",
+    "date": null,
+    "reviewer_name": "",
+    "reviewer_role": null,
+    "reviewer_industry": null,
+    "reviewer_usage_duration": null,
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": null,
+      "ease_of_use": null,
+      "features": null,
+      "value_for_money": null,
+      "customer_service": null,
+      "likelihood_to_recommend": null
+    },
+    "review_body": null,
+    "pros": null,
+    "cons": null
+  },
+  {
+    "title": "\"Trello Makes Network Task Management More Structured\"",
+    "date": "July 29, 2026",
+    "reviewer_name": "Emilia W.",
+    "reviewer_role": "Network Support Coordinator",
+    "reviewer_industry": "Facilities Services",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "My overall experience with Trello has been positive because it helps simplify task coordination and improves visibility across technical teams. It provides a straightforward way to manage priorities, track responsibilities, and ensure important network activities are not overlooked. While it is not a replacement for specialized IT service management platforms, Trello is a practical solution for improving organization, communication, and productivity in day-to-day support operations.",
+    "pros": "The biggest advantage of Trello is how easily it brings visibility to ongoing work. I can quickly see which tasks are pending, in progress, or completed without searching through multiple conversations or emails. The card-based system works well for tracking network incidents, change requests, and routine support activities, while comments and attachments help maintain important technical details in one place.",
+    "cons": "Trello works well for basic and medium-sized workflows, but managing a high volume of support tasks can become challenging over time. It would be helpful to have more advanced reporting, ticket management capabilities, and deeper analytics features for teams handling larger IT environments."
+  },
+  {
+    "title": "\"TRELLO Review\"",
+    "date": "July 31, 2026",
+    "reviewer_name": "Andrew B.",
+    "reviewer_role": "Managing Partner",
+    "reviewer_industry": "Marketing and Advertising",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 3.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Overall, Trello act as an intermediate among the team for creating such a user friendly environment where everyone can grow and prosper in their own area of activities. The usage of Trello is too marvelous, it makes the work easier only with the help of email address which in return does not require or involve the multiple emails chains, files, etc. The trello support center is great as well the user interface is also quite nice.",
+    "pros": "Trello is the best tool used for retaining the things in a well defined manner which enables to organize everything at a single peep. It can also be used for customization, and the use of the labels is also more helpful and interesting to differentiate work.",
+    "cons": "Trello has no ability to create gantt charts which is limiting for some users which can prefer it to have in projects. Also the software helps in maintaining a communication between the team and the stakeholders which is not likely by all of the users."
+  },
+  {
+    "title": "\"Simple, Organized, and Great for Team Collaboration”\"",
+    "date": "May 15, 2026",
+    "reviewer_name": "Kayla H.",
+    "reviewer_role": "Consultant",
+    "reviewer_industry": "Civic & Social Organization",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F4d5f9907e9fca7287483de20ffa5199d1c2f1c5c7e12de267b7a6ffbf83e8ce4.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 7
+    },
+    "review_body": "Overall, my experience with Trello has been very positive. It’s a reliable and flexible platform that helps keep projects, deadlines, and daily tasks organized without requiring a lot of technical knowledge. The interface is clean, easy to navigate, and simple to learn, which makes onboarding new users quick and stress-free. Trello has been especially helpful for improving organization, collaboration, and workflow management while keeping everything visually accessible.",
+    "pros": "Trello is extremely user-friendly and makes organizing tasks, projects, and workflows simple without feeling overwhelming. I really like the drag-and-drop kanban style boards because they make it easy to visually track progress and keep everything organized in one place. The ability to add checklists, due dates, comments, attachments, and team collaboration tools helps keep communication clear and projects moving smoothly. It’s also great for both personal organization and team management.",
+    "cons": "Some of the more advanced features and automations are limited unless you upgrade to a paid plan. While Trello works great for basic and moderate project management, larger or more complex projects can sometimes feel too simplified compared to other platforms with more advanced reporting and tracking options."
   },
   {
     "title": "\"Simple and effective project management tool\"",
@@ -1540,26 +620,6 @@
     "cons": "It felt like it was unnecessarily complex in ways where it was supposed to actually be easier for you, which makes the whole software feel cheap and confusing. I can tell the people behind the software intended for this to be a game changing, life changing software, especially for people like myself who are often disorganized and need something like this software to sort everything out. But it feels like they might have been over ambitious in wanting the software to do and be everything because instead of being really good at just one thing it is not really not that good at all at doing anything."
   },
   {
-    "title": "\"Simple, Organized, and Great for Team Collaboration”\"",
-    "date": "May 15, 2026",
-    "reviewer_name": "Kayla H.",
-    "reviewer_role": "Consultant",
-    "reviewer_industry": "Civic & Social Organization",
-    "reviewer_usage_duration": "6-12 months",
-    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F4d5f9907e9fca7287483de20ffa5199d1c2f1c5c7e12de267b7a6ffbf83e8ce4.jpeg&w=256&q=75",
-    "ratings": {
-      "overall": 5.0,
-      "ease_of_use": 5.0,
-      "features": 5.0,
-      "value_for_money": 5.0,
-      "customer_service": 5.0,
-      "likelihood_to_recommend": 7
-    },
-    "review_body": "Overall, my experience with Trello has been very positive. It’s a reliable and flexible platform that helps keep projects, deadlines, and daily tasks organized without requiring a lot of technical knowledge. The interface is clean, easy to navigate, and simple to learn, which makes onboarding new users quick and stress-free. Trello has been especially helpful for improving organization, collaboration, and workflow management while keeping everything visually accessible.",
-    "pros": "Trello is extremely user-friendly and makes organizing tasks, projects, and workflows simple without feeling overwhelming. I really like the drag-and-drop kanban style boards because they make it easy to visually track progress and keep everything organized in one place. The ability to add checklists, due dates, comments, attachments, and team collaboration tools helps keep communication clear and projects moving smoothly. It’s also great for both personal organization and team management.",
-    "cons": "Some of the more advanced features and automations are limited unless you upgrade to a paid plan. While Trello works great for basic and moderate project management, larger or more complex projects can sometimes feel too simplified compared to other platforms with more advanced reporting and tracking options."
-  },
-  {
     "title": "\"Terrific Trello\"",
     "date": "March 20, 2026",
     "reviewer_name": "Mai M.",
@@ -1580,6 +640,386 @@
     "cons": "So far, NO CONS! I'm truly loving this platform! Loving the use of the Boards the Lists and the Cards features."
   },
   {
+    "title": "\"Organizzare e ricordare in un unica piattaforma\"",
+    "date": "March 1, 2026",
+    "reviewer_name": "Kristian A.",
+    "reviewer_role": "Consulente esterno",
+    "reviewer_industry": "Construction",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fe8374a664fe331e6ecb61475f3eae32ff8922625a1bb373da73e93f5c4b44488.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 3.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Il capo ufficio lo utilizza per ricordare a tutti noi collaboratori diversi appuntamenti e tenere una memo e storicità di chiamate e comunicazioni con i clienti",
+    "pros": "Una bella piattaforma per sincronizzare gli appuntamenti e tenere i reminder a schermo. Avrei migliorato alcuni aspetti grafici e semplificato alcune disposizioni rendendolo un pò più semplice.",
+    "cons": "All inizio era un pò complesso, ci sono voluti 4 mesi per utilizzarlo al massimo delle funzionalità. Un buon prodotto per le aziende con più di 4 dipendenti"
+  },
+  {
+    "title": "\"A Simple Yet Powerful Tool for Managing Software Development\"",
+    "date": "August 2, 2026",
+    "reviewer_name": "Vincenza F.",
+    "reviewer_role": "Software Engineer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "My overall experience with Trello has been positive because it simplifies project organization and improves communication within development teams. It helps create a structured workflow where engineers can track priorities, collaborate with teammates, and stay aligned with project goals. While it may not replace specialized engineering management platforms, Trello remains a reliable tool for managing everyday software development activities and improving team productivity.",
+    "pros": "The best part of Trello is how easily it helps organize development work into clear stages. It provides a quick overview of pending tasks, active development items, code reviews, and completed work, which makes prioritization much easier. The ability to add descriptions, attachments, checklists, and comments helps keep technical discussions and project details connected to the relevant tasks.",
+    "cons": "Trello is excellent for lightweight project management, but it can become less effective when managing large engineering projects with complex dependencies. More advanced features around reporting, workload management, and technical project tracking would make it more suitable for larger software teams."
+  },
+  {
+    "title": "\"Trello: easy to use & great for collaboration\"",
+    "date": "August 8, 2026",
+    "reviewer_name": "Ann Hampton S.",
+    "reviewer_role": "Proposal Content Manager",
+    "reviewer_industry": "Computer Software",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F1020d527bceed57fa67092b4fe4d3dd945b2bcbd7320ce7af3f2afc5a6a7f6c9.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Love using Trello for teams. It's great to have the satisfaction of moving Trello cards to \"complete\" and have dates associated as well as team members in the loop.",
+    "pros": "Trello is easy to use and great for collaboration. Great for mid-level complexity projects. Microsoft project, for example, is overly granular.",
+    "cons": "Teams shirk and shrink from learning new software. And only certain features are free. I don't always get a chance to decide which software to use for project management, but I've used it in several roles."
+  },
+  {
+    "title": "\"Mortgage Broker\"",
+    "date": "April 21, 2026",
+    "reviewer_name": "Addy B.",
+    "reviewer_role": "Mortgage Broker",
+    "reviewer_industry": "Banking",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F882802d930259eb7707e57b9afd065dac2f2344b9128fcbc2b80f168d061041d.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 7
+    },
+    "review_body": "It's been great thus far.  No complaints.  I have not had any major issues that I cannot fix or chat with AI/service.",
+    "pros": "Trello is very user friendly.  It keeps me organized.  I like how I can share my boards easily, but if I don't want to, I don't have to.  I can integrate w/ many other programs that I use regularly.",
+    "cons": "Not everyone uses it.  It is pricey compared to others for what it offers.  Some find other solutions more affordable."
+  },
+  {
+    "title": "\"Great Tool for Staying Organized and On Track\"",
+    "date": "December 26, 2025",
+    "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "Senior software engineer",
+    "reviewer_industry": "Financial Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "My overall experience with Trello has been great. It keeps our team organized, reduces back-and-forth messages, and makes tracking work incredibly clear. The drag-and-drop boards, checklists, and integrations make it easy to manage projects without over-complicating things.",
+    "pros": "Easy member assign to the specific card and can move the card based on the status of card so that it can be tracked easily. We get notified if card move to other status. Effort estimation also can be done on the card to track the effort given for each card. Cost is low and good customer support,",
+    "cons": "Notifications can be overwhelming and sometimes easy to miss at the same time. It’s not always clear what actually needs attention.\nTrello is great for tasks, but reporting and progress tracking are weak. It’s hard to see big-picture status across multiple boards."
+  },
+  {
+    "title": "\"An Easy Way to Stay on Top of Everyday Tasks\"",
+    "date": "July 19, 2026",
+    "reviewer_name": "Ankith T.",
+    "reviewer_role": "Software Developer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F7b923bddfd6c7ca509f01228c0ec05da65cd5a4bcf784542457b5f85a1170ba2.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Overall, Trello has been a reliable tool for keeping track of daily work. Before using it, I often relied on sticky notes and spreadsheets, which made it easy to forget tasks. Now everything is in one place, deadlines are easier to manage, and I can quickly see what's finished and what's still pending. It has made staying organized much easier.",
+    "pros": "The best thing about Trello is how simple it is to use. I can create tasks, move them between different stages, and know exactly what I'm supposed to work on next. The boards are easy to understand, and I don't have to spend time figuring out where things are. It keeps my work organized without feeling complicated.",
+    "cons": "Trello works really well for smaller projects, but once a project gets bigger, the boards can become crowded. I also wish there were better reporting tools and more automation features in the free version. Sometimes finding older cards takes longer than I'd like."
+  },
+  {
+    "title": "\"Simple, Visual, and Effective\"",
+    "date": "February 21, 2026",
+    "reviewer_name": "Yann S.",
+    "reviewer_role": "Psychotherapist",
+    "reviewer_industry": "Health, Wellness and Fitness",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ff30275bd4b879de0cb2d44fca8b18b7991ff09eab3ee607f4249e41e28857e77.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 2.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Trello remains excellent for organising work in a very simple and visual way. However, for larger teams it might be too basic.",
+    "pros": "Trello stands out for its easy to use. The card and board system is intuitive and makes task tracking visually clear enough. About the features it covers the essential well such as: task lists, due dates, labels and file attachments are easy to manage. Process automation through Butler is useful addition for all repetitive actions like moving cards or sending some reminders. Value for money is great for small team and individuals. The performance and speed are smooth",
+    "cons": "The customer support is sufficient however mostly self service. Get ready to rely heavily on documentation."
+  },
+  {
+    "title": "\"Trello works very good\"",
+    "date": "July 26, 2026",
+    "reviewer_name": "Byron L.",
+    "reviewer_role": "Software Developer",
+    "reviewer_industry": "Computer Software",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "There are far too many steps necessary to give someone the ability to access permissions. Also, there are numerous oddities within the various menus. As a result of the features described above, we will likely miss fewer deadline due to dependencies being visible at all times.",
+    "pros": "It is a relief the Trello timeline view didn't completely freeze when I uploaded our whole project portfolio.",
+    "cons": "The third problem with this tool was how much work was required to make changes to the colors used in the critical path. Not only did making these changes cause strange problems – but also caused confusion for all employees trying to utilize the tools provided by this system. Lastly, as an avid Mac user, I have found support for Mac users has been poor."
+  },
+  {
+    "title": "\"A Flexible Workspace for Managing Product Design Workflows\"",
+    "date": "July 31, 2026",
+    "reviewer_name": "Braden H.",
+    "reviewer_role": "Senior Product Designer",
+    "reviewer_industry": "Design",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "It helps bring structure to creative processes by making tasks, feedback, and project progress more visible. As a product designer, having a clear overview of priorities and deadlines helps improve focus and collaboration with cross-functional teams. While it may not replace dedicated design management platforms, Trello remains an efficient and flexible tool for managing product design workflows and keeping projects moving forward.",
+    "pros": "The biggest strength of Trello is how effectively it helps organize the entire design process from idea generation to final delivery. It provides a clear view of design tasks, research activities, user feedback, revisions, and priorities. The ability to customize boards, add references, attach files, and collaborate with team members makes it easier to maintain a smooth workflow across different stages of product design.",
+    "cons": "Trello can feel limited when managing complex projects that require detailed documentation, advanced design analytics, or deeper project reporting. It also requires additional integrations for some specialized design workflows and advanced collaboration needs."
+  },
+  {
+    "title": "\"The Perfect Balance of Visual Simplicity & Automation Power r\"",
+    "date": "April 28, 2026",
+    "reviewer_name": "Kira H.",
+    "reviewer_role": "Administrator",
+    "reviewer_industry": "Marketing and Advertising",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 4.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "My overall experience with Trello has been incredibly positive, primarily because it strikes a rare balance between radical simplicity and backend power. I use it as a central 'command center' for my projects. While it doesn't have the rigid structure of more traditional project management software,that flexibility is actually its greatest asset. By leaning heavily into the But!er automation, I've managed to cut my administrative time in half. It's reliable, stable platform that turns a messy brainstorm into a structured,actionable plan in minutes. Its the first tool I open every morning to ground myself in what actually needs to get done.",
+    "pros": "The Butler Automation is a game changer! I've set up rules so that when i move a card to a specific column, it automatically tags the right team member and sets a due date for two days out. I like having a virtual assistant that handles all the \"Busy work\" in the background, which allows me to focus on the actual tasks instead of just managing them.",
+    "cons": "The automation is top-- tier, Trello can feel a bit limited when a project requires deep hierarchies or complex task dependencies.Because everything is card-based, its hard to visualize how one delayed tasks impacts the rest of a massive timeline with out adding extra Power -Ups. I love the simplicity,but for high- level engineering or construction- style projects, i wish there were more native 'parent-child' task relationships built-in without needing external plugins."
+  },
+  {
+    "title": "\"Simple and intuitive, but outgrows itself quickly\"",
+    "date": "July 31, 2026",
+    "reviewer_name": "Léo L.",
+    "reviewer_role": "Manager",
+    "reviewer_industry": "Management Consulting",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 2.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Overall, Trello is a lightweight, intuitive tool that's excellent for simple task management and small-to-medium team collaboration. The visual board format is easy to adopt and requires almost no onboarding, which makes it a great starting point for teams that don't want a steep learning curve. However, as projects grow in complexity.",
+    "pros": "The visual, drag-and-drop board layout makes it easy to see project status at a glance without digging through menus. It has a low learning curve, new team members can pick it up in minutes and the free tier is generous enough for small teams or personal projects",
+    "cons": "Trello works great for simple workflows but starts to strain as projects get more complex. There's no built-in way to see dependencies between tasks, so multi-step projects with blockers get hard to track. Reporting and analytics are weak or nonexistent without a paid Power-Up or third-party integration. Boards can also get cluttered and hard to navigate once a project has dozens of cards, and there's no true subtask/checklist hierarchy."
+  },
+  {
+    "title": "\"Keeps our team moving without overcomplicating things\"",
+    "date": "September 12, 2025",
+    "reviewer_name": "Carl F.",
+    "reviewer_role": "Owner",
+    "reviewer_industry": "Construction",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "We use Trello every day to track jobs, bids, and follow-ups. It’s simple enough that nobody resists using it, but flexible enough that we’ve built boards for estimating, project management, and sales. For a growing shop like ours, that balance of structure + ease has been critical.",
+    "pros": "New hires understand it within minutes, and the visual layout makes it easy to see bottlenecks at a glance. It also plays nicely with Gmail, n8n, and QuickBooks, so we’ve been able to automate a lot of repetitive steps without needing heavy IT support.",
+    "cons": "Reporting feels limited unless you start adding Power-Ups, and once you’re looking for more advanced automation or dashboards, it can feel a little basic."
+  },
+  {
+    "title": "\"Great for project management\"",
+    "date": "May 25, 2026",
+    "reviewer_name": "Gabby W.",
+    "reviewer_role": "Founder",
+    "reviewer_industry": "E-Learning",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fbce0e8f82b12743306493a5941fed9b4e8a904fdfb925a0ba086ed7698bc0c05.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": null,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "I’ve had a very positive experience with Trello overall. It’s a simple and effective project management tool that makes it easy to organize tasks, content, and workflows visually. I especially like the drag-and-drop board system because it helps keep projects clear and easy to manage without feeling overwhelming. It works well for both personal organization and team collaboration.",
+    "pros": "Pros:\n\nVery easy to learn and use, even for beginners\nClean visual layout with boards, lists, and cards\nGreat for task management, content planning, and team collaboration\nHelpful integrations and automation features through Power-Ups\nFlexible enough for both simple projects and more detailed workflows",
+    "cons": "Cons:\n\nCan feel limited for larger or more complex project management needs\nSome useful features are locked behind paid plans\nManaging many boards at once can become cluttered\nReporting and analytics tools are more basic than some competitors"
+  },
+  {
+    "title": "\"Trello is a handy software and great tool to manage progress and track tasks\"",
+    "date": "September 3, 2025",
+    "reviewer_name": "Wilberth A.",
+    "reviewer_role": "Operation manager",
+    "reviewer_industry": "Computer Software",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Trello is a handy tool for managing teams with multiple members, though the free version works best for small to medium projects. I’ve used it extensively for IT projects and find it excellent for tracking task progress. It’s also great for client collaboration: you can assign tasks to both your team and customers and control visibility as needed.",
+    "pros": "Trello is very user-friendly, allowing you to manage multiple team members and gain a clear overview of your project. It also helps track customer tasks and facilitates collaboration. One of its key features is team-collaboration software, which keeps your team updated effortlessly.",
+    "cons": "n my opinion, the main drawbacks are the limited number of projects you can track, difficulty switching between projects, and potential storage constraints."
+  },
+  {
+    "title": "\"Useful & easy to use low-cost tool for managing our marketing comms/content calendar\"",
+    "date": "March 18, 2026",
+    "reviewer_name": "Tom L.",
+    "reviewer_role": "Marketing Director",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F76ceef97af0fdb8d01c5bcc52c46ae3b19297910af0c4c57e891923a6751a7de.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Useful low-cost tool for managing our marketing comms/content calendar - easy to use and update as well as share with relevant stakeholders",
+    "pros": "Useful collaboration tool for the marketing team to manage our content and comms calendar - the calendar power up in particular is easy to manage within the team, and share across the wider business to give visibility on our activity",
+    "cons": "The UI can sometimes be a little obtuse and settings which were once saved become undone. Quite random and not a major issue but can be frustrating nonetheless."
+  },
+  {
+    "title": "\"Easy to use customizable communication \"",
+    "date": "December 31, 2025",
+    "reviewer_name": "Denise C.",
+    "reviewer_role": "Senior HR Manager",
+    "reviewer_industry": "Construction",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Great experience. Easy to use. No training needed. Allows for easy collaboration. Can set up preferred notifications.",
+    "pros": "Very easy to use. Clear concise displays. Customizable. Can setup notifications for new comments, content, etc.",
+    "cons": "Wish there were a few more options for customizing theme, colors, etc. Otherwise overall a good easy to use platform."
+  },
+  {
+    "title": "\"Why the change?\"",
+    "date": "October 27, 2025",
+    "reviewer_name": "Verified Reviewer",
+    "reviewer_role": "Designer",
+    "reviewer_industry": "Apparel & Fashion",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": null,
+      "customer_service": null,
+      "likelihood_to_recommend": 5
+    },
+    "review_body": "I used to love it and it supported and made my and my colleagues life so much easier but since the last update we all use it less",
+    "pros": "It’s so visual and simple. Moving cards feels just like sticky notes on a wall. It’s perfect for seeing the status of a design project fast, and it’s easy for the whole team to use.",
+    "cons": "Reporting and viewing timelines is limited on the free plan and the last update made me completely stop using it. I cannot see the list of all my projects at once, terrible."
+  },
+  {
+    "title": "\"Excelente para gestionar proyectos\"",
+    "date": "May 26, 2026",
+    "reviewer_name": "Luis Antonio S.",
+    "reviewer_role": "Ingenieria de sistemas e informatica",
+    "reviewer_industry": "Construction",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F68cb557603ac1845db3454fee29dc707403c1792ef2fdc6d7ad8c277d1ad34d7.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "He podido trabajar en proyectos individuales como también en proyectos con equipos, la cual Trello me ayudó a gestionarlo y mantener una buena organización con el equipo.",
+    "pros": "Poder organizar proyectos y compartilos con el equipo de trabajo, trazar objetivos con fechas estimadas.",
+    "cons": "Hay opciones muy interesantes pero cuentan con un pago de por medio y que en la versión básica no se pueda exportar un excel para guarar los trabajos relaizados"
+  },
+  {
+    "title": "\"Organizing Work Made Easy\"",
+    "date": "July 1, 2026",
+    "reviewer_name": "Rustam A.",
+    "reviewer_role": "Software developer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb1d318164ffbf224ed0634e764eb8e94d2fd009d72adc97a04b3b01bd1de7802.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Overall, my experience with Trello has been very positive. It is a clean, user-friendly tool that makes task and project management simple and efficient. It works perfectly for small to medium-sized teams and personal productivity. However, for highly complex or enterprise-level project management, it may require additional tools or upgrades. Still, it remains one of the best lightweight project management tools available.",
+    "pros": "Trello is extremely easy to use and very intuitive, even for beginners. The drag-and-drop interface makes task management smooth and visually clear. I like how quickly I can organise projects using boards, lists, and cards without needing any technical setup. It helps in improving productivity by giving a clear overview of tasks and their progress.",
+    "cons": "While Trello is great for simple workflows, it becomes limited when handling complex project management needs. Advanced reporting, dependency tracking, and deep analytics are missing in the free version. It can also feel less structured for large enterprise-level projects compared to other tools like Jira."
+  },
+  {
     "title": "",
     "date": null,
     "reviewer_name": "",
@@ -1598,6 +1038,506 @@
     "review_body": null,
     "pros": null,
     "cons": null
+  },
+  {
+    "title": "\"Highly visual, easy to use, and effective task management software.\"",
+    "date": "July 19, 2026",
+    "reviewer_name": "Shyam Kishor P.",
+    "reviewer_role": "Developer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F9f31aa410003a94e2d5e76c2037168cf09a9f8ed1d5e52b70b9baa739f2aec63.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Trello provides a highly straightforward and effective way to manage everyday tasks and collaborate with a team. Its visual Kanban board layout makes it easy to stay organized, offering great overall value despite some limitations in native data reporting.",
+    "pros": "The platform offers incredible ease of use, making daily task tracking highly visual and intuitive. Setting up process automation with Butler rules saves a lot of time, and the core features provide excellent value for money for cross-functional teams.",
+    "cons": "The built-in reporting options are fairly limited unless you rely on external Power-Ups. When projects grow massive, the boards can start to feel cluttered, and customer support response times can be slow on the standard tier."
+  },
+  {
+    "title": "\"Trello is Built for Collaboration\"",
+    "date": "April 30, 2026",
+    "reviewer_name": "Kaleb V.",
+    "reviewer_role": "Clinic Director",
+    "reviewer_industry": "Hospital & Health Care",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F4f2c3aaba208c09bd00075c4423a46c95ecf8e11e52bd671fe5a7a7c4ef3262c.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 3.0,
+      "customer_service": 2.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "I've used Trello for so many projects and will continue to coordinate with team members across distances and time zones. Intuitive interface, collaborative design, this is an amazing way to keep everyone moving in the right direction.",
+    "pros": "Trello is an incredibly intuitive, versatile, multi-functional, and collaborative way for me to coordinate projects across multiple platforms. I manage multiple teams across different industries, some of which don't consider themselves \"tech savvy\". They've had no trouble adopting this system to update everyone in live time, as easily as posting a sticky note on a whiteboard. Storing documents, images, project details in a centralized place makes it easy to share critical project infrastructure.",
+    "cons": "I was logged out frequently, and sometimes my email account was not recoverable. Since it is paired under the \"Atlassian\" brands, their customer service was unable to resolve my issue and I had to recreate accounts, boards, and projects."
+  },
+  {
+    "title": "\"A Lightweight, High-Performance Solution for Streamlined Workflows\"",
+    "date": "May 7, 2026",
+    "reviewer_name": "Diego G.",
+    "reviewer_role": "Project Manager",
+    "reviewer_industry": "Retail",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F42ab650add55c113898dca30839b2f96097f3c72402a167a815f213c821baeea.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "My overall experience with Trello has been defined by agility and visual clarity. It is an exceptional tool for maintaining high team velocity without the burden of a steep learning curve. The UI/UX is arguably the most user-friendly in the space, which made our Onboarding process seamless and allowed the team to focus on execution rather than tool management.\n\nWhile it lacks some of the deep analytical depth of more complex platforms, its Performance and reliable Integrations provide a solid foundation for tracking linear rollout phases. We have found the AI / Intelligence features (Butler) to be a subtle but effective way to handle repetitive administrative tasks. From a business perspective, the Pricing / ROI is excellent for projects that require a lightweight, high-speed coordination engine rather than a heavy data-processing machine. It remains my go-to solution for maintaining transparency and simplicity in fast-moving technical environments.",
+    "pros": "What I like best about Trello is its exceptional UI/UX, which remains one of the most intuitive in the market. This simplicity drastically reduces the time spent on Onboarding, allowing new team members to become productive almost instantly.\n\nFrom a technical standpoint, the Performance is consistently smooth, and the platform’s Integrations—via Power-Ups—allow us to connect our essential tools without cluttering the workspace. We have also started to see the benefits of their AI / Intelligence features (Butler), which help automate repetitive tasks and suggest smarter workflows.\n\nOverall, Trello offers a very high ROI due to its competitive Pricing model; it provides exactly the right amount of structure for agile coordination without the administrative complexity of larger platforms, making it an incredibly cost-effective solution for our team's daily operations.",
+    "cons": "What I dislike about Trello is its limited scalability for highly complex projects. While the UI/UX is great for simple tasks, the platform struggles when you need to manage deep hierarchies or cross-board dependencies. The AI / Intelligence features, though helpful, feel less integrated compared to more robust competitors.\n\nFurthermore, while the Pricing is attractive for small teams, the ROI can diminish as you scale, because you often need multiple paid Integrations (Power-Ups) to achieve basic reporting or Gantt functionality. I also find that the Performance can lag when a board becomes heavily populated with cards and attachments, and the Support for lower-tier plans can be slower than what I’ve experienced elsewhere. For a high-stakes rollout, the lack of advanced native analytical features is its biggest drawback."
+  },
+  {
+    "title": "\"Excellent for visual project tracking, but lacks deep analytical reporting\"",
+    "date": "June 16, 2026",
+    "reviewer_name": "Mantesh C.",
+    "reviewer_role": "Assistant Digital Marketing Manager",
+    "reviewer_industry": "Mechanical or Industrial Engineering",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "The overall experiance about the trello is amazing. Trello is a highly reliable and best tool for managing daily workflows, task management, and keeping teams aligned. It excels at breaking down multi-step processes into clear, actionable visual stages.",
+    "pros": "As per my personal experience, the User Interface and the Kanban-style layout are incredibly intuitive. It takes a fraction of a second to onboard a beginner team member because everything operates via a simple \"drag-and-drop\" interface. I love how flexible the cards are-you can dump links, attachments, checklists, and assign deadlines all in one place.",
+    "cons": "I used lots of time trello in my day-to-day activities. The least like tings is once a project expands beyond a certain specific size, the boards can become cluttered and overwhelming to look at. The built-in facilities, like reporting and automations (Butler) are fine for basic tasks, but if you want to look at high-level portfolio views, resource allocation, or complex dependency mapping, Trello starts to feel a bit too lightweight."
+  },
+  {
+    "title": "\"Un outil intuitif et complet pour la gestion de projet\"",
+    "date": "May 4, 2026",
+    "reviewer_name": "Julien B.",
+    "reviewer_role": "Responsable social media",
+    "reviewer_industry": "Transportation/Trucking/Railroad",
+    "reviewer_usage_duration": "6-12 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F3cf0724d6b85169db79ba7a6d3dd67a02396fc34c8384754130457498a6ac514.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Nous utilisons actuellement la version gratuite avec une équipe de 6 personnes. Nous avons donc un tableau commun pour nos objectifs collectifs, mais aussi des tableaux individuels pour avancer sur nos propres tâches. Honnêtement, c'est vraiment un outil intuitif pour tout le monde.",
+    "pros": "Trello à le mérite d'être extrêmement complet, même en version gratuite. Il contient à peu près tous les outils qui sont utiles à la gestion de projet et on notera que l'interface a vraiment été pensée pour nous faciliter la vie. C'est clair, rapide et efficace.",
+    "cons": "La structure reste parfois un peu rigide dans sa version gratuite. Ils manquent certaines options qui permettraient vraiment d'aller plus loin dans l'attribution des tâches. J'ai aussi l'impression que les images insérées dans les cartes sont compressées, ce qui, en fonction des besoins, peut-être problématique"
+  },
+  {
+    "title": "\"Great Project Management Tool\"",
+    "date": "July 9, 2026",
+    "reviewer_name": "Caroline N.",
+    "reviewer_role": "Business analyst",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "In my experience, it is very user-friendly, and you can easily start working with Trello. If you know how to handle your integrations and automation needs, it can be very helpful to organize and manage your projects within your team simultaneously.",
+    "pros": "The possibility of adding Powerful integrations to other tools, such as text editors or file storage, and creating automation for free (even if limited), brings so much value to Trello, because we can keep our work flowing even if it gets bigger and more complex.",
+    "cons": "When I need to export data from some cards, it doesn't download the comments or the files attached to the project, such as PNGs or tables, which forces the user to start again."
+  },
+  {
+    "title": "\"Trabajando de forma visual y ordenada\"",
+    "date": "April 5, 2026",
+    "reviewer_name": "Magno Gabriel H.",
+    "reviewer_role": "Asistente de producción",
+    "reviewer_industry": "Food Production",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F3fb6b62816d9045aa67a7cb22fc6be1d1a3f99b7e8d3d17cae5008a205d59a05.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Utilizo Trello de manera diaria para organizar tareas de mi ntorno laboral y académico de forma práctica. Me parace una herramienta fácil de implementar.",
+    "pros": "Trello oferece una gran facilidad para organizar tareas de manera visual. Facilita el seguimiento de proyectos mediante el uso de tableros, listas y targetas. Además, es muy útil para priorizar tareas, asignar responsabilidades y mantener todo ordenado en un solo lugar.",
+    "cons": "Suele limitarse cuando se gestiona proyectos más grandes y complejos, ya que no posee funcionalidades más avanzadas que que solo es manejable con la versión de pago."
+  },
+  {
+    "title": "\"Ottimo programma per gestione di piccoli progetti\"",
+    "date": "April 20, 2026",
+    "reviewer_name": "Samuele R.",
+    "reviewer_role": "CEO e CTO",
+    "reviewer_industry": "Computer Software",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F20d9fad4f2aa035136d1fb4e6554a2800b299151f20201d6f4cbf4fca9270adf.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 3.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 7
+    },
+    "review_body": "Con Trello ho sviluppato in modo efficiente i progetti di piccola scala che avevo in mente di fare. Lo ritengo meno adatto a progetti grandi perché offre poche possibilità di aggiungere appunti, risorse ecc in modo organizzato. Tuttavia, per to-do più belli visivamente è un ottimo strumento.",
+    "pros": "Di Trello mi è piaciuta la semplicità di utilizzo, l'interfaccia pulita e semplice, e la versatilità dello strumento in diversi tipi di progetti.",
+    "cons": "Trello è un programma delle volte fin troppo semplice, l'interfaccia non è modernissima, e apprezzerei più funzionalità per organizzare i miei progetti. La sola visualizzazione Kanban non è sempre sufficiente."
+  },
+  {
+    "title": "\"Great simple project management service\"",
+    "date": "March 11, 2026",
+    "reviewer_name": "Achirachaya T.",
+    "reviewer_role": "Software Engineer",
+    "reviewer_industry": "Investment Management",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F1f4def974f2fba1870d20f42d37b73257dc6e9ccd6cef28f01f528ef54709e63.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": null,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "It is a nice simple project management tool, with great uptime and stability (I don't remember developers broke any single thing inside it so far)",
+    "pros": "Generous free version, big quantity of different plugins, and simple idea behind and intuitive interface. I never had a problem of searching certain functionality for long time like with many other project management tools.",
+    "cons": "When there are a lot of cards interface becomes quite laggy and it is hard to use it, so you cant use one board to work and collect ideas in the same time for example."
+  },
+  {
+    "title": "\"Simple and visual Task Management, Best for basic Team Collaboration\"",
+    "date": "April 16, 2026",
+    "reviewer_name": "Sandra J.",
+    "reviewer_role": "Science Communication Technician",
+    "reviewer_industry": "Biotechnology",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ffe0f47c7fd59460c237e904497bfe1ae22882c35bae098bafee403913e41aeb6.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Trello makes it easy and smooth to mange tasks and simple project with great visual organization. It's simple to use and work well for teams that don't need a lot of automation or advanced controls. But it becomes limiting when the project gets more complicated and the need for reports grows.",
+    "pros": "Trello is very easy to use because its interface is clean and simple. Anyone can start managing tasks right away. It has boards and cards that make it easy to see how tasks are going, which makes it easier to understands how the project is going. Collaboration is easy, so team can stay on the same page without any problems. In general, it's light, quick and dependable for basic project management needs.",
+    "cons": "Trello's advanced feature are limited, especially for managing complicated projects and automating processes, which makes it hard to grow. Customer service can seem slow or less proactive when it comes to fixing bigger problems. Compared to more advanced tools, it doesn't have very good reporting and analytics."
+  },
+  {
+    "title": "\"Visualize Your Success\"",
+    "date": "February 12, 2026",
+    "reviewer_name": "Ahmed A.",
+    "reviewer_role": "Marketing Officer",
+    "reviewer_industry": "Computer Networking",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fffe659f3fe3570cc8b45cf163ebd3b4cb52e14850b6d505baf31d817fb3511fc.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Highly practical and efficient; it turns project complexity into a simple, easy-to-track visual workflow, though it can become overwhelming when tasks pile up excessively.",
+    "pros": "Trello’s standout feature is its intuitive visual interface, which makes tracking complex projects effortless through a simple drag-and-drop system. I highly value its extreme flexibility for customizing workflows and the powerful \"Butler\" automation that handles repetitive tasks seamlessly.",
+    "cons": "The biggest downside is that boards become cluttered and hard to manage as projects grow large, making it less ideal for complex team workflows. Additionally, many essential views like Calendar and Timeline are locked behind paid tiers, limiting the functionality of the free version."
+  },
+  {
+    "title": "\"Trelllo - Easy Peasy Usage\"",
+    "date": "March 18, 2026",
+    "reviewer_name": "Anne O.",
+    "reviewer_role": "Senior Developer",
+    "reviewer_industry": "Insurance",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "It's a very useful tool. It's a great way to track projects and share where you are in a project with the rest of the team. It has awesome tools so you can track and check off different tasks on a project. I love that you can communicate with other people. It's a good way to track projects without having to go back and search through hundreds of emails -- everything is located in one convenient location. I won't go back to tracking projects by spreadsheets after this!",
+    "pros": "It's easy to plan projects and see where they are in the process. I'm a visual learner so I like to see where a project is. I also like that you other team members can see the progress of a particular project and I can communicate with team members using the Trello cards. Easy peasy!",
+    "cons": "Once a team member accidentally erased a card, but she was able to restore it after she looked up how to do it. It would be nice to have an extra warning before a Trello card is deleted."
+  },
+  {
+    "title": "\"Wonderful Platform!\"",
+    "date": "April 21, 2026",
+    "reviewer_name": "Heather M.",
+    "reviewer_role": "Online Platform Coordinator",
+    "reviewer_industry": "Mental Health Care",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Trello has helped our team as a whole in so many ways! It has been a wonderful addition to help us navigate through our daily duties by letting us see at a glance what is happening and what needs to be completed.",
+    "pros": "What I liked most about Trello is its simplicity and visual approach to project management. The board and card system makes it easy to organize tasks, track progress, and quickly understand what's going on at a glance.",
+    "cons": "Absolutely Nothing! Trello is everything it is setup to be, its perfect the way it is! We, as a team, have had nothing but positive feedback when it comes to Trello."
+  },
+  {
+    "title": "\"Expensive to do list\"",
+    "date": "March 9, 2026",
+    "reviewer_name": "Jenifer M.",
+    "reviewer_role": "Events Coordinator",
+    "reviewer_industry": "Events Services",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 2.0,
+      "ease_of_use": 3.0,
+      "features": 3.0,
+      "value_for_money": 1.0,
+      "customer_service": 2.0,
+      "likelihood_to_recommend": 2
+    },
+    "review_body": "Very expensive to implement for a pretty product that says can be a great management tool, but you can only organize it vertically or horizontally. Needs to be built out more and not have everyone working out of a tiny square. It is more of a fancy elaborate check list/to do list. Do not use for project management.",
+    "pros": "The prettiness, it's a pretty product, it's a good checklist. Can replace your post it nots and make it digital but there are other free apps for this too.",
+    "cons": "Not as effective in project management as ASANA or other project management systems. It cannot support an organization's yearly marketing plan. Too much information in one place, can't organize it so that it is manageable."
+  },
+  {
+    "title": "\"Review of Trello over 2 years of usage\"",
+    "date": "April 1, 2026",
+    "reviewer_name": "Rakhi V.",
+    "reviewer_role": "QA Lead",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "It’s a reliable, easy-to-use tool for organizing work and keeping teams aligned, especially for smaller projects or simple workflows. While it isn’t always the best fit for more complex tracking or analytics, it’s excellent for clarity, speed, and day-to-day task management.",
+    "pros": "Trello is simple and visual  boards, lists, and cards make it easy to see what’s going on at a glance without needing training. It’s also great for lightweight collaboration because it’s quick to add tasks, assign owners, and move work along, which makes it feel less heavy than more complex project tools",
+    "cons": "Trello can start to feel a bit limited—tracking dependencies, reporting, or more complex workflows often needs add-ons or workarounds. It can also get messy if a board isn’t maintained consistently, since cards pile up and it becomes harder to tell what’s truly important versus just “still sitting there.”"
+  },
+  {
+    "title": "\"Easy, Customizable, Effective Task Management \"",
+    "date": "December 22, 2025",
+    "reviewer_name": "Jen P.",
+    "reviewer_role": "Director of Tutor Development and Operations",
+    "reviewer_industry": "E-Learning",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Overall, I have a very positive view of Trello. It is a very flexible software that can be customized to fit just about any need. The add-ons such as the day counter and automations make it even more adaptable.",
+    "pros": "I love how Trello is easy to use and super customizable! The templates make it super easy to get started and all the add on automations are incredibly helpful for keeping tasks organized. I also LOVE the shortcuts to add cards from any where on your computer. The free version is SUCH a great value!",
+    "cons": "Trello seems to use quite a bit of memory and sometimes slows down my computer if I have several applications open which means I have to close it at times."
+  },
+  {
+    "title": "\"Good enough for monitoring board meetings but inadequate otherwise.\"",
+    "date": "May 16, 2026",
+    "reviewer_name": "Alexandre D.",
+    "reviewer_role": "Secretary General",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": null,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "Trello serves the purpose as an administrative tool for a mid-sized technology company, but just about. While it is good enough for basic activities, it simply cannot handle our projects' interdependency and their board documents' versioning process.",
+    "pros": "The card system works fine in terms of monitoring the actions that the board takes along with any governance. I can assign different cards to individual managers within various departments and get an overview of pending activities. Activity streams help me monitor all the activity carried out by individual employees in case of audits. Butler automation assists in saving time in terms of repeated governance actions.",
+    "cons": "There are no Gantt charts, making it impossible to monitor our reporting deadlines on a quarterly basis. The free plan allows for 10 boards at most, making it inadequate since we need to manage multiple board committees. The integration process with the document repository in SharePoint poses an issue."
+  },
+  {
+    "title": "\"The perfect visual tool for simple and effective task tracking\"",
+    "date": "December 30, 2025",
+    "reviewer_name": "Camilo I.",
+    "reviewer_role": "Project Manager",
+    "reviewer_industry": "Translation and Localization",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb6095fe64d6684bb5ac53d0f5af20e8a36a88b77ff7326488c1fc817d8dd9181.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "Overall, my experience with Trello has been excellent for daily organization and team collaboration. It is the most user-friendly way to manage a to-do list or a creative pipeline without the overhead of more complex software. It might not be the best fit for highly technical or massive projects, but for staying organized and seeing progress at a glance, it's my favorite choice.",
+    "pros": "What I like most is the visual simplicity. The Kanban board layout is incredibly intuitive—I can see exactly where every project stands just by looking at the cards. It’s one of the few tools where I didn't need a tutorial to get started; the drag-and-drop interface makes organizing tasks feel natural and fast.",
+    "cons": "While the simplicity is a strength, it can feel a bit limited for complex projects. It's hard to get a bird's-eye view of work happening across multiple boards, and things like task dependencies or advanced reporting usually require extra 'Power-Ups.' It’s great for straightforward workflows, but it can get a little cluttered as the team grows."
+  },
+  {
+    "title": "\"Simple and effective tool for task management\"",
+    "date": "April 18, 2026",
+    "reviewer_name": "MARWA B.",
+    "reviewer_role": "Desinger",
+    "reviewer_industry": "Commercial Real Estate",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F6e93a0d4095ad358c6d3851d06fde92ab3a7b855e6b50ef7f9011447899514da.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Overall, my experience with Trello has been very positive. It’s a great tool for organizing tasks and staying productive, especially for simple workflows or small teams. However, for more advanced project management needs, it may feel limited. It’s best suited for users who want something simple, visual, and easy to manage.",
+    "pros": "Trello is very easy to use and has a clean, visual interface. The drag-and-drop system makes organizing tasks simple and intuitive. I like how I can quickly create boards, lists, and cards to track my work. It’s great for both personal use and small team collaboration, and the free version already offers a lot of useful features",
+    "cons": "Trello can become messy when managing large or complex projects. It lacks advanced features like detailed reporting, timelines, or Gantt charts. Also, some useful features like automation and advanced views are only available in paid plans."
+  },
+  {
+    "title": "\"Sencillo, visual y efectivo para el seguimiento de proyectos internos\"",
+    "date": "June 12, 2026",
+    "reviewer_name": "Tsvetelina B.",
+    "reviewer_role": "Customer Success Manager",
+    "reviewer_industry": "Banking",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 5.0,
+      "customer_service": 4.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Trello es una herramienta excelente para el seguimiento de proyectos internos donde prima la simplicidad y la visibilidad rápida del estado de las iniciativas. Su curva de aprendizaje prácticamente inexistente lo hace ideal para equipos multidisciplinares. No es la solución más potente del mercado, pero para la mayoría de casos de uso del día a día cumple con creces y aporta mucho orden sin añadir complejidad operativa.",
+    "pros": "La visualización en formato Kanban hace que el seguimiento de proyectos internos sea inmediato y sin fricción. Es muy fácil de adoptar por cualquier perfil del equipo, sin necesidad de formación previa. Las tarjetas permiten centralizar toda la información relevante de cada iniciativa (descripción, adjuntos, fechas límite, responsables) en un solo lugar, lo que reduce enormemente la cantidad de información por email o chat.",
+    "cons": "Para proyectos con dependencias complejas entre tareas, Trello se queda corto frente a herramientas más avanzadas como Jira. La gestión de permisos por tablero puede resultar algo rígida en organizaciones con muchos equipos, y las funcionalidades de reporting nativo son bastante básicas, lo que obliga a apoyarse en integraciones externas para obtener métricas útiles."
+  },
+  {
+    "title": "\"Easy to learn, perfect for getting started\"",
+    "date": "July 13, 2026",
+    "reviewer_name": "Álvaro C.",
+    "reviewer_role": "Deploy Manager",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Fb4c6f1742f30f6a3985be1125c8a6120a8a80478be9102146847ee089e915e34.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": null,
+      "customer_service": null,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "I used Trello during my programming studies with classmates to organize our tasks — deciding who was responsible for what — which also helped us get a sense of how tools like this are used to organize work in a professional setting. It's great for getting started and very easy to understand, with virtually no learning curve. I've also used it for personal projects with groups of programmers, and it works really well. I'd recommend it for organizing smaller projects that won't grow too large in scope",
+    "pros": "The ease of understanding how to use the tools stands out, with a fairly simple interface. It's very useful for creating individual or group tasks involving multiple users, and for setting deadlines to get them done. It's great for studying, work, trip planning, and many other purposes. It features a board and list view that make it very easy to see and interact with everything.",
+    "cons": "I don't think the process of marking a task as completed is very automated — everything remains manual, which means it might not get updated correctly if the person responsible for it doesn't do so. It's also not possible to link tasks that are dependent on one another, which would be important for knowing whether one task affects another.\nAs the project scales up significantly, the view can become quite chaotic and hard to follow in terms of a clear timeline."
+  },
+  {
+    "title": "\"Trello is perfect for organizing all of your tasks\"",
+    "date": "November 26, 2025",
+    "reviewer_name": "Julia G.",
+    "reviewer_role": "Dance Teacher and Choreographer",
+    "reviewer_industry": "Recreational Facilities and Services",
+    "reviewer_usage_duration": "1-2 years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F79d88f1ad0fb6bf8dc7320fae95cf8b6c71193c3d653bc73c287b2427227e6ee.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 10
+    },
+    "review_body": "It has been wonderful! It has made organization and task tracking so much easier and keeps everything in one place.",
+    "pros": "I love how organized it is and how clearly each section is separated. It is easy to see every piece of information I need and keep track of all of my tasks.",
+    "cons": "Sometimes I found it a bit difficult to find how to delete a comment or a card on a board. I had to search around for it for a while."
+  },
+  {
+    "title": "\"Trello: Great for Quick Wins, Overwhelming for Everything Else\"",
+    "date": "November 10, 2025",
+    "reviewer_name": "Willy H.",
+    "reviewer_role": "IT PM",
+    "reviewer_industry": "Insurance",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2F08771defd7f31909c293cd8f5365894171f9635c35492d33500fa1acd368d79f.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": 4.0,
+      "customer_service": 3.0,
+      "likelihood_to_recommend": 5
+    },
+    "review_body": "My experience with Trello has been genuinely great, as long as I keep it simple.\n\nIt's my go-to tool for things like personal to-do lists, planning a quick social media calendar, or handling small projects with a defined beginning and end. The fact that I can instantly see where every task is—just by glancing at the board—is what keeps me coming back. It’s the closest thing to a truly digital, zero-friction whiteboard, and that visual clarity is a huge win.",
+    "pros": "I genuinely love how visual Trello is. The whole \"Boards, Lists, and Cards\" system makes it feel like you're moving virtual sticky notes around. I can see exactly where a project stands in about two seconds flat—no hunting through a dense spreadsheet or a cluttered inbox. It's fantastic for getting a quick, high-level view of the entire workflow.",
+    "cons": "While the visual aspect is a huge pro, it's also the main con. Once a board has, say, 10+ lists and 50+ active cards, it can feel overwhelming and crowded. It's easy for important tasks to get visually lost. Trello is brilliant for simple, contained projects, but for massive, enterprise-level planning, it starts to feel a bit too much like a huge, intimidating wall of digital stickies."
+  },
+  {
+    "title": "\"Trello is the best Kanban tool out there\"",
+    "date": "August 9, 2026",
+    "reviewer_name": "Craig C.",
+    "reviewer_role": "Consult of Continuous Improvement",
+    "reviewer_industry": "Insurance",
+    "reviewer_usage_duration": "2+ years",
+    "reviewer_avatar": null,
+    "ratings": {
+      "overall": 5.0,
+      "ease_of_use": 5.0,
+      "features": 5.0,
+      "value_for_money": 5.0,
+      "customer_service": null,
+      "likelihood_to_recommend": 9
+    },
+    "review_body": "As Continuous Improvement/Lean practitioner, I’ve always been a huge fan of Kanban Boards. There’s no better feeling than moving stickies from “Doing” to “Done”. There are lots of free tools online for Kanban-like boards, but Trello is the best. It’s easy to use, highly customizable, and the visual design/UI is aesthetically pleasing. It struggles with behemoth-sized projects, but what tool out there doesn’t?  Despite that, I would absolutely recommend Trello to others.",
+    "pros": "Trellis is great because it’s easy to use but still has lots of depth in terms of customization. I’m involved with lots of projects and no two are the same. Trello’s customization tools easily helps me visualize and capture these difference. And, the automation/Butler tool has saved me a ton of time by handling some of the tedious/repetitive tasks.",
+    "cons": "Trello isn’t ideal for large, complex, cross-functional projects. It can handle the volume, but the boards look bloated and are hard to parse (just like in real life). That’s less a con and more an accurate reflection of how hard it can be to manage huge projects. \n\nAnother small issue I’ve run into is that there’s no easy way to create contingent tasks (ones that depend on the completion of another)."
+  },
+  {
+    "title": "\"Visual, Intuitive, and Streamlined Task Management for Agile Projects\"",
+    "date": "August 2, 2026",
+    "reviewer_name": "Sourav M.",
+    "reviewer_role": "AI Engineer",
+    "reviewer_industry": "Information Technology and Services",
+    "reviewer_usage_duration": "Less than 6 months",
+    "reviewer_avatar": "https://www.capterra.com/assets-bx-capterra/_next/image?url=https%3A%2F%2Freviews.capterra.com%2Fcdn%2Fprofile-images%2Flinkedin%2Ff3bd832a14027da460246de3cb247c1a83dd870c0e8ebcda5828f49e65d1c54d.jpeg&w=256&q=75",
+    "ratings": {
+      "overall": 4.0,
+      "ease_of_use": 5.0,
+      "features": 4.0,
+      "value_for_money": null,
+      "customer_service": 5.0,
+      "likelihood_to_recommend": 8
+    },
+    "review_body": "Overall, Trello is one of the most accessible and effective tools available for managing projects and team workflows. It strikes a great balance between flexibility and simplicity, making it easy to jump straight into planning without getting bogged down by complicated configurations. Whether used for lightweight daily task management or coordinating active project milestones, Trello delivers a seamless and reliable productivity boost.",
+    "pros": "What stands out most about Trello is its minimal learning curve combined with powerful visual organization. The Kanban board layout makes it incredibly simple to organize project pipelines, track task progress, and keep cross-functional work structured. Butler automation is another major highlight—it automates routine steps like auto-assigning team members or updating card labels, saving significant time every week.",
+    "cons": "While Trello excels at Kanban-style task tracking, it can feel limited when managing highly complex, multi-layered dependencies across large-scale engineering or research projects. Advanced reporting, timeline gantt charts, and custom workflow rules require paid tiers or third-party Power-Ups, which can make the setup feel slightly fragmented if you need heavy analytical tracking right out of the box."
   },
   {
     "title": "",

--- a/capterra-scraper/run.py
+++ b/capterra-scraper/run.py
@@ -23,14 +23,14 @@ async def run():
         max_pages=3,
     )
     with open(output.joinpath("category.json"), "w", encoding="utf-8") as file:
-        json.dump(category_data, file, indent=2, ensure_ascii=False)
+        json.dump(category_data["products"], file, indent=2, ensure_ascii=False)
 
     reviews_data = await capterra.scrape_reviews(
         url="https://www.capterra.com/p/211559/Trello/",
         max_review_pages=3,
     )
     with open(output.joinpath("reviews.json"), "w", encoding="utf-8") as file:
-        json.dump(reviews_data, file, indent=2, ensure_ascii=False)
+        json.dump(reviews_data["reviews"], file, indent=2, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/capterra-scraper/test.py
+++ b/capterra-scraper/test.py
@@ -59,12 +59,16 @@ review_schema = {
 async def test_category_scraping():
     category_data = await capterra.scrape_category(
         category="scheduling-software",
-        max_pages=1,
+        max_pages=2,
     )
     validator = Validator(category_product_schema, allow_unknown=True)
-    for item in category_data:
+    for item in category_data["products"]:
         validate_or_fail(item, validator)
-    assert len(category_data) >= 10
+    assert len(category_data["products"]) >= 10
+    if category_data["total_pages"] < 21:
+        pytest.fail(
+            f"expected total_pages >= 21, got {category_data['total_pages']}"
+        )
 
 
 @pytest.mark.asyncio
@@ -72,9 +76,14 @@ async def test_category_scraping():
 async def test_review_scraping():
     reviews_data = await capterra.scrape_reviews(
         url="https://www.capterra.com/p/211559/Trello/reviews/",
-        max_review_pages=1,
+        max_review_pages=2,
     )
     validator = Validator(review_schema, allow_unknown=True)
-    for item in reviews_data:
+    for item in reviews_data["reviews"]:
         validate_or_fail(item, validator)
-    assert len(reviews_data) >= 5
+    assert len(reviews_data["reviews"]) >= 5
+    if reviews_data["total_pages"] != 100:
+        pytest.fail(
+            f"expected total_pages=100, got {reviews_data['total_pages']}"
+        )
+


### PR DESCRIPTION
I updated the pagination to get the maximum page from the last-page chevron icon and added an assertion in test.py to verify the total number of pages.

For Capterra reviews, the results are always capped at 100, even when a product has more reviews, such as Trello. So, in this case, the expected value should always be 100.

For category pages, there are currently 21 pages, but this number can increase in the future.