### PR TITLE
[imdb] read reviews from the reviews page instead of the nulled featuredReviews field

### DIFF
--- a/imdb-scraper/imdb.py
+++ b/imdb-scraper/imdb.py
@@ -160,24 +160,23 @@ async def scrape_titles(urls: List[str]) -> List[IMDbTitle]:
 
 
 def parse_reviews(response: ScrapeApiResponse) -> List[IMDbReview]:
-    """parse featured user reviews from title page __NEXT_DATA__"""
+    """parse user reviews from the reviews page __NEXT_DATA__"""
     page = _parse_next_data(response.selector).get("props", {}).get("pageProps", {})
-    edges = ((page.get("mainColumnData") or {}).get("featuredReviews") or {}).get("edges") or []
+    items = ((page.get("contentData") or {}).get("reviews")) or []
     reviews = []
-    for edge in edges:
-        node = edge.get("node") or {}
-        if not node.get("id"):
+    for item in items:
+        node = item.get("review") or {}
+        if not node.get("reviewId"):
             continue
         author = node.get("author") or {}
-        raw = ((node.get("text") or {}).get("originalText") or {}).get("plaidHtml") or ""
-        text = html.unescape(raw)
+        text = html.unescape(node.get("reviewText") or "")
         text = re.sub(r"<br\s*/?>", "\n", text, flags=re.I)
         text = re.sub(r"<[^>]+>", "", text).strip() or None
         reviews.append(
             IMDbReview(
-                id=node["id"],
+                id=node["reviewId"],
                 author=(author.get("username") or {}).get("text"),
-                summary=(node.get("summary") or {}).get("originalText"),
+                summary=node.get("reviewSummary"),
                 text=text,
                 rating=node.get("authorRating"),
                 spoiler=bool(node.get("spoiler")),
@@ -187,9 +186,8 @@ def parse_reviews(response: ScrapeApiResponse) -> List[IMDbReview]:
 
 
 async def scrape_reviews(title_id: str) -> List[IMDbReview]:
-    """scrape featured user reviews from the title page hidden dataset
-    (the /reviews/ page requires sign-in and no longer embeds review data)"""
-    url = f"https://www.imdb.com/title/{title_id}/"
+    """scrape user reviews from the title reviews page hidden dataset"""
+    url = f"https://www.imdb.com/title/{title_id}/reviews/"
     result = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
     reviews = parse_reviews(result)
     log.success(f"scraped {len(reviews)} reviews for {title_id}")


### PR DESCRIPTION
Fixes #170

## What changed

`scrape_reviews` goes back to `/title/<id>/reviews/` and reads `contentData.reviews[].review`.

The old source, `mainColumnData.featuredReviews` on the title page, is `null` now. `test_review_scraping` has failed every night since 2026-07-30.

All six schema fields map over:

| `IMDbReview` | new path |
|---|---|
| `id` | `reviewId` |
| `author` | `author.username.text` |
| `summary` | `reviewSummary` |
| `text` | `reviewText`, then the existing unescape, `<br/>` to newline and tag strip |
| `rating` | `authorRating` |
| `spoiler` | `spoiler` |

One function and one URL. The text cleaning code is untouched.

## Why this source and not the relocated one

A copy of `featuredReviews` turned up under `aboveTheFoldData`, but it has no `id` (the schema wants a non-nullable string), uses `author.nickName`, uses `plainText` instead of `plaidHtml`, drops `spoiler`, and carries a single review.

The bigger reason: `featuredReviews` feeds an optional UI slot, so it has no contract and can go null again next month. `/reviews/` is the review collection's own page. That's also where `results/reviews.json` was generated from originally.

## Checks

- `poetry run pytest test.py -k test_review_scraping` passes, 5 reviews, 0 schema violations
- replayed offline against a saved copy of the page: 5/5 valid, every field populated except one nullable `rating` that is correctly absent
- `tt0903747` (TV series): 5 reviews, 0 violations
- `tt13649118`: 0 reviews, and its payload independently reports `reviewCount: 0`, so that title really has none and the parser is behaving
- committed `results/reviews.json` already holds these exact ids (`rw6606154` and friends), so this restores the checked in output contract instead of changing it. No fixture update needed.
- `README.md` already says "IMDb review pages for user reviews", so it reads accurately again without an edit
