### PR TITLE
[autoscout24] fix swallowed page failures, pagination, dedupe and render cost

### DIFF
--- a/.github/workflows/test_scrapers.yaml
+++ b/.github/workflows/test_scrapers.yaml
@@ -271,7 +271,7 @@ jobs:
           - project_dir: amazon-scraper
             test: test_review_scraping
           - project_dir: autoscout24-scraper
-            test: test_listings_scraping
+            test: test_page_url or test_listings_scraping
           - project_dir: autoscout24-scraper
             test: test_car_details_scraping
           - project_dir: ticketmaster-scraper
@@ -418,7 +418,7 @@ jobs:
         SCRAPFLY_KEY: ${{ secrets.SCRAPFLY_KEY }}
       run: |
         cd ${{ matrix.project_dir }}
-        poetry run pytest test.py -k ${{ matrix.test }}
+        poetry run pytest test.py -k "${{ matrix.test }}"
 
     - name: Send Slack notification
       uses: 8398a7/action-slack@v3

--- a/autoscout24-scraper/README.md
+++ b/autoscout24-scraper/README.md
@@ -40,6 +40,7 @@ This AutoScout24.com scraper uses __Python 3.10__ with [scrapfly-sdk](https://py
     $ poetry install --with dev
     $ poetry run pytest test.py
     # or specific scraping areas
+    $ poetry run pytest test.py -k test_page_url
     $ poetry run pytest test.py -k test_listings_scraping
     $ poetry run pytest test.py -k test_car_details_scraping
     ```

--- a/autoscout24-scraper/autoscout24.py
+++ b/autoscout24-scraper/autoscout24.py
@@ -7,12 +7,12 @@ $ export $SCRAPFLY_KEY="your key from https://scrapfly.io/dashboard
 """
 import json
 import os
-import re
 from pathlib import Path
-from typing import Dict, List, TypedDict, Optional, Any
+from typing import Dict, List, Tuple, TypedDict, Optional, Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from loguru import logger as log
-from scrapfly import ScrapeApiResponse, ScrapeConfig, ScrapflyClient, ScrapflyScrapeError
+from scrapfly import ScrapeApiResponse, ScrapeConfig, ScrapflyClient, ScrapflyError
 
 SCRAPFLY = ScrapflyClient(key=os.environ["SCRAPFLY_KEY"])
 
@@ -20,7 +20,8 @@ BASE_CONFIG = {
     # AutoScout24 requires Anti Scraping Protection bypass feature.
     # for more: https://scrapfly.io/docs/scrape-api/anti-scraping-protection
     "asp": True,
-    "render_js": True
+    # no render_js: the listing and offer data is in the server rendered __NEXT_DATA__ payload,
+    # so rendering only adds cost and a browser page load to wait on
 }
 
 output = Path(__file__).parent / "results"
@@ -46,59 +47,146 @@ class CarDetails(TypedDict, total=False):
     location: Optional[Dict[str, Any]]
 
 
-def parse_listings(result: ScrapeApiResponse) -> List[CarListing]:
-    """Parse AutoScout24 listings page for car listings"""
+def change_page(url: str, page: int) -> str:
+    """set the page number on an AutoScout24 search url, replacing it when one is already there"""
+    parts = urlsplit(url)
+    # the multi select filters repeat a key (eq=1&eq=15), so the pairs stay a list instead of
+    # becoming a dict, which would keep only the last value of each filter
+    query = [(key, value) for key, value in parse_qsl(parts.query, keep_blank_values=True) if key != "page"]
+    query.append(("page", str(page)))
+    return urlunsplit(parts._replace(query=urlencode(query), fragment=""))
+
+
+def parse_listings(result: ScrapeApiResponse) -> Tuple[List[CarListing], int]:
+    """Parse AutoScout24 listings page for car listings and the number of available pages"""
     selector = result.selector
 
     script_data = selector.css("script#__NEXT_DATA__::text").get()
     if not script_data:
-        log.warning(f"Could not find __NEXT_DATA__ on page: {result.context['url']}")
-        return []
-    data = json.loads(script_data)
-    listings = data.get("props", {}).get("pageProps", {}).get("listings", [])
-    return listings
+        log.warning(f"could not find __NEXT_DATA__ on page: {result.context['url']}")
+        return [], 0
+    page_props = json.loads(script_data).get("props", {}).get("pageProps", {})
+    listings = page_props.get("listings") or []
+    if not listings:
+        # an upstream error page still ships a __NEXT_DATA__ blob, so an empty payload
+        # has to be logged or a failed page looks exactly like a page of zero results
+        log.warning(f"no listings in __NEXT_DATA__ on page: {result.context['url']}")
+    return listings, page_props.get("numberOfPages") or 0
 
 
-def parse_car_details(result: ScrapeApiResponse) -> CarDetails:
+def parse_car_details(result: ScrapeApiResponse) -> Optional[CarDetails]:
     """Parse car detail page"""
     selector = result.selector
     script_data = selector.css("script#__NEXT_DATA__::text").get()
     if not script_data:
-        log.warning(f"Could not find __NEXT_DATA__ on page: {result.context['url']}")
+        log.warning(f"could not find __NEXT_DATA__ on page: {result.context['url']}")
         return None
     data = json.loads(script_data)
-    car_data = data.get("props", {}).get("pageProps", {}).get("listingDetails", {})
-
+    car_data = data.get("props", {}).get("pageProps", {}).get("listingDetails") or None
+    if not car_data:
+        log.warning(f"no listing details in __NEXT_DATA__ on page: {result.context['url']}")
     return car_data
 
 
 async def scrape_listings(url: str, max_pages: int = 3) -> List[CarListing]:
-    """Scrape car listings from AutoScout24 search/category page"""
-    all_listings = []
-    result = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
-    all_listings.extend(parse_listings(result))
+    """Scrape car listings from AutoScout24 search/category page (with pagination)"""
+    # page 1 goes through change_page too, otherwise a url that already carries ?page=5 is
+    # scraped once at page 5 and then continued from page 2
+    first_page = await SCRAPFLY.async_scrape(ScrapeConfig(change_page(url, 1), **BASE_CONFIG))
+    first_listings, total_pages = parse_listings(first_page)
+    if not first_listings:
+        log.error(f"the first page of {url} returned no listings, giving up on the remaining pages")
+        return []
 
-    # check if url contains '?' to determine if we should use '&' or '?' for the page parameter
-    if "?" in url:
-        page_param = "&page="
-    else:
-        page_param = "?page="
+    all_listings: List[CarListing] = []
+    seen = set()
 
-    other_pages = [ScrapeConfig(url + f"{page_param}{page}", **BASE_CONFIG) for page in range(2, max_pages + 1)]
+    def collect(page_listings: List[CarListing]) -> int:
+        """add the listings of one page, dropping the ones already collected"""
+        added = 0
+        for listing in page_listings:
+            listing_url = listing.get("url")
+            if listing_url and listing_url in seen:
+                continue
+            seen.add(listing_url)
+            all_listings.append(listing)
+            added += 1
+        return len(page_listings) - added
+
+    collect(first_listings)
+    last_page = min(max_pages, total_pages) if total_pages else max_pages
+    log.info(f"scraped page 1 of {url}: {len(all_listings)} listings, {total_pages} pages available")
+
+    page_numbers = list(range(2, last_page + 1))
+    other_pages = [ScrapeConfig(change_page(url, page), **BASE_CONFIG) for page in page_numbers]
+    scraped_urls = set()
     async for response in SCRAPFLY.concurrent_scrape(other_pages):
-        log.info(f"Scraping page {response.context['url']}")
-        all_listings.extend(parse_listings(response))
+        # concurrent_scrape yields whatever the request raised instead of raising it, and those
+        # errors are not all one class, so only a real response may be touched
+        if not isinstance(response, ScrapeApiResponse):
+            log.error(f"failed to scrape a listings page, got: {response}")
+            continue
+        page_listings, _ = parse_listings(response)
+        if not page_listings:
+            continue
+        # config holds the requested url, context holds the final one, which is the homepage
+        # whenever the page bounced
+        scraped_urls.add(response.config["url"])
+        # AutoScout24 repeats boosted listings across pages, so they are dropped by url
+        duplicates = collect(page_listings)
+        log.info(f"scraped {response.context['url']}: {len(page_listings)} listings, {duplicates} duplicates dropped")
 
-    log.success(f"Scraped {len(all_listings)} car listings from {url}")
+    # under concurrency AutoScout24 sometimes bounces a page to the homepage, which carries no
+    # listings, so the pages that came back empty get one more sequential attempt
+    for page in page_numbers:
+        page_url = change_page(url, page)
+        if page_url in scraped_urls:
+            continue
+        log.info(f"retrying page {page} of {url}")
+        try:
+            retry = await SCRAPFLY.async_scrape(ScrapeConfig(page_url, **BASE_CONFIG))
+        except ScrapflyError as error:
+            log.error(f"retry of page {page} failed, got: {error}")
+            continue
+        page_listings, _ = parse_listings(retry)
+        if page_listings:
+            collect(page_listings)
+        else:
+            log.error(f"page {page} of {url} returned no listings after a retry")
+
+    log.success(f"scraped {len(all_listings)} car listings from {url}")
     return all_listings
+
 
 async def scrape_car_details(urls: List[str]) -> List[CarDetails]:
     """Scrape detailed car information from car page"""
     all_car_details = []
     to_scrape = [ScrapeConfig(url, **BASE_CONFIG) for url in urls]
 
+    scraped_urls = set()
     async for response in SCRAPFLY.concurrent_scrape(to_scrape):
-        all_car_details.append(parse_car_details(response))
+        if not isinstance(response, ScrapeApiResponse):
+            log.error(f"failed to scrape a car details page, got: {response}")
+            continue
+        car_details = parse_car_details(response)
+        # an unparsed page must not leave a null in the results
+        if car_details:
+            scraped_urls.add(response.config["url"])
+            all_car_details.append(car_details)
 
-    log.success(f"Scraped {len(all_car_details)} car details from {urls}")
+    # a page can bounce to the homepage under concurrency, so the missing ones get one more try
+    for url in urls:
+        if url in scraped_urls:
+            continue
+        log.info(f"retrying {url}")
+        try:
+            retry = await SCRAPFLY.async_scrape(ScrapeConfig(url, **BASE_CONFIG))
+        except ScrapflyError as error:
+            log.error(f"retry of {url} failed, got: {error}")
+            continue
+        car_details = parse_car_details(retry)
+        if car_details:
+            all_car_details.append(car_details)
+
+    log.success(f"scraped {len(all_car_details)} car details of {len(urls)} requested")
     return all_car_details

--- a/autoscout24-scraper/pyproject.toml
+++ b/autoscout24-scraper/pyproject.toml
@@ -17,6 +17,7 @@ ruff = "^0.0.269"
 cerberus = "^1.3.4"
 pytest = "^7.3.1"
 pytest-asyncio = "^0.21.0"
+pytest-rerunfailures = "^11.1.2"
 
 [build-system]
 requires = ["poetry-core"]

--- a/autoscout24-scraper/results/car_details.json
+++ b/autoscout24-scraper/results/car_details.json
@@ -1,105 +1,72 @@
 [
   {
-    "id": "117b7cf9-f7e8-449c-bfdd-cfd449484f99",
+    "id": "56fe41bc-c72f-4fa2-8fc3-310340b0a82d",
     "searchResultType": "Organic",
     "isDeliverable": false,
-    "description": "<strong>HIGHLIGHTS:</strong>  <br /><ul><li><strong>Bordcomputer</strong> </li><li><strong>DAB Receiver</strong> </li><li><strong>Android Auto</strong> </li><li><strong>Apple Car Play</strong> </li><li><strong>Touchscreen</strong> </li><li><strong>Regensensor</strong> </li><li><strong>Einparkhilfe hinten</strong> </li><li><strong>Klimaanlage</strong> </li><li><strong>Panoramadach</strong> </li><li><strong>LM-Felgen</strong> <br /> <strong>MULTIMEDIA UND KOMMUNIKATION:</strong>  </li><li><strong>Radio</strong> </li><li><strong>Freisprecheinrichtung</strong> </li><li><strong>Bluetooth</strong> </li><li><strong>USB Anschluss</strong> </li><li><strong>MP3-Schnittstelle</strong> </li><li><strong>Gruppe Multimedia und Kommunikation</strong> <br /> <strong>SICHERHEIT:</strong>  </li><li>ABS </li><li>ESP </li><li>Stabilitätskontrolle </li><li>ASC (Traktionskontrolle) </li><li>ASR (Antriebsschlupfregelung) </li><li><strong>Servolenkung</strong> </li><li><strong>Start-/Stopp-Automatik</strong> </li><li><strong>Berganfahrassistent</strong> </li><li><strong>Bremsassistent (EBS)</strong> </li><li><strong>Geschwindigkeitsregelanlage</strong> </li><li><strong>Geschwindigkeitsbegrenzer</strong> </li><li><strong>Elektrische Wegfahrsperre</strong> </li><li>Fahrer-/Beifahrer Airbag </li><li>Fahrer Airbag </li><li>Knie-Airbag </li><li>Beifahrer-Airbag ausschaltbar </li><li>Beifahrer-Airbag </li><li>Seiten-Airbags </li><li>Kopf-Airbags <br /> <strong>INNENAUSSTATTUNG UND KOMFORT:</strong>  </li><li><strong>Zentralverriegelung mit Funk</strong> </li><li><strong>Coming-Home-Funktion</strong> </li><li><strong>Leaving-Home-Funktion</strong> </li><li><strong>Außenspiegel elektrisch verstellbar</strong> </li><li><strong>Außenspiegel beheizbar</strong> </li><li><strong>Außenspiegel manuell heranklappbar</strong> </li><li><strong>Elektrische Fensterheber vorne</strong> </li><li><strong>Teilleder</strong> </li><li>Kindersitzvorbereitung (ISOFIX) </li><li>4 Kopfstützen </li><li>Multifunktionslenkrad </li><li>Lederlenkrad </li><li>Lenkrad höhenverstellbar <br /> <strong>EXTRAS:</strong>  </li><li>Colorverglasung </li><li>Heckscheibe beheizbar </li><li>Gepäckraumabdeckung </li><li>Metallic </li><li>Tire-Mobility Set </li><li>Reifendruckkontrolle </li><li>LED-Tagfahrlicht </li><li>Garantie </li><li>Scheckheftgepflegt </li><li>Nichtraucherfahrzeug <br /><br />     <strong>Irrtümer, Änderungen und Zwischenverkauf vorbehalten</strong>   <strong>Interesse an einem Leasingangebot? Sprechen Sie uns an!</strong>   <strong>5 Jahre Gebrauchtwagengarantie möglich<br /></strong></li></ul>",
-    "ratings": {
-      "customerCulture": "de-DE",
-      "urlName": "https://www.autoscout24.com/dealerinfo/autohaus-siebrecht-gmbh-einbeck-37574-1/ratings",
-      "ratingsCount": 7,
-      "ratingsStars": 5,
-      "ratingsAverage": "4,7",
-      "recommendPercentage": 85,
-      "ratingsByCategory": [
-        {
-          "stars": 5,
-          "label": "Gesamteindruck"
-        },
-        {
-          "stars": 5,
-          "label": "Erreichbarkeit"
-        },
-        {
-          "stars": 5,
-          "label": "Zuverlässigkeit"
-        },
-        {
-          "stars": 5,
-          "label": "Angebotsbeschreibung"
-        },
-        {
-          "stars": 5,
-          "label": "Kaufprozess"
-        },
-        {
-          "stars": 4.5,
-          "label": "Consultancy"
-        }
-      ]
-    },
+    "description": "<strong>Technische informatie</strong><br />Bandenmaat: <strong>165/60 R15</strong><br />Acceleratie (0-100): <strong>14,3 s</strong><br />Topsnelheid: <strong>160 km/u</strong><br /><br /><strong>Maten en gewichten</strong><br />Laadvermogen: <strong>410 kg</strong><br />GVW: <strong>1.240 kg</strong><br />Afmetingen (LxBxH): <strong>346 x 162 x 146 cm</strong><br />Wielbasis: <strong>234 cm</strong><br /><br /><strong>Interieur</strong><br />Interieurkleur: <strong>Lichtgrijs</strong><br /><br /><strong>Milieu</strong><br />Energielabel: <strong>A</strong><br /><br /><strong>Verbruik</strong><br />Gemiddeld brandstofverbruik: <strong>3,8 l/100km</strong> (1 op 26,3)<br />Brandstofverbruik in de stad: <strong>4,5 l/100km</strong> (1 op 22,2)<br />Brandstofverbruik op de snelweg: <strong>3,4 l/100km</strong> (1 op 29,4)<br /><br /><strong>Staat</strong><br />Aantal sleutels: <strong>2 (1 handzender)</strong><br /><br /><strong>Financiële informatie</strong><br />BTW/marge: <strong>BTW niet verrekenbaar voor ondernemers (margeregeling)</strong><br />Motorrijtuigenbelasting: <strong>€ 70 - € 76</strong> per kwartaal<br /><br /><strong>Aanvullende opties en accessoires</strong><br /><br /><strong>Comfort &amp; Interieur</strong><br /><ul><li>Bestuurdersstoel in hoogte verstelbaar</li><li>Houten versnellingspook</li><li>Multimedia-voorbereiding</li></ul><br /><strong>Exterieur</strong><br /><ul><li>Buitenspiegels verwarmbaar</li></ul><br /><strong>Veiligheid</strong><br /><ul><li>Airbag(s) hoofd achter</li><li>Airbag(s) hoofd voor</li><li>Electronic Brake Distribution</li></ul>",
+    "ratings": null,
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_fcc4639e-2ba9-4778-881e-6eba43729aab.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_17acac4a-1aca-40ad-9033-95bf548fd195.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_b105546f-9dab-4ee2-a6f8-ac7fd07b3088.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_416c15e3-15b2-4e50-b12b-6169501c85a6.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_4457544b-efa4-4371-b556-d6a8a0a0471c.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_7a06a436-585d-4673-9ba1-e1e526742d4e.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_fa08b05c-d011-4d35-b8a3-4eafc53f6b70.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_6772ae0a-1e9a-4090-8246-14cc93adcd87.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_b8315775-510e-4d62-bc51-8e818427baae.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_0aad6279-c2da-4118-a99e-d043f59864e2.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_ccfe85bf-2d1e-4ed3-9ed2-82e544871fd7.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_36ba65d2-15df-46ce-b5b5-ae463af7eb32.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_f2461de1-4098-4ed9-a7fc-b6aad76132de.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_1f0b1f37-f79e-4bbd-8227-21f57c112a0a.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_62ccdffc-34b2-402f-8a19-f2ccbd88a76e.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_7880e055-219e-4d6b-abda-8ac94e0c71f4.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_8baf3964-ec02-4973-9f7d-c5a2d353d851.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_f3b78525-b9f8-4d60-ac49-c37da0ac07fc.jpg/1280x960.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_c5a34cdf-a907-4416-a56d-9918bb4a4030.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_b11bc820-33e8-4727-9e89-44e03c4fed7d.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_826f51b3-e2e6-4db3-8dca-5319c9d511a7.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_9029516a-c2ab-4e51-b5fb-aabc5449f4c5.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_634f0e6f-9319-4477-a626-0401b6009ec7.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_2b426b45-f568-477d-8f8a-75bd99c38f12.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_72ae1fde-0e26-42fb-b70b-0a2ef9400c98.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_e2a35be2-82af-4fc5-a328-49636426d53e.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_5d5c5151-a130-47f6-907b-8200b1e53929.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_74d513ce-02fc-4cd2-99d1-d2c24028680f.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_61926956-478e-4ba8-892d-86599209cdf0.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_ad540762-817d-40b6-98dc-810d89e31211.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_a434dcc0-20be-40a8-bae8-8f42ef992c0b.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_663adace-7d16-4c08-b3a3-f0d437e2352f.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_11b2c756-46ce-4eda-b7a1-895deddeb806.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_1216c7e8-e433-4297-94d0-a5633d86b44c.jpg/1280x960.webp"
     ],
-    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_fcc4639e-2ba9-4778-881e-6eba43729aab.jpg/120x90.webp",
+    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_c5a34cdf-a907-4416-a56d-9918bb4a4030.jpg/120x90.webp",
     "youtubeLink": null,
     "twinnerUrl": null,
     "isCoverImagePlaceholder": false,
-    "coverImageAttractiveness": 0.24435598882892529,
+    "coverImageAttractiveness": 0.20131681993242156,
     "hasThreeSixtyContent": false,
+    "vehicleReport": null,
     "threeSixty": null,
     "prices": {
       "isFinalPrice": false,
       "public": {
-        "price": "€ 13,270",
-        "priceRaw": 13270,
-        "taxDeductible": true,
+        "price": "€ 3,950",
+        "priceRaw": 3950,
+        "taxDeductible": false,
         "negotiable": false,
         "onRequestOnly": false,
         "netPrice": null,
         "netPriceRaw": null,
-        "vatRate": 19,
+        "vatRate": null,
         "category": null,
+        "median": null,
         "evaluationRanges": null
       },
       "dealer": {
-        "price": "€ 12,770",
-        "priceRaw": 12770,
-        "taxDeductible": true,
+        "price": "€ 3,950",
+        "priceRaw": 3950,
+        "taxDeductible": false,
         "negotiable": false,
         "onRequestOnly": false,
         "netPrice": null,
         "netPriceRaw": null,
-        "vatRate": 19,
+        "vatRate": null,
         "category": null,
+        "median": null,
         "evaluationRanges": null
       },
       "suggestedRetail": null,
-      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/117b7cf9-f7e8-449c-bfdd-cfd449484f99?culture=en-GB",
+      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/56fe41bc-c72f-4fa2-8fc3-310340b0a82d?culture=en-GB",
       "error": null
     },
     "superDeal": null,
     "price": {
-      "priceFormatted": "€ 13,270",
+      "priceFormatted": "€ 3,950",
       "isVatLabelLegallyRequired": false,
-      "priceSuperscriptString": "1",
       "isConditionalPrice": false
     },
     "availability": {
@@ -113,34 +80,36 @@
     "vehicle": {
       "licensePlate": null,
       "carpassMileageUrl": null,
-      "makeId": 28,
-      "modelOrModelLineId": 15160,
-      "make": "Fiat",
-      "model": "500",
-      "modelGroup": "500",
-      "variant": "500",
-      "modelId": 15160,
+      "makeId": 70,
+      "modelOrModelLineId": 18655,
+      "make": "Toyota",
+      "model": "Aygo",
+      "modelGroup": "Aygo",
+      "variant": "5 Door",
+      "modelId": 18655,
       "modelGroupIds": [
-        200524
+        201443
       ],
-      "modelGenerationId": 789,
-      "modelVariantId": 3447,
-      "motorTypeId": 1762,
-      "trimLineId": 2586,
-      "modelVersionInput": "Lim. Dolcevita 1.0*PDCh*DAB*Klima*uvm",
+      "modelGenerationId": 1214,
+      "modelVariantId": 3888,
+      "motorTypeId": null,
+      "motorTypeName": null,
+      "trimLineId": 8523,
+      "modelVersionInput": "1.0 VVT-i x-play Cruise control",
+      "modelVersionCustom": null,
       "type": "Car",
-      "hsnTsn": "1727/AUD",
-      "mileageInKmRaw": 28558,
-      "mileageInKm": "28,558 km",
-      "firstRegistrationDateRaw": "2022-10-01",
-      "firstRegistrationDate": "10/2022",
-      "bodyType": "Sedan",
+      "hsnTsn": null,
+      "mileageInKmRaw": 194048,
+      "mileageInKm": "194,048 km",
+      "firstRegistrationDateRaw": "2014-10-01",
+      "firstRegistrationDate": "10/2014",
+      "bodyType": "Compact",
       "numberOfSeats": 4,
-      "numberOfDoors": 3,
-      "bodyColor": "White",
-      "bodyColorRaw": "White",
-      "paintType": "Metallic",
-      "bodyColorOriginal": "Weiß",
+      "numberOfDoors": 5,
+      "bodyColor": "Red",
+      "bodyColorRaw": "Red",
+      "paintType": null,
+      "bodyColorOriginal": "Rood",
       "engineHours": "",
       "fuelDeliveryType": "",
       "engineCoolingSystem": "",
@@ -171,27 +140,27 @@
       "engineMountingType": null,
       "engineCount": null,
       "isCabinClean": false,
-      "upholstery": "Part leather",
-      "upholsteryColor": "White",
+      "upholstery": "Cloth",
+      "upholsteryColor": "Grey",
       "marketingDescription": "",
       "controlModuleName": "",
-      "powerInKw": "52 kW",
-      "powerInHp": "71 hp",
-      "rawPowerInKw": 52,
-      "rawPowerInHp": 71,
+      "powerInKw": "51 kW",
+      "powerInHp": "69 hp",
+      "rawPowerInKw": 51,
+      "rawPowerInHp": 69,
       "transmissionType": "Manual",
-      "gears": 6,
+      "gears": 5,
       "cylinders": 3,
       "driveTrain": "Front Wheel Drive",
-      "displacementInCCM": "999 cc",
-      "rawDisplacementInCCM": 999,
-      "cylinderCapacity": "999 cc",
-      "rawCylinderCapacity": 999,
-      "weight": "1,055 kg",
+      "displacementInCCM": "998 cc",
+      "rawDisplacementInCCM": 998,
+      "cylinderCapacity": "998 cc",
+      "rawCylinderCapacity": 998,
+      "weight": "830 kg",
       "hasParticleFilter": false,
       "fuelCategory": {
-        "raw": "2",
-        "formatted": "Electric/Gasoline"
+        "raw": "B",
+        "formatted": "Gasoline"
       },
       "batteryOwnershipType": {
         "raw": null,
@@ -210,25 +179,10 @@
         "formatted": null
       },
       "primaryFuel": {
-        "raw": 5,
-        "formatted": "Super E10 95"
+        "raw": null,
+        "formatted": null
       },
-      "additionalFuel": [
-        {
-          "raw": 12,
-          "formatted": "Electricity",
-          "consumptionCombined": {
-            "raw": null,
-            "formatted": "- (kWh/100 km)",
-            "isFallback": false
-          },
-          "co2emissionInGramPerKmWithFallback": {
-            "raw": null,
-            "formatted": null,
-            "isFallback": null
-          }
-        }
-      ],
+      "additionalFuel": [],
       "fuelConsumptionCombined": {
         "raw": null,
         "formatted": "- (l/100 km)",
@@ -249,16 +203,12 @@
       },
       "wltp": {
         "co2EmissionsCombinedWithFallback": {
-          "raw": 106,
-          "formatted": "106 g/km (comb.)",
+          "raw": 88,
+          "formatted": "88 g/km (comb.)",
           "isFallback": false
         },
         "co2EmissionsCombinedWeightedWithFallback": null,
-        "consumptionCombinedWithFallback": {
-          "raw": 4.7,
-          "formatted": "4.7 l/100 km (comb.)",
-          "isFallback": false
-        },
+        "consumptionCombinedWithFallback": null,
         "consumptionElectricCombinedWithFallback": null,
         "consumptionCombinedWeightedWithFallback": null,
         "consumptionElectricCombinedWeightedWithFallback": null,
@@ -283,11 +233,6 @@
       "equipment": {
         "comfortAndConvenience": [
           {
-            "id": "Air conditioning",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
             "id": "Cruise control",
             "categoryName": "Comfort & Convenience",
             "categoryId": "comfortAndConvenience"
@@ -308,32 +253,7 @@
             "categoryId": "comfortAndConvenience"
           },
           {
-            "id": "Multi-function steering wheel",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Panorama roof",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Park Distance Control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system sensors rear",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
             "id": "Power windows",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Rain sensor",
             "categoryName": "Comfort & Convenience",
             "categoryId": "comfortAndConvenience"
           },
@@ -343,70 +263,6 @@
             "categoryId": "comfortAndConvenience"
           }
         ],
-        "entertainmentAndMedia": [
-          {
-            "id": "Android Auto",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Apple CarPlay",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Bluetooth",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Digital radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Hands-free equipment",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "MP3",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "On-board computer",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "USB",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          }
-        ],
-        "extras": [
-          {
-            "id": "Alloy wheels",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "E10-enabled",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Touch screen",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          }
-        ],
         "safetyAndSecurity": [
           {
             "id": "ABS",
@@ -414,7 +270,17 @@
             "categoryId": "safetyAndSecurity"
           },
           {
+            "id": "Central door lock",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
             "id": "Central door lock with remote control",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Daytime running lights",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
           },
@@ -429,6 +295,11 @@
             "categoryId": "safetyAndSecurity"
           },
           {
+            "id": "Emergency brake assistant",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
             "id": "Head airbag",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
@@ -439,12 +310,12 @@
             "categoryId": "safetyAndSecurity"
           },
           {
-            "id": "Isofix",
+            "id": "LED Daytime Running Lights",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
           },
           {
-            "id": "LED Daytime Running Lights",
+            "id": "LED Headlights",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
           },
@@ -454,17 +325,12 @@
             "categoryId": "safetyAndSecurity"
           },
           {
-            "id": "Power steering",
+            "id": "Rear airbag",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
           },
           {
             "id": "Side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Speed limit control system",
             "categoryName": "Safety & Security",
             "categoryId": "safetyAndSecurity"
           },
@@ -483,33 +349,27 @@
       "environmentPkwEnVKV": null,
       "environmentEuDirective": {
         "description": null,
-        "formatted": "Euro 6d",
-        "label": "EURO6d",
+        "formatted": "Euro 5",
+        "label": "EURO5",
         "isFallback": false,
-        "co2EfficiencyClass": "EURO6d"
+        "co2EfficiencyClass": "EURO5"
       },
-      "environmentBImSchV35": {
-        "description": null,
-        "formatted": "4 (Green)",
-        "label": "Green",
-        "isFallback": false,
-        "co2EfficiencyClass": "Green"
-      },
-      "originalMarket": "Germany",
+      "environmentBImSchV35": null,
+      "originalMarket": null,
       "legalCategories": [
         "Used"
       ],
       "legalCategoriesRaw": [
         "UsedVehicle"
       ],
-      "hadAccident": false,
+      "hadAccident": null,
       "damageConditions": [],
       "newInspection": true,
       "lastBeltServiceDate": null,
       "lastTechnicalServiceDate": null,
       "hasFullServiceHistory": true,
-      "nonSmoking": true,
-      "noOfPreviousOwners": 1,
+      "nonSmoking": false,
+      "noOfPreviousOwners": null,
       "nextVehicleSafetyInspection": null,
       "isRental": false,
       "numberOfBeds": null,
@@ -544,47 +404,39 @@
           "type": "Car",
           "modelYear": null,
           "make": {
-            "raw": 28,
-            "formatted": "Fiat"
+            "raw": 70,
+            "formatted": "Toyota"
           },
           "model": {
-            "raw": 15160,
-            "formatted": "500"
+            "raw": 18655,
+            "formatted": "Aygo"
           },
           "modelGroups": [
             {
-              "raw": 200524,
-              "formatted": "500"
+              "raw": 201443,
+              "formatted": "Aygo"
             }
           ],
           "modelGeneration": {
-            "raw": 789,
-            "formatted": "312"
+            "raw": 1214,
+            "formatted": "AB1"
           },
           "modelVariant": {
-            "raw": 3447,
-            "formatted": "500"
+            "raw": 3888,
+            "formatted": "5 Door"
           },
-          "motorType": {
-            "raw": 1762
-          },
+          "motorType": null,
           "trimLine": {
-            "raw": 2586
+            "raw": 8523
           },
-          "modelVersionInput": "Lim. Dolcevita 1.0*PDCh*DAB*Klima*uvm",
-          "germanHsnTsn": {
-            "formatted": "1727/AUD"
-          }
+          "modelVersionInput": "1.0 VVT-i x-play Cruise control",
+          "modelVersionCustom": null,
+          "germanHsnTsn": null
         },
         "fuels": {
-          "isPluginHybrid": {
-            "raw": false
-          },
+          "isPluginHybrid": null,
           "primary": {
-            "type": {
-              "raw": 5,
-              "formatted": "Super E10 95"
-            },
+            "type": null,
             "consumption": {
               "combinedWithFallback": {
                 "raw": null,
@@ -600,38 +452,19 @@
               "isFallback": false
             }
           },
-          "additional": [
-            {
-              "type": {
-                "raw": 12,
-                "formatted": "Electricity"
-              },
-              "consumption": {
-                "combinedWithFallback": {
-                  "raw": null,
-                  "formatted": "- (kWh/100 km)",
-                  "isFallback": false
-                }
-              },
-              "co2emissionInGramPerKmWithFallback": null
-            }
-          ],
+          "additional": [],
           "fuelCategory": {
-            "raw": "2",
-            "formatted": "Electric/Gasoline"
+            "raw": "B",
+            "formatted": "Gasoline"
           },
           "wltp": {
             "co2EmissionsCombinedWithFallback": {
-              "raw": 106,
-              "formatted": "106 g/km (comb.)",
+              "raw": 88,
+              "formatted": "88 g/km (comb.)",
               "isFallback": false
             },
             "co2EmissionsCombinedWeightedWithFallback": null,
-            "consumptionCombinedWithFallback": {
-              "raw": 4.7,
-              "formatted": "4.7 l/100 km (comb.)",
-              "isFallback": false
-            },
+            "consumptionCombinedWithFallback": null,
             "consumptionElectricCombinedWithFallback": null,
             "consumptionCombinedWeightedWithFallback": null,
             "consumptionElectricCombinedWeightedWithFallback": null,
@@ -659,17 +492,17 @@
         },
         "engine": {
           "engineDisplacementInCCM": {
-            "raw": 999,
-            "formatted": "999 cc"
+            "raw": 998,
+            "formatted": "998 cc"
           },
           "power": {
             "kw": {
-              "raw": 52,
-              "formatted": "52 kW"
+              "raw": 51,
+              "formatted": "51 kW"
             },
             "hp": {
-              "raw": 71,
-              "formatted": "71 hp"
+              "raw": 69,
+              "formatted": "69 hp"
             }
           },
           "transmissionType": {
@@ -678,47 +511,47 @@
           },
           "numberOfCylinders": 3,
           "cylinderCapacity": {
-            "raw": 999,
+            "raw": 998,
             "unit": "ccm",
-            "formatted": "999 cc"
+            "formatted": "998 cc"
           },
-          "numberOfGears": 6,
+          "numberOfGears": 5,
           "driveTrain": {
             "formatted": "Front Wheel Drive"
           }
         },
         "condition": {
           "firstRegistrationDate": {
-            "raw": "2022-10-01",
-            "formatted": "10/2022"
+            "raw": "2014-10-01",
+            "formatted": "10/2014"
           },
           "mileageInKm": {
-            "raw": 28558,
-            "formatted": "28,558 km"
+            "raw": 194048,
+            "formatted": "194,048 km"
           },
           "numberOfPreviousOwnersExtended": {
-            "raw": 1,
-            "formatted": "1 previous owner"
+            "raw": null,
+            "formatted": "- (Previous Owners)"
           },
           "damage": {
-            "isCurrentlyDamaged": false,
-            "isRoadworthy": true,
-            "accidentFree": true,
-            "hasRepairedDamages": false,
+            "isCurrentlyDamaged": null,
+            "isRoadworthy": null,
+            "accidentFree": null,
+            "hasRepairedDamages": null,
             "damageConditions": []
           },
-          "nonSmoking": true,
+          "nonSmoking": false,
           "newInspection": true,
           "isCabinClean": null,
           "carpassMileageUrl": null
         },
         "bodyType": {
-          "formatted": "Sedan",
-          "raw": "Sedan"
+          "formatted": "Compact",
+          "raw": "Compact"
         },
         "bodyColor": {
-          "raw": "White",
-          "formatted": "White"
+          "raw": "Red",
+          "formatted": "Red"
         },
         "numberOfBeds": {
           "raw": null,
@@ -731,26 +564,23 @@
         "grossVehicleWeight": null,
         "wheelBase": null,
         "costModel": null,
-        "numberOfDoors": 3,
-        "paintType": {
-          "formatted": "Metallic"
-        },
-        "bodyColorOriginal": "Weiß",
+        "numberOfDoors": 5,
+        "paintType": null,
+        "bodyColorOriginal": "Rood",
         "interior": {
           "numberOfSeats": 4,
           "upholstery": {
-            "formatted": "Part leather"
+            "formatted": "Cloth"
           },
           "upholsteryColor": {
-            "formatted": "White"
+            "formatted": "Grey"
           }
         },
         "emptyWeight": {
-          "formatted": "1,055 kg"
+          "formatted": "830 kg"
         },
         "identifier": {
-          "licensePlate": null,
-          "vin": "ZFACF1CJ5NJG89146"
+          "licensePlate": null
         },
         "totalHeight": null,
         "totalWidth": null,
@@ -767,33 +597,16 @@
           "particulateFilter": false,
           "environmentLabelsWithFallback": [
             {
-              "norm": "BImSchV_35",
-              "description": null,
-              "formatted": "4 (Green)",
-              "label": "Green",
-              "isFallback": false
-            },
-            {
               "norm": "EU_Directive_70_220_EEC_LDV",
               "description": null,
-              "formatted": "Euro 6d",
-              "label": "EURO6d",
+              "formatted": "Euro 5",
+              "label": "EURO5",
               "isFallback": false
             }
           ]
         },
         "equipment": {
           "as24": [
-            {
-              "id": {
-                "raw": 5,
-                "formatted": "Air conditioning"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
             {
               "id": {
                 "raw": 38,
@@ -836,58 +649,8 @@
             },
             {
               "id": {
-                "raw": 114,
-                "formatted": "Multi-function steering wheel"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 50,
-                "formatted": "Panorama roof"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 40,
-                "formatted": "Park Distance Control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 129,
-                "formatted": "Parking assist system sensors rear"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
                 "raw": 13,
                 "formatted": "Power windows"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 127,
-                "formatted": "Rain sensor"
               },
               "equipmentCategory": {
                 "raw": "comfortAndConvenience",
@@ -906,126 +669,6 @@
             },
             {
               "id": {
-                "raw": 222,
-                "formatted": "Android Auto"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 221,
-                "formatted": "Apple CarPlay"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 122,
-                "formatted": "Bluetooth"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 138,
-                "formatted": "Digital radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 124,
-                "formatted": "Hands-free equipment"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 43,
-                "formatted": "MP3"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 41,
-                "formatted": "On-board computer"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 10,
-                "formatted": "Radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 161,
-                "formatted": "USB"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 15,
-                "formatted": "Alloy wheels"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 173,
-                "formatted": "E10-enabled"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 159,
-                "formatted": "Touch screen"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
                 "raw": 1,
                 "formatted": "ABS"
               },
@@ -1036,8 +679,28 @@
             },
             {
               "id": {
+                "raw": 17,
+                "formatted": "Central door lock"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
                 "raw": 47,
                 "formatted": "Central door lock with remote control"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 115,
+                "formatted": "Daytime running lights"
               },
               "equipmentCategory": {
                 "raw": "safetyAndSecurity",
@@ -1066,6 +729,16 @@
             },
             {
               "id": {
+                "raw": 148,
+                "formatted": "Emergency brake assistant"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
                 "raw": 46,
                 "formatted": "Head airbag"
               },
@@ -1086,8 +759,8 @@
             },
             {
               "id": {
-                "raw": 125,
-                "formatted": "Isofix"
+                "raw": 141,
+                "formatted": "LED Daytime Running Lights"
               },
               "equipmentCategory": {
                 "raw": "safetyAndSecurity",
@@ -1096,8 +769,8 @@
             },
             {
               "id": {
-                "raw": 141,
-                "formatted": "LED Daytime Running Lights"
+                "raw": 140,
+                "formatted": "LED Headlights"
               },
               "equipmentCategory": {
                 "raw": "safetyAndSecurity",
@@ -1116,8 +789,8 @@
             },
             {
               "id": {
-                "raw": 12,
-                "formatted": "Power steering"
+                "raw": 45,
+                "formatted": "Rear airbag"
               },
               "equipmentCategory": {
                 "raw": "safetyAndSecurity",
@@ -1128,16 +801,6 @@
               "id": {
                 "raw": 32,
                 "formatted": "Side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 227,
-                "formatted": "Speed limit control system"
               },
               "equipmentCategory": {
                 "raw": "safetyAndSecurity",
@@ -1167,9 +830,7 @@
           ]
         },
         "alloyWheelInches": null,
-        "originalMarket": {
-          "formatted": "Germany"
-        },
+        "originalMarket": null,
         "maintenance": {
           "nextVehicleSafetyInspection": null,
           "lastBeltServiceDate": null,
@@ -1179,149 +840,94 @@
           "lastTechnicalServiceDate": null
         },
         "newDriverSuitable": null
-      },
-      "identifier": {
-        "vin": "ZFACF1CJ5NJG89146"
       }
     },
     "identifier": {
-      "offerReference": "4002490",
+      "offerReference": null,
       "legacyId": null,
-      "crossReferenceId": "69ca1ed74da10ecf1d0603a6"
+      "crossReferenceId": "50476874"
     },
     "seals": null,
     "location": {
-      "countryCode": "DE",
-      "zip": "37574",
-      "city": "Einbeck",
-      "street": "Hannoversche Strasse 24",
-      "latitude": 51.82131,
-      "longitude": 9.8509
+      "countryCode": "NL",
+      "zip": "1704 RM",
+      "city": "HEERHUGOWAARD",
+      "street": "Nobelstraat 8",
+      "latitude": 52.67792,
+      "longitude": 4.83166
     },
     "seller": {
-      "id": 50433550,
-      "sellId": 197000051,
+      "id": 60485689,
+      "sellId": 2142275740,
       "isDealer": true,
       "type": "Dealer",
-      "companyName": "Autohaus Siebrecht GmbH",
-      "contactName": "Ihr Verkaufsteam",
+      "companyName": "DVW Automotive",
+      "contactName": "Afdeling Verkoop",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-15449a76-bc51-4bbd-a9a2-59a715f30ea5.jpg/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/60485689-original-53059786-0912-486e-a08a-5147bfd0d8fa.jpeg/resize/100x50%3E/quality/90"
         },
         "big": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-15449a76-bc51-4bbd-a9a2-59a715f30ea5.jpg/resize/200x100%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/60485689-original-53059786-0912-486e-a08a-5147bfd0d8fa.jpeg/resize/200x100%3E/quality/90"
         }
       },
       "links": {
-        "infoPage": "https://www.autoscout24.com/dealerinfo/autohaus-siebrecht-gmbh-einbeck-37574-1/about-us",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-siebrecht-gmbh-einbeck-37574-1/imprint",
-        "stockLink": "https://www.autoscout24.com/dealerinfo/autohaus-siebrecht-gmbh-einbeck-37574-1?atype=C"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/dvw-automotive/about-us",
+        "imprint": "https://www.autoscout24.com/dealerinfo/dvw-automotive/imprint",
+        "stockLink": "https://www.autoscout24.com/dealerinfo/dvw-automotive?atype=C"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+49 (0)5571 - 92304722",
-          "callTo": "+49557192304722"
+          "formattedNumber": "+31 (0)728 - 080666",
+          "callTo": "+31728080666"
         },
         {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)5571 - 92304747",
-          "callTo": "+49557192304747"
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 18601870",
+          "callTo": "+31618601870"
         }
       ],
       "dealer": {
         "maxImages": 50,
-        "culture": "de-DE",
+        "isSMSLeadsEnabled": false,
+        "culture": "nl-NL",
         "isFreespeeCallTrackingEnabled": true,
+        "isBestPricedDealer": false,
         "tieredPricingPackage": "PRO",
         "autoMatchPackage": {
           "tier": "high"
         },
         "hasMyVehiclesRecommenderCarousel": true,
+        "similarVehiclesRecommenderTop": false,
         "superbranding": {
           "images": {
-            "dealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-48a588dd-05fc-4a31-ab21-7389c8c32b3a.png/resize/800x500%3E/quality/90",
+            "dealershipExterior": null,
             "dealershipInterior": null,
-            "mediumDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-48a588dd-05fc-4a31-ab21-7389c8c32b3a.png/resize/800x500%3E/quality/90",
-            "smallDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-48a588dd-05fc-4a31-ab21-7389c8c32b3a.png/resize/800x500%3E/quality/90",
+            "mediumDealershipExterior": null,
+            "smallDealershipExterior": null,
             "smallDealershipInterior": null,
             "mediumDealershipInterior": null
           },
           "contactPerson": {
-            "image": "https://prod.pictures.autoscout24.net/dealer-info/50433588-original-0e3d0d05-a41e-47da-ae56-7e7a81e08815.jpg/resize/200x100%3E/quality/90",
-            "languages": [
-              {
-                "id": "GERMAN",
-                "name": "Deutsch"
-              },
-              {
-                "id": "ENGLISH",
-                "name": "English"
-              }
-            ],
-            "name": "Kundenkontaktcenter",
-            "position": "Verkauf & Kundenservice"
+            "image": null,
+            "languages": null,
+            "name": null,
+            "position": null
           }
         },
         "covidServices": null,
-        "openingHours": {
-          "department": "Verkauf",
-          "state": "open",
-          "statusLabel": "Open",
-          "infoLabel": "Closes at 18:00"
-        },
-        "openingHoursRaw": [
-          {
-            "department": "Verkauf",
-            "timetable": [
-              [
-                730,
-                1230,
-                1230,
-                1800
-              ],
-              [
-                730,
-                1230,
-                1230,
-                1800
-              ],
-              [
-                730,
-                1230,
-                1230,
-                1800
-              ],
-              [
-                730,
-                1230,
-                1230,
-                1800
-              ],
-              [
-                730,
-                1230,
-                1230,
-                1800
-              ],
-              [
-                800,
-                1200
-              ],
-              []
-            ]
-          }
-        ],
-        "homepageUrl": "https://echt.autos",
+        "openingHours": null,
+        "openingHoursRaw": null,
+        "homepageUrl": null,
         "googleRatings": null,
-        "customerSince": 2025,
+        "customerSince": 2026,
         "region": null,
         "nationwideListingsData": null
       }
     },
-    "whatsappNumber": "+49 (0)5571 - 92304747",
-    "webPage": "https://www.autoscout24.com/offers/fiat-500-lim-dolcevita-1-0-pdch-dab-klima-uvm-electric-gasoline-white-117b7cf9-f7e8-449c-bfdd-cfd449484f99",
+    "whatsappNumber": "+31 (0)6 - 18601870",
+    "webPage": "https://www.autoscout24.com/offers/toyota-aygo-1-0-vvt-i-x-play-cruise-control-gasoline-red-cat_ma70mo18655-56fe41bc-c72f-4fa2-8fc3-310340b0a82d",
     "status": "Active",
     "leasingDetails": null,
     "warranty": null,
@@ -1330,19 +936,20 @@
       "__typename": "NotOcs"
     },
     "financingAndInsurance": {
-      "buttonWithFinance": [
+      "buttonWithFinance": [],
+      "buttonWithInsurance": [
         {
           "id": null,
           "location": "Stage",
-          "productType": "Edf",
+          "productType": "Anwb",
           "stage": {
-            "rate": 167,
+            "rate": null,
             "link": {
-              "url": null,
+              "url": "https://ad.doubleclick.net/ddm/trackclk/N59701.135402AUTOSCOUT24.NL/B21621491.227696077;dc_trk_aid=425745719;dc_trk_cid=105284009;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;tfua=?https://www.anwb.nl/verzekeringen/autoverzekering/regulier/berekenen?utm_source=autoscout_calculator_sell_vz_avz&utm_medium=display&utm_campaign=sell_vz_avz&utm_content=autoscout_detailpagina_calculator",
               "caption": "",
-              "text": "request financing",
+              "text": "",
               "tracking": {
-                "linkId": "edf-stage-widget",
+                "linkId": "anwb-fb-stage-widget",
                 "linkGroup": {
                   "click": "dp-finance-click",
                   "impr": "dp-finance-impr"
@@ -1352,58 +959,42 @@
           },
           "overlay": {
             "price": {
-              "raw": 13270,
-              "formatted": "€ 13.270,-",
-              "translation": {
-                "value": "Cash price"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
-            "pageTitle": {
-              "value": "Dealer financing example"
-            },
+            "pageTitle": null,
             "rate": {
-              "raw": 167,
-              "formatted": "€ 167,-",
-              "translation": {
-                "value": "Monthly rate"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "staticTexts": null,
             "financingDisclaimer": null,
             "duration": {
-              "raw": 36,
-              "formatted": "36 Months",
-              "translation": {
-                "value": "Term"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "creditAmount": {
-              "raw": 10776,
-              "formatted": "€ 10.776,-",
-              "translation": {
-                "value": "Net loan amount"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "interest": {
-              "raw": 6.99,
-              "formatted": "6,99 %",
-              "translation": {
-                "value": "Effective annual interest"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "debitInterest": {
-              "raw": 6.78,
-              "formatted": "6,78 %",
-              "translation": {
-                "value": "Fixed borrowing rate p.a."
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "totalAmount": {
-              "raw": 10775.9974,
-              "formatted": "€ 10.776,-",
-              "translation": {
-                "value": "Gross loan amount"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "offerDuration": {
               "raw": null,
@@ -1411,24 +1002,20 @@
               "translation": null
             },
             "deposit": {
-              "raw": 2694.0053,
-              "formatted": "€ 2.694,01",
-              "translation": {
-                "value": "Down payment"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "disclaimer": {
-              "value": "2/3 of customers receive 6,99 % effective annual interest rate, 6,78 % fixed borrowing rate p.a., total amount € 10.776,-, net loan amount € 10.776,-, 36 monthly installments of € 167,-"
+              "value": null
             },
             "bank": {
-              "value": "Bank Deutsches Kraftfahrzeuggewerbe"
+              "value": null
             },
             "balloon": {
-              "raw": 6735,
-              "formatted": "€ 6.735,-",
-              "translation": {
-                "value": "Final installment"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "firstInstallment": {
               "raw": null,
@@ -1448,11 +1035,9 @@
             "jsonData": null,
             "proxyOffering": null,
             "serviceFee": {
-              "raw": 0,
-              "formatted": "€ 0,-",
-              "translation": {
-                "value": "Processing fees"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "durations": null,
             "loanThreshold": null,
@@ -1522,15 +1107,15 @@
         {
           "id": null,
           "location": "Slice",
-          "productType": "Edf",
+          "productType": "Anwb",
           "stage": {
-            "rate": 167,
+            "rate": null,
             "link": {
-              "url": null,
+              "url": "https://ad.doubleclick.net/ddm/trackclk/N59701.135402AUTOSCOUT24.NL/B21621491.227696077;dc_trk_aid=425745719;dc_trk_cid=105284009;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;tfua=?https://www.anwb.nl/verzekeringen/autoverzekering/regulier/berekenen?utm_source=autoscout_calculator_sell_vz_avz&utm_medium=display&utm_campaign=sell_vz_avz&utm_content=autoscout_detailpagina_calculator",
               "caption": "",
-              "text": "request financing",
+              "text": "",
               "tracking": {
-                "linkId": "edf-slice-widget",
+                "linkId": "anwb-fb-slice-widget",
                 "linkGroup": {
                   "click": "dp-finance-click",
                   "impr": "dp-finance-impr"
@@ -1540,58 +1125,42 @@
           },
           "overlay": {
             "price": {
-              "raw": 13270,
-              "formatted": "€ 13.270,-",
-              "translation": {
-                "value": "Cash price"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
-            "pageTitle": {
-              "value": "Dealer financing example"
-            },
+            "pageTitle": null,
             "rate": {
-              "raw": 167,
-              "formatted": "€ 167,-",
-              "translation": {
-                "value": "Monthly rate"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "staticTexts": null,
             "financingDisclaimer": null,
             "duration": {
-              "raw": 36,
-              "formatted": "36 Months",
-              "translation": {
-                "value": "Term"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "creditAmount": {
-              "raw": 10776,
-              "formatted": "€ 10.776,-",
-              "translation": {
-                "value": "Net loan amount"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "interest": {
-              "raw": 6.99,
-              "formatted": "6,99 %",
-              "translation": {
-                "value": "Effective annual interest"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "debitInterest": {
-              "raw": 6.78,
-              "formatted": "6,78 %",
-              "translation": {
-                "value": "Fixed borrowing rate p.a."
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "totalAmount": {
-              "raw": 10775.9974,
-              "formatted": "€ 10.776,-",
-              "translation": {
-                "value": "Gross loan amount"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "offerDuration": {
               "raw": null,
@@ -1599,24 +1168,20 @@
               "translation": null
             },
             "deposit": {
-              "raw": 2694.0053,
-              "formatted": "€ 2.694,01",
-              "translation": {
-                "value": "Down payment"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "disclaimer": {
-              "value": "2/3 of customers receive 6,99 % effective annual interest rate, 6,78 % fixed borrowing rate p.a., total amount € 10.776,-, net loan amount € 10.776,-, 36 monthly installments of € 167,-"
+              "value": null
             },
             "bank": {
-              "value": "Bank Deutsches Kraftfahrzeuggewerbe"
+              "value": null
             },
             "balloon": {
-              "raw": 6735,
-              "formatted": "€ 6.735,-",
-              "translation": {
-                "value": "Final installment"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "firstInstallment": {
               "raw": null,
@@ -1636,15 +1201,2720 @@
             "jsonData": null,
             "proxyOffering": null,
             "serviceFee": {
-              "raw": 0,
-              "formatted": "€ 0,-",
-              "translation": {
-                "value": "Processing fees"
-              }
+              "raw": null,
+              "formatted": null,
+              "translation": null
             },
             "durations": null,
             "loanThreshold": null,
             "buttons": null,
+            "partiallyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "fullyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "check24Disclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "extendedDisclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "stage": {
+              "rate": null,
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "hasLowestInterestRate": null
+          }
+        }
+      ],
+      "buttonWithLeasing": []
+    },
+    "trackingParams": {
+      "classified_recency": "new",
+      "classified_makeId": 70,
+      "classified_makeTxt": "toyota",
+      "classified_modelID": 18655,
+      "classified_modelGroupID": 201443,
+      "classified_modelTxt": "aygo",
+      "classified_mileage": 194048,
+      "classified_power": 51,
+      "classified_price": 3950,
+      "classified_fueltype": "b",
+      "classified_transmission": "m",
+      "classified_equipment": "38,121,137,142,13,113,1,17,47,115,2,42,148,46,26,141,140,3,45,32,150,31",
+      "classified_offerType": "u",
+      "classified_doors": 5,
+      "classified_seats": 4,
+      "classified_customer_type": "d",
+      "classified_customerID": "60485689",
+      "classified_zipcode": "1704 RM",
+      "classified_year": "2014",
+      "classified_capacity": 998,
+      "classified_bodyType": 1,
+      "classified_carSegment": "microcar,subcompact",
+      "classified_country": "NL",
+      "classified_emissionStandard": 5,
+      "classified_tier": "t50",
+      "classified_applied_tier": "t50",
+      "classified_images_threesixty": "standard",
+      "classified_dealerPackage": "pro",
+      "classified_exclusiveOffer": "false",
+      "classified_leadsRange": "zero",
+      "classified_imageContent": "no-placeholder|0.20131681993242156",
+      "classified_isSmyleEligible": "false",
+      "classified_ownershipModels": "tr"
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "specialConditions": [],
+    "hasPremiumListingTreatment": true,
+    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"microcar,subcompact\",\"did\":\"60485689\",\"stmil\":\"194048\",\"gear\":\"M\",\"make\":\"70\",\"stmak\":\"Toyota\",\"model\":\"18655\",\"stmod\":\"Aygo\",\"cost\":\"3950\",\"stmon\":\"10\",\"styea\":\"2014\",\"ad\":\"dealer\",\"vat\":\"0\",\"art\":\"1\",\"carby\":\"0\",\"fr\":\"6\",\"stccm\":\"998\",\"buyonline\":\"false\",\"stkw\":\"51\",\"sthp\":\"69\",\"equi\":\"32,1,2,3,38,137,42,140,13,45,141,46,142,47,17,113,115,148,150,121,26,31,120,49\",\"miles\":\"9\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_c5a34cdf-a907-4416-a56d-9918bb4a4030.jpg/720x540.webp\",\"price\":\"1\",\"rnd\":\"39\",\"ECO\":\"NO\",\"fuel\":\"B\",\"kenteken\":\"false\",\"acc\":\"U\",\"hp\":\"2\",\"mgroupid\":\"201443\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"NL1704 RM\",\"zip2\":\"1704 RM\",\"articleType\":\"C\",\"tiered\":\"pro\"}",
+    "statistics": {
+      "leadsRange": "Zero"
+    },
+    "imgAltText": "Toyota Aygo 1.0 VVT-i x-play Cruise control Red",
+    "createdTimestampWithOffset": "2026-08-20T07:46:49.365Z",
+    "vehicleType": "ice",
+    "searchTrackingParams": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "organic"
+      },
+      {
+        "key": "boosting_product",
+        "value": "none"
+      }
+    ],
+    "articleType": "car",
+    "isNew": true
+  },
+  {
+    "id": "0c344a98-edd9-46bd-b0d4-bf24792ecc77",
+    "searchResultType": "Organic",
+    "isDeliverable": false,
+    "description": "Citroën C1 1.0 12V Ambiance uit 2010 met 167.xxx km op de teller. Een compacte en praktische benzineauto die dankzij zijn lage gewicht en handzame formaat uitstekend geschikt is voor dagelijks gebruik. De C1 is gemakkelijk te rijden, eenvoudig te parkeren en daardoor een fijne keuze als bijvoorbeeld eerste auto, boodschappenauto of voor dagelijks woon-werkverkeer.<br /><br />De 1.0 12V benzinemotor past goed bij het compacte karakter van de C1. Dankzij het overzichtelijke formaat voelt de auto zich vooral in de stad helemaal thuis, maar ook voor ritten buiten de stad is hij prima inzetbaar.<br /><br />Voor extra comfort is deze C1 voorzien van airconditioning. Vooral tijdens warme zomerdagen is dit een prettige optie. Daarnaast beschikt de auto over elektrisch bedienbare ramen, wat het dagelijkse gebruik net wat gemakkelijker maakt.<br /><br />Een mooi pluspunt is de lange APK. Deze Citroën is APK-goedgekeurd tot mei 2027, waardoor de volgende APK voorlopig nog niet aan de orde is.<br /><br />Ondanks zijn compacte buitenmaten biedt de C1 verrassend veel gebruiksgemak. De auto neemt weinig ruimte in beslag en is daardoor gemakkelijk te manoeuvreren op krappe parkeerplaatsen. Tegelijkertijd is er binnenin voldoende ruimte voor dagelijks gebruik.<br /><br />Kortom, een praktische Citroën C1 met de bekende 1.0 benzinemotor en een lange APK tot mei 2027. Met onder andere airconditioning en elektrische ramen is hij voorzien van fijne opties voor dagelijks gebruik. Een leuke en compacte auto voor wie op zoek is naar eenvoudig en betaalbaar vervoer.<br /><br />Interesse? Neem gerust contact met ons op voor meer informatie of voor een bezichtiging of proefrit.<br />Bij Van der Kolk Auto&#x27;s staan we garant voor kwaliteit en betrouwbaarheid. Elke auto die ons terrein verlaat, wordt grondig gecontroleerd en voorzien van 3 maanden garantie. Zo kun je met een gerust hart de weg op, wetende dat je een auto van hoge kwaliteit hebt gekocht. Ontdek ons ruime assortiment en vind de perfecte auto voor jouw behoeften bij Van der Kolk Auto&#x27;s.<br /><br />Uiteraard doen wij ons best deze advertentie zo goed mogelijk te plaatsen, echter is fouten maken menselijk, aan deze advertentie kunnen dus geen rechten worden ontleend. En controleer bij twijfel de opties in de auto.<br /><br /><strong>van der Kolk auto&#x27;s</strong><br />De Grift 4<br />7711 EPNieuwleusen<br />+31615218890<br />info@vanderkolkautos.nl<br /> <br />vanderkolkautos.nl",
+    "ratings": null,
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_66335ab8-96ff-4dcb-962f-29ebf73055d2.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_9954ff6f-d386-45c7-9e12-6731b6bfd8eb.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_4013e350-37dd-4c44-8f6d-7e2d0c685501.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_32c6318c-cb35-4d3d-a7a3-a1372bcfa138.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_0656ec8d-919c-434c-b1ed-75997a7984af.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_def191e7-4f08-46e6-b888-24e572551ffd.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_0ef19f93-cdb6-4d91-89e5-e4c430204095.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_dadd2941-d283-4291-a0e5-e9d319489425.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_5478804b-eea4-4818-939f-9fa3f292ce33.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_88ec53e3-3b3b-4c4d-a456-cfa9c18e3fba.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_bbf9270a-f736-4980-8838-86f05edcf716.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_852166e3-b998-4b67-8e86-eea88001d2e9.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_e4f8a8e0-d5bf-48e7-81bb-62dde4ba7fc8.jpg/1280x960.webp"
+    ],
+    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_66335ab8-96ff-4dcb-962f-29ebf73055d2.jpg/120x90.webp",
+    "youtubeLink": null,
+    "twinnerUrl": null,
+    "isCoverImagePlaceholder": false,
+    "coverImageAttractiveness": 0.2619919708389691,
+    "hasThreeSixtyContent": false,
+    "vehicleReport": null,
+    "threeSixty": null,
+    "prices": {
+      "isFinalPrice": false,
+      "public": {
+        "price": "€ 1,885",
+        "priceRaw": 1885,
+        "taxDeductible": false,
+        "negotiable": false,
+        "onRequestOnly": false,
+        "netPrice": null,
+        "netPriceRaw": null,
+        "vatRate": null,
+        "category": null,
+        "median": null,
+        "evaluationRanges": null
+      },
+      "dealer": {
+        "price": "€ 1,885",
+        "priceRaw": 1885,
+        "taxDeductible": false,
+        "negotiable": false,
+        "onRequestOnly": false,
+        "netPrice": null,
+        "netPriceRaw": null,
+        "vatRate": null,
+        "category": null,
+        "median": null,
+        "evaluationRanges": null
+      },
+      "suggestedRetail": {
+        "amountInEUR": {
+          "raw": 10585,
+          "formatted": "€ 10,585"
+        }
+      },
+      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/0c344a98-edd9-46bd-b0d4-bf24792ecc77?culture=en-GB",
+      "error": null
+    },
+    "superDeal": null,
+    "price": {
+      "priceFormatted": "€ 1,885",
+      "suggestedRetailPrice": "€ 10,585",
+      "isVatLabelLegallyRequired": false,
+      "isConditionalPrice": false
+    },
+    "availability": {
+      "rawFromDate": null,
+      "fromDate": null,
+      "inDays": null
+    },
+    "financingFlags": {
+      "showStageFinancingAmvLegendSpain": false
+    },
+    "vehicle": {
+      "licensePlate": "86-LXL-2",
+      "carpassMileageUrl": null,
+      "makeId": 21,
+      "modelOrModelLineId": 18651,
+      "make": "Citroen",
+      "model": "C1",
+      "modelGroup": "C1",
+      "variant": "C1",
+      "modelId": 18651,
+      "modelGroupIds": [
+        200305
+      ],
+      "modelGenerationId": 2122,
+      "modelVariantId": 3411,
+      "motorTypeId": 1430,
+      "motorTypeName": "1.0",
+      "trimLineId": 988,
+      "modelVersionInput": "1.0-12V Ambiance | Airco | Elektrische Ramen | Toe",
+      "modelVersionCustom": null,
+      "type": "Car",
+      "hsnTsn": null,
+      "mileageInKmRaw": 167850,
+      "mileageInKm": "167,850 km",
+      "firstRegistrationDateRaw": "2010-07-01",
+      "firstRegistrationDate": "07/2010",
+      "bodyType": "Compact",
+      "numberOfSeats": 4,
+      "numberOfDoors": 3,
+      "bodyColor": "White",
+      "bodyColorRaw": "White",
+      "paintType": null,
+      "bodyColorOriginal": "Biały",
+      "engineHours": "",
+      "fuelDeliveryType": "",
+      "engineCoolingSystem": "",
+      "slideOutCount": null,
+      "chassisManufacturerName": "",
+      "exteriorMaterial": "",
+      "extendedLength": "",
+      "flooringMaterial": "",
+      "fridgePowerType": "",
+      "fridgeCapacity": "",
+      "waterTankCapacity": "",
+      "wasteTankCapacity": "",
+      "engineManufacturerName": "",
+      "axleSpread": "",
+      "brakeType": "",
+      "cabinAxleDistance": "",
+      "differentialRatio": "",
+      "frameType": "",
+      "rearAxleWeightRating": "",
+      "frontAxleWeightRating": "",
+      "trackDimension": "",
+      "skiStanceWidth": "",
+      "fuelCapacity": "",
+      "headCount": null,
+      "hullMaterial": null,
+      "steeringType": null,
+      "auxiliaryPower": null,
+      "engineMountingType": null,
+      "engineCount": null,
+      "isCabinClean": false,
+      "upholstery": null,
+      "upholsteryColor": null,
+      "marketingDescription": "",
+      "controlModuleName": "",
+      "powerInKw": "50 kW",
+      "powerInHp": "68 hp",
+      "rawPowerInKw": 50,
+      "rawPowerInHp": 68,
+      "transmissionType": "Manual",
+      "gears": null,
+      "cylinders": 3,
+      "driveTrain": "Front Wheel Drive",
+      "displacementInCCM": "998 cc",
+      "rawDisplacementInCCM": 998,
+      "cylinderCapacity": "998 cc",
+      "rawCylinderCapacity": 998,
+      "weight": "775 kg",
+      "hasParticleFilter": false,
+      "fuelCategory": {
+        "raw": "B",
+        "formatted": "Gasoline"
+      },
+      "batteryOwnershipType": {
+        "raw": null,
+        "formatted": null
+      },
+      "batteryChargingTime": {
+        "raw": null,
+        "formatted": null
+      },
+      "electricRangeWithFallback": {
+        "raw": null,
+        "formatted": null
+      },
+      "electricRangeCity": {
+        "raw": null,
+        "formatted": null
+      },
+      "primaryFuel": {
+        "raw": null,
+        "formatted": null
+      },
+      "additionalFuel": [],
+      "fuelConsumptionCombined": {
+        "raw": null,
+        "formatted": "- (l/100 km)",
+        "isFallback": false
+      },
+      "fuelConsumptionUrban": {
+        "raw": null,
+        "formatted": null
+      },
+      "fuelConsumptionExtraUrban": {
+        "raw": null,
+        "formatted": null
+      },
+      "co2emissionInGramPerKmWithFallback": {
+        "raw": null,
+        "formatted": "- (g/km)",
+        "isFallback": false
+      },
+      "wltp": {
+        "co2EmissionsCombinedWithFallback": {
+          "raw": 106,
+          "formatted": "106 g/km (comb.)",
+          "isFallback": false
+        },
+        "co2EmissionsCombinedWeightedWithFallback": null,
+        "consumptionCombinedWithFallback": null,
+        "consumptionElectricCombinedWithFallback": null,
+        "consumptionCombinedWeightedWithFallback": null,
+        "consumptionElectricCombinedWeightedWithFallback": null,
+        "co2ClassWithFallback": null,
+        "co2ClassDischarged": null,
+        "consumptionCombinedDischarged": null,
+        "consumptionCity": null,
+        "consumptionSuburban": null,
+        "consumptionRural": null,
+        "consumptionHighway": null,
+        "consumptionElectricCity": null,
+        "consumptionElectricSuburban": null,
+        "consumptionElectricRural": null,
+        "consumptionElectricHighway": null,
+        "consumptionCityDischarged": null,
+        "consumptionSuburbanDischarged": null,
+        "consumptionRuralDischarged": null,
+        "consumptionHighwayDischarged": null,
+        "co2EmissionsDischarged": null
+      },
+      "allFuelTypes": [],
+      "equipment": {
+        "comfortAndConvenience": [
+          {
+            "id": "Air conditioning",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Power windows",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          }
+        ],
+        "entertainmentAndMedia": [
+          {
+            "id": "CD player",
+            "categoryName": "Entertainment & Media",
+            "categoryId": "entertainmentAndMedia"
+          },
+          {
+            "id": "Radio",
+            "categoryName": "Entertainment & Media",
+            "categoryId": "entertainmentAndMedia"
+          }
+        ],
+        "safetyAndSecurity": [
+          {
+            "id": "ABS",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Alarm system",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Central door lock",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Central door lock with remote control",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Driver-side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Immobilizer",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Isofix",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Passenger-side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Power steering",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          }
+        ]
+      },
+      "environmentPkwEnVKV": null,
+      "environmentEuDirective": {
+        "description": null,
+        "formatted": "Euro 4",
+        "label": "EURO4",
+        "isFallback": false,
+        "co2EfficiencyClass": "EURO4"
+      },
+      "environmentBImSchV35": null,
+      "originalMarket": "Netherlands",
+      "legalCategories": [
+        "Used"
+      ],
+      "legalCategoriesRaw": [
+        "UsedVehicle"
+      ],
+      "hadAccident": false,
+      "damageConditions": [],
+      "newInspection": false,
+      "lastBeltServiceDate": null,
+      "lastTechnicalServiceDate": null,
+      "hasFullServiceHistory": false,
+      "nonSmoking": false,
+      "noOfPreviousOwners": null,
+      "nextVehicleSafetyInspection": "05/2027",
+      "isRental": false,
+      "numberOfBeds": null,
+      "numberOfAxles": null,
+      "wheelBase": null,
+      "totalHeight": null,
+      "totalWidth": null,
+      "totalLength": null,
+      "maximumTowingWeight": null,
+      "grossVehicleWeight": null,
+      "payload": null,
+      "loadWidth": null,
+      "loadHeight": null,
+      "loadLength": null,
+      "loadVolume": null,
+      "productionYear": null,
+      "hasCarRegistration": false,
+      "offerType": "U",
+      "newDriverSuitable": null,
+      "rawData": {
+        "totalLength": null,
+        "engineHours": null,
+        "usageState": "U",
+        "productionDate": null,
+        "legalCategories": [
+          {
+            "formatted": "Used",
+            "raw": "UsedVehicle"
+          }
+        ],
+        "classification": {
+          "type": "Car",
+          "modelYear": null,
+          "make": {
+            "raw": 21,
+            "formatted": "Citroen"
+          },
+          "model": {
+            "raw": 18651,
+            "formatted": "C1"
+          },
+          "modelGroups": [
+            {
+              "raw": 200305,
+              "formatted": "C1"
+            }
+          ],
+          "modelGeneration": {
+            "raw": 2122,
+            "formatted": "1. Generation"
+          },
+          "modelVariant": {
+            "raw": 3411,
+            "formatted": "C1"
+          },
+          "motorType": {
+            "raw": 1430,
+            "formatted": "1.0"
+          },
+          "trimLine": {
+            "raw": 988
+          },
+          "modelVersionInput": "1.0-12V Ambiance | Airco | Elektrische Ramen | Toe",
+          "modelVersionCustom": null,
+          "germanHsnTsn": null
+        },
+        "fuels": {
+          "isPluginHybrid": null,
+          "primary": {
+            "type": null,
+            "consumption": {
+              "combinedWithFallback": {
+                "raw": null,
+                "formatted": "- (l/100 km)",
+                "isFallback": false
+              },
+              "urban": null,
+              "extraUrban": null
+            },
+            "co2emissionInGramPerKmWithFallback": {
+              "raw": null,
+              "formatted": "- (g/km)",
+              "isFallback": false
+            }
+          },
+          "additional": [],
+          "fuelCategory": {
+            "raw": "B",
+            "formatted": "Gasoline"
+          },
+          "wltp": {
+            "co2EmissionsCombinedWithFallback": {
+              "raw": 106,
+              "formatted": "106 g/km (comb.)",
+              "isFallback": false
+            },
+            "co2EmissionsCombinedWeightedWithFallback": null,
+            "consumptionCombinedWithFallback": null,
+            "consumptionElectricCombinedWithFallback": null,
+            "consumptionCombinedWeightedWithFallback": null,
+            "consumptionElectricCombinedWeightedWithFallback": null,
+            "co2ClassWithFallback": null,
+            "co2ClassDischarged": null,
+            "consumptionCombinedDischarged": null,
+            "consumptionCity": null,
+            "consumptionSuburban": null,
+            "consumptionRural": null,
+            "consumptionHighway": null,
+            "consumptionElectricCity": null,
+            "consumptionElectricSuburban": null,
+            "consumptionElectricRural": null,
+            "consumptionElectricHighway": null,
+            "consumptionCityDischarged": null,
+            "consumptionSuburbanDischarged": null,
+            "consumptionRuralDischarged": null,
+            "consumptionHighwayDischarged": null,
+            "co2EmissionsDischarged": null
+          },
+          "electricRangeWithFallback": null,
+          "electricRangeCity": null,
+          "allFuelTypes": [],
+          "battery": null
+        },
+        "engine": {
+          "engineDisplacementInCCM": {
+            "raw": 998,
+            "formatted": "998 cc"
+          },
+          "power": {
+            "kw": {
+              "raw": 50,
+              "formatted": "50 kW"
+            },
+            "hp": {
+              "raw": 68,
+              "formatted": "68 hp"
+            }
+          },
+          "transmissionType": {
+            "raw": "Manual",
+            "formatted": "Manual"
+          },
+          "numberOfCylinders": 3,
+          "cylinderCapacity": {
+            "raw": 998,
+            "unit": "ccm",
+            "formatted": "998 cc"
+          },
+          "numberOfGears": null,
+          "driveTrain": {
+            "formatted": "Front Wheel Drive"
+          }
+        },
+        "condition": {
+          "firstRegistrationDate": {
+            "raw": "2010-07-01",
+            "formatted": "07/2010"
+          },
+          "mileageInKm": {
+            "raw": 167850,
+            "formatted": "167,850 km"
+          },
+          "numberOfPreviousOwnersExtended": {
+            "raw": null,
+            "formatted": "- (Previous Owners)"
+          },
+          "damage": {
+            "isCurrentlyDamaged": null,
+            "isRoadworthy": null,
+            "accidentFree": true,
+            "hasRepairedDamages": null,
+            "damageConditions": []
+          },
+          "nonSmoking": false,
+          "newInspection": false,
+          "isCabinClean": null,
+          "carpassMileageUrl": null
+        },
+        "bodyType": {
+          "formatted": "Compact",
+          "raw": "Compact"
+        },
+        "bodyColor": {
+          "raw": "White",
+          "formatted": "White"
+        },
+        "numberOfBeds": {
+          "raw": null,
+          "formatted": "- (Number of sleeps)"
+        },
+        "numberOfAxles": {
+          "raw": null,
+          "formatted": "- (Axle count)"
+        },
+        "grossVehicleWeight": null,
+        "wheelBase": null,
+        "costModel": null,
+        "numberOfDoors": 3,
+        "paintType": null,
+        "bodyColorOriginal": "Biały",
+        "interior": {
+          "numberOfSeats": 4,
+          "upholstery": null,
+          "upholsteryColor": null
+        },
+        "emptyWeight": {
+          "formatted": "775 kg"
+        },
+        "identifier": {
+          "licensePlate": "86-LXL-2"
+        },
+        "totalHeight": null,
+        "totalWidth": null,
+        "maximumTowingWeight": null,
+        "payload": null,
+        "loadWidth": null,
+        "loadHeight": null,
+        "loadLength": null,
+        "loadVolume": null,
+        "hasCarRegistration": {
+          "raw": false
+        },
+        "environment": {
+          "particulateFilter": false,
+          "environmentLabelsWithFallback": [
+            {
+              "norm": "EU_Directive_70_220_EEC_LDV",
+              "description": null,
+              "formatted": "Euro 4",
+              "label": "EURO4",
+              "isFallback": false
+            }
+          ]
+        },
+        "equipment": {
+          "as24": [
+            {
+              "id": {
+                "raw": 5,
+                "formatted": "Air conditioning"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 13,
+                "formatted": "Power windows"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 132,
+                "formatted": "CD player"
+              },
+              "equipmentCategory": {
+                "raw": "entertainmentAndMedia",
+                "formatted": "Entertainment & Media"
+              }
+            },
+            {
+              "id": {
+                "raw": 10,
+                "formatted": "Radio"
+              },
+              "equipmentCategory": {
+                "raw": "entertainmentAndMedia",
+                "formatted": "Entertainment & Media"
+              }
+            },
+            {
+              "id": {
+                "raw": 1,
+                "formatted": "ABS"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 18,
+                "formatted": "Alarm system"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 17,
+                "formatted": "Central door lock"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 47,
+                "formatted": "Central door lock with remote control"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 2,
+                "formatted": "Driver-side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 26,
+                "formatted": "Immobilizer"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 125,
+                "formatted": "Isofix"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 3,
+                "formatted": "Passenger-side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 12,
+                "formatted": "Power steering"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 32,
+                "formatted": "Side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            }
+          ]
+        },
+        "alloyWheelInches": null,
+        "originalMarket": {
+          "formatted": "Netherlands"
+        },
+        "maintenance": {
+          "nextVehicleSafetyInspection": {
+            "formatted": "05/2027"
+          },
+          "lastBeltServiceDate": null,
+          "hasFullServiceHistory": {
+            "raw": false
+          },
+          "lastTechnicalServiceDate": null
+        },
+        "newDriverSuitable": null
+      }
+    },
+    "identifier": {
+      "offerReference": "86-LXL-2",
+      "legacyId": null,
+      "crossReferenceId": "51126661"
+    },
+    "seals": null,
+    "location": {
+      "countryCode": "NL",
+      "zip": "7711 EP",
+      "city": "NIEUWLEUSEN",
+      "street": "De Grift 4",
+      "latitude": 52.58935,
+      "longitude": 6.24875
+    },
+    "seller": {
+      "id": 38182565,
+      "sellId": 2142202652,
+      "isDealer": true,
+      "type": "Dealer",
+      "companyName": "van der Kolk auto's",
+      "contactName": "Ian van der Kolk",
+      "logo": {
+        "small": {
+          "href": null
+        },
+        "big": {
+          "href": null
+        }
+      },
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/van-der-kolk-auto-s/about-us",
+        "imprint": "https://www.autoscout24.com/dealerinfo/van-der-kolk-auto-s/imprint",
+        "stockLink": "https://www.autoscout24.com/dealerinfo/van-der-kolk-auto-s?atype=C"
+      },
+      "phones": [
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 15218890",
+          "callTo": "+31615218890"
+        }
+      ],
+      "dealer": {
+        "maxImages": 50,
+        "isSMSLeadsEnabled": false,
+        "culture": "nl-NL",
+        "isFreespeeCallTrackingEnabled": false,
+        "isBestPricedDealer": false,
+        "tieredPricingPackage": "SMART",
+        "autoMatchPackage": {
+          "tier": "medium"
+        },
+        "hasMyVehiclesRecommenderCarousel": false,
+        "similarVehiclesRecommenderTop": false,
+        "superbranding": {
+          "images": {
+            "dealershipExterior": null,
+            "dealershipInterior": null,
+            "mediumDealershipExterior": null,
+            "smallDealershipExterior": null,
+            "smallDealershipInterior": null,
+            "mediumDealershipInterior": null
+          },
+          "contactPerson": {
+            "image": null,
+            "languages": null,
+            "name": null,
+            "position": null
+          }
+        },
+        "covidServices": null,
+        "openingHours": null,
+        "openingHoursRaw": null,
+        "homepageUrl": null,
+        "googleRatings": null,
+        "customerSince": 2021,
+        "region": null,
+        "nationwideListingsData": null
+      }
+    },
+    "whatsappNumber": null,
+    "webPage": "https://www.autoscout24.com/offers/citroen-c1-1-0-12v-ambiance-airco-elektrische-ramen-toe-gasoline-white-cat_ma21mo18651-0c344a98-edd9-46bd-b0d4-bf24792ecc77",
+    "status": "Active",
+    "leasingDetails": null,
+    "warranty": null,
+    "warrantyExists": false,
+    "ocsInfo": {
+      "__typename": "NotOcs"
+    },
+    "financingAndInsurance": {
+      "buttonWithFinance": [],
+      "buttonWithInsurance": [
+        {
+          "id": null,
+          "location": "Stage",
+          "productType": "Anwb",
+          "stage": {
+            "rate": null,
+            "link": {
+              "url": "https://ad.doubleclick.net/ddm/trackclk/N59701.135402AUTOSCOUT24.NL/B21621491.227696077;dc_trk_aid=425745719;dc_trk_cid=105284009;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;tfua=?https://www.anwb.nl/verzekeringen/autoverzekering/regulier/berekenen?utm_source=autoscout_calculator_sell_vz_avz&utm_medium=display&utm_campaign=sell_vz_avz&utm_content=autoscout_detailpagina_calculator&rKenteken=86-LXL-2",
+              "caption": "",
+              "text": "",
+              "tracking": {
+                "linkId": "anwb-fb-stage-widget",
+                "linkGroup": {
+                  "click": "dp-finance-click",
+                  "impr": "dp-finance-impr"
+                }
+              }
+            }
+          },
+          "overlay": {
+            "price": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "pageTitle": null,
+            "rate": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "staticTexts": null,
+            "financingDisclaimer": null,
+            "duration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "creditAmount": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "interest": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "debitInterest": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "totalAmount": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "offerDuration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "deposit": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "disclaimer": {
+              "value": null
+            },
+            "bank": {
+              "value": null
+            },
+            "balloon": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "firstInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "finalInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "automobileLiability": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "jsonData": null,
+            "proxyOffering": null,
+            "serviceFee": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "durations": null,
+            "loanThreshold": null,
+            "buttons": null,
+            "partiallyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "fullyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "check24Disclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "extendedDisclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "stage": {
+              "rate": null,
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "hasLowestInterestRate": null
+          }
+        },
+        {
+          "id": null,
+          "location": "Slice",
+          "productType": "Anwb",
+          "stage": {
+            "rate": null,
+            "link": {
+              "url": "https://ad.doubleclick.net/ddm/trackclk/N59701.135402AUTOSCOUT24.NL/B21621491.227696077;dc_trk_aid=425745719;dc_trk_cid=105284009;dc_lat=;dc_rdid=;tag_for_child_directed_treatment=;tfua=?https://www.anwb.nl/verzekeringen/autoverzekering/regulier/berekenen?utm_source=autoscout_calculator_sell_vz_avz&utm_medium=display&utm_campaign=sell_vz_avz&utm_content=autoscout_detailpagina_calculator&rKenteken=86-LXL-2",
+              "caption": "",
+              "text": "",
+              "tracking": {
+                "linkId": "anwb-fb-slice-widget",
+                "linkGroup": {
+                  "click": "dp-finance-click",
+                  "impr": "dp-finance-impr"
+                }
+              }
+            }
+          },
+          "overlay": {
+            "price": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "pageTitle": null,
+            "rate": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "staticTexts": null,
+            "financingDisclaimer": null,
+            "duration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "creditAmount": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "interest": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "debitInterest": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "totalAmount": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "offerDuration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "deposit": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "disclaimer": {
+              "value": null
+            },
+            "bank": {
+              "value": null
+            },
+            "balloon": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "firstInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "finalInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "automobileLiability": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "jsonData": null,
+            "proxyOffering": null,
+            "serviceFee": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "durations": null,
+            "loanThreshold": null,
+            "buttons": null,
+            "partiallyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "fullyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "check24Disclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "extendedDisclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "stage": {
+              "rate": null,
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "hasLowestInterestRate": null
+          }
+        }
+      ],
+      "buttonWithLeasing": []
+    },
+    "trackingParams": {
+      "classified_recency": "new",
+      "classified_makeId": 21,
+      "classified_makeTxt": "citroen",
+      "classified_modelID": 18651,
+      "classified_modelGroupID": 200305,
+      "classified_modelTxt": "c1",
+      "classified_mileage": 167850,
+      "classified_power": 50,
+      "classified_price": 1885,
+      "classified_fueltype": "b",
+      "classified_transmission": "m",
+      "classified_equipment": "5,13,132,10,1,18,17,47,2,26,125,3,12,32",
+      "classified_offerType": "u",
+      "classified_doors": 3,
+      "classified_seats": 4,
+      "classified_customer_type": "d",
+      "classified_customerID": "38182565",
+      "classified_zipcode": "7711 EP",
+      "classified_year": "2010",
+      "classified_capacity": 998,
+      "classified_bodyType": 1,
+      "classified_carSegment": "microcar,subcompact",
+      "classified_country": "NL",
+      "classified_emissionStandard": 4,
+      "classified_tier": "t50",
+      "classified_applied_tier": "t50",
+      "classified_images_threesixty": "standard",
+      "classified_dealerPackage": "smart",
+      "classified_exclusiveOffer": "false",
+      "classified_leadsRange": "zero",
+      "classified_imageContent": "no-placeholder|0.2619919708389691",
+      "classified_isSmyleEligible": "false",
+      "classified_ownershipModels": "tr"
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "specialConditions": [],
+    "hasPremiumListingTreatment": true,
+    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"microcar,subcompact\",\"did\":\"38182565\",\"stmil\":\"167850\",\"gear\":\"M\",\"make\":\"21\",\"stmak\":\"Citroen\",\"model\":\"18651\",\"stmod\":\"C1\",\"cost\":\"1885\",\"stmon\":\"7\",\"styea\":\"2010\",\"ad\":\"dealer\",\"vat\":\"0\",\"art\":\"1\",\"carby\":\"0\",\"fr\":\"6\",\"stccm\":\"998\",\"buyonline\":\"false\",\"stkw\":\"50\",\"sthp\":\"68\",\"equi\":\"32,1,2,3,132,5,10,12,13,47,17,18,26,125\",\"miles\":\"8\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_66335ab8-96ff-4dcb-962f-29ebf73055d2.jpg/720x540.webp\",\"price\":\"1\",\"rnd\":\"36\",\"ECO\":\"NO\",\"fuel\":\"B\",\"ken\":\"86-LXL-2\",\"kenteken\":\"true\",\"acc\":\"U\",\"hp\":\"2\",\"mgroupid\":\"200305\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"NL7711 EP\",\"zip2\":\"7711 EP\",\"articleType\":\"C\",\"seal\":\"146\",\"tiered\":\"smart\"}",
+    "statistics": {
+      "leadsRange": "Zero"
+    },
+    "imgAltText": "Citroen C1 1.0-12V Ambiance | Airco | Elektrische Ramen | Toe White",
+    "createdTimestampWithOffset": "2026-08-19T16:08:11.808Z",
+    "vehicleType": "ice",
+    "searchTrackingParams": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "organic"
+      },
+      {
+        "key": "boosting_product",
+        "value": "none"
+      }
+    ],
+    "articleType": "car",
+    "isNew": true
+  },
+  {
+    "id": "0b6c654f-cd2c-452c-a559-4904c696cae8",
+    "searchResultType": "Organic",
+    "isDeliverable": false,
+    "description": "<strong>Hallo zum Verkauf bieten wir einen Audi A2 aus 2004 der optische und technisch in einem guten Zustand ist . Motor Lampe an wegen der Lambdasonde ist aber voll fahrbereit ! Verkauf nur an Gewerbetreibende oder Export !<br /><br /><br />Sonderausstattung:</strong><br />Aktiv-Lautsprecher, Audiosystem Concert (Radio/CD-Player), Klimaautomatik, Metallic-Lackierung, Open-Sky-System (vollverglaste Dachfläche - schiebbar)<br /><br /><strong>Weitere Ausstattung:</strong><br />Airbag Fahrer-/Beifahrerseite, Antriebs-Schlupfregelung (ASR), Außenspiegel asphärisch, links, Außenspiegel elektr. verstellbar, beide, Außenspiegel konvex, rechts, Außentemperaturanzeige, Elektron. Differentialsperre (EDS), Gepäckraumabdeckung / Rollo, Innenausstattung: Dekoreinlagen Aluminium, Isofix-Aufnahmen für Kindersitz, Karosserie: 4-türig, Lenksäule (Lenkrad) höhenverstellbar, Motor 1,4 Ltr. - 55 kW 16V, Seitenairbag vorn, Sitzbezug / Polsterung: Stoff Sinus, Wärmeschutzverglasung grün getönt",
+    "ratings": null,
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_77bfe203-d39e-4372-934f-87d56dd73a33.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_cb03cf8d-4168-47e7-8d6a-ef4fff8b8502.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_a9078254-56a9-4bc2-acbe-4dc1a688c639.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_b40e72c4-fabf-4e88-940d-5cd835218472.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_78adb742-f132-469b-8901-4092fab8ae39.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_a92b5404-f295-4e3e-9cd3-8a084376a051.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_4b83278e-31a2-4ac6-b92b-edc61a2a6afb.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_dc8e39e0-cee4-4e20-8e06-990d6d7d6d9c.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_fcd21b1e-7265-4691-a4d2-7c2a65ffd854.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_562a0462-b141-4656-96a5-73b87ccdac46.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_3aeeea8e-c26c-456e-93e4-5cef4d3f44a5.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_0fe4bfe0-062c-433b-8181-103bd15bb8ea.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_58766cf6-d223-4ea7-9148-42d18c1bb9ee.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_92aff917-da6a-40d9-bd7b-1e6111cca581.jpg/1280x960.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_605b1e8e-487d-4476-8117-8fbc33278aef.jpg/1280x960.webp"
+    ],
+    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_77bfe203-d39e-4372-934f-87d56dd73a33.jpg/120x90.webp",
+    "youtubeLink": null,
+    "twinnerUrl": null,
+    "isCoverImagePlaceholder": false,
+    "coverImageAttractiveness": 0.18517955248082607,
+    "hasThreeSixtyContent": false,
+    "vehicleReport": {
+      "carfax": {
+        "carfaxMode": "FreeCarFax",
+        "reportUrlEn": "https://www.carfax.eu/de/partner/autoscout24-germany/29bc71dc685748b1e21b9404e4331613f6cd4fb2a80634bf5d7b972469365161",
+        "reportUrlFr": "https://www.carfax.eu/de/partner/autoscout24-germany/498c99fc275d8b9aae0de687a9096b369c84fc1ff4d206d05c187f916e3dec96|https://www.carfax.eu/de/partner/autoscout24-germany/d26be0184200457fd00fd781cca3f00ed348801bf4ac4caaba3cce0eca9e409d"
+      }
+    },
+    "threeSixty": null,
+    "prices": {
+      "isFinalPrice": false,
+      "public": {
+        "price": "€ 1,900",
+        "priceRaw": 1900,
+        "taxDeductible": false,
+        "negotiable": false,
+        "onRequestOnly": false,
+        "netPrice": null,
+        "netPriceRaw": null,
+        "vatRate": null,
+        "category": null,
+        "median": null,
+        "evaluationRanges": null
+      },
+      "dealer": {
+        "price": "€ 1,900",
+        "priceRaw": 1900,
+        "taxDeductible": false,
+        "negotiable": false,
+        "onRequestOnly": false,
+        "netPrice": null,
+        "netPriceRaw": null,
+        "vatRate": null,
+        "category": null,
+        "median": null,
+        "evaluationRanges": null
+      },
+      "suggestedRetail": null,
+      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/0b6c654f-cd2c-452c-a559-4904c696cae8?culture=en-GB",
+      "error": null
+    },
+    "superDeal": null,
+    "price": {
+      "priceFormatted": "€ 1,900",
+      "isVatLabelLegallyRequired": false,
+      "isConditionalPrice": true
+    },
+    "availability": {
+      "rawFromDate": null,
+      "fromDate": null,
+      "inDays": null
+    },
+    "financingFlags": {
+      "showStageFinancingAmvLegendSpain": false
+    },
+    "vehicle": {
+      "licensePlate": null,
+      "carpassMileageUrl": null,
+      "makeId": 9,
+      "modelOrModelLineId": 16416,
+      "make": "Audi",
+      "model": "A2",
+      "modelGroup": "A2",
+      "variant": null,
+      "modelId": 16416,
+      "modelGroupIds": [
+        16416
+      ],
+      "modelGenerationId": 726,
+      "modelVariantId": null,
+      "motorTypeId": 3158,
+      "motorTypeName": "1.4",
+      "trimLineId": 479948,
+      "modelVersionInput": "1.4 /Panorama /",
+      "modelVersionCustom": null,
+      "type": "Car",
+      "hsnTsn": "0588/734",
+      "mileageInKmRaw": 214000,
+      "mileageInKm": "214,000 km",
+      "firstRegistrationDateRaw": "2004-03-01",
+      "firstRegistrationDate": "03/2004",
+      "bodyType": "Compact",
+      "numberOfSeats": 5,
+      "numberOfDoors": 4,
+      "bodyColor": "Blue",
+      "bodyColorRaw": "Blue",
+      "paintType": "Metallic",
+      "bodyColorOriginal": "Kobaltblau Metallic",
+      "engineHours": "",
+      "fuelDeliveryType": "",
+      "engineCoolingSystem": "",
+      "slideOutCount": null,
+      "chassisManufacturerName": "",
+      "exteriorMaterial": "",
+      "extendedLength": "",
+      "flooringMaterial": "",
+      "fridgePowerType": "",
+      "fridgeCapacity": "",
+      "waterTankCapacity": "",
+      "wasteTankCapacity": "",
+      "engineManufacturerName": "",
+      "axleSpread": "",
+      "brakeType": "",
+      "cabinAxleDistance": "",
+      "differentialRatio": "",
+      "frameType": "",
+      "rearAxleWeightRating": "",
+      "frontAxleWeightRating": "",
+      "trackDimension": "",
+      "skiStanceWidth": "",
+      "fuelCapacity": "",
+      "headCount": null,
+      "hullMaterial": null,
+      "steeringType": null,
+      "auxiliaryPower": null,
+      "engineMountingType": null,
+      "engineCount": null,
+      "isCabinClean": false,
+      "upholstery": "Cloth",
+      "upholsteryColor": "Black",
+      "marketingDescription": "",
+      "controlModuleName": "",
+      "powerInKw": "55 kW",
+      "powerInHp": "75 hp",
+      "rawPowerInKw": 55,
+      "rawPowerInHp": 75,
+      "transmissionType": "Manual",
+      "gears": null,
+      "cylinders": 4,
+      "driveTrain": "Front Wheel Drive",
+      "displacementInCCM": "1,390 cc",
+      "rawDisplacementInCCM": 1390,
+      "cylinderCapacity": "1,390 cc",
+      "rawCylinderCapacity": 1390,
+      "weight": "895 kg",
+      "hasParticleFilter": false,
+      "fuelCategory": {
+        "raw": "B",
+        "formatted": "Gasoline"
+      },
+      "batteryOwnershipType": {
+        "raw": null,
+        "formatted": null
+      },
+      "batteryChargingTime": {
+        "raw": null,
+        "formatted": null
+      },
+      "electricRangeWithFallback": {
+        "raw": null,
+        "formatted": null
+      },
+      "electricRangeCity": {
+        "raw": null,
+        "formatted": null
+      },
+      "primaryFuel": {
+        "raw": 1,
+        "formatted": "Regular/Benzine 91"
+      },
+      "additionalFuel": [],
+      "fuelConsumptionCombined": {
+        "raw": null,
+        "formatted": "- (l/100 km)",
+        "isFallback": false
+      },
+      "fuelConsumptionUrban": {
+        "raw": null,
+        "formatted": null
+      },
+      "fuelConsumptionExtraUrban": {
+        "raw": null,
+        "formatted": null
+      },
+      "co2emissionInGramPerKmWithFallback": {
+        "raw": null,
+        "formatted": "- (g/km)",
+        "isFallback": false
+      },
+      "wltp": {
+        "co2EmissionsCombinedWithFallback": {
+          "raw": 146,
+          "formatted": "146 g/km (comb.)",
+          "isFallback": false
+        },
+        "co2EmissionsCombinedWeightedWithFallback": null,
+        "consumptionCombinedWithFallback": {
+          "raw": 6.1,
+          "formatted": "6.1 l/100 km (comb.)",
+          "isFallback": false
+        },
+        "consumptionElectricCombinedWithFallback": null,
+        "consumptionCombinedWeightedWithFallback": null,
+        "consumptionElectricCombinedWeightedWithFallback": null,
+        "co2ClassWithFallback": null,
+        "co2ClassDischarged": null,
+        "consumptionCombinedDischarged": null,
+        "consumptionCity": null,
+        "consumptionSuburban": null,
+        "consumptionRural": null,
+        "consumptionHighway": null,
+        "consumptionElectricCity": null,
+        "consumptionElectricSuburban": null,
+        "consumptionElectricRural": null,
+        "consumptionElectricHighway": null,
+        "consumptionCityDischarged": null,
+        "consumptionSuburbanDischarged": null,
+        "consumptionRuralDischarged": null,
+        "consumptionHighwayDischarged": null,
+        "co2EmissionsDischarged": null
+      },
+      "allFuelTypes": [],
+      "equipment": {
+        "comfortAndConvenience": [
+          {
+            "id": "Air conditioning",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Armrest",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Automatic climate control",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Electrical side mirrors",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Electrically heated windshield",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Panorama roof",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          },
+          {
+            "id": "Power windows",
+            "categoryName": "Comfort & Convenience",
+            "categoryId": "comfortAndConvenience"
+          }
+        ],
+        "entertainmentAndMedia": [
+          {
+            "id": "CD player",
+            "categoryName": "Entertainment & Media",
+            "categoryId": "entertainmentAndMedia"
+          },
+          {
+            "id": "Radio",
+            "categoryName": "Entertainment & Media",
+            "categoryId": "entertainmentAndMedia"
+          }
+        ],
+        "extras": [
+          {
+            "id": "Winter package",
+            "categoryName": "Extras",
+            "categoryId": "extras"
+          }
+        ],
+        "safetyAndSecurity": [
+          {
+            "id": "ABS",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Central door lock",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Daytime running lights",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Driver-side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Electronic stability control",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Immobilizer",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Isofix",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Passenger-side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Power steering",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Side airbag",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          },
+          {
+            "id": "Tire pressure monitoring system",
+            "categoryName": "Safety & Security",
+            "categoryId": "safetyAndSecurity"
+          }
+        ]
+      },
+      "environmentPkwEnVKV": null,
+      "environmentEuDirective": {
+        "description": null,
+        "formatted": "Euro 4",
+        "label": "EURO4",
+        "isFallback": false,
+        "co2EfficiencyClass": "EURO4"
+      },
+      "environmentBImSchV35": {
+        "description": null,
+        "formatted": "4 (Green)",
+        "label": "Green",
+        "isFallback": false,
+        "co2EfficiencyClass": "Green"
+      },
+      "originalMarket": null,
+      "legalCategories": [
+        "Used"
+      ],
+      "legalCategoriesRaw": [
+        "UsedVehicle"
+      ],
+      "hadAccident": false,
+      "damageConditions": [],
+      "newInspection": false,
+      "lastBeltServiceDate": null,
+      "lastTechnicalServiceDate": null,
+      "hasFullServiceHistory": true,
+      "nonSmoking": false,
+      "noOfPreviousOwners": null,
+      "nextVehicleSafetyInspection": null,
+      "isRental": false,
+      "numberOfBeds": null,
+      "numberOfAxles": null,
+      "wheelBase": null,
+      "totalHeight": null,
+      "totalWidth": null,
+      "totalLength": null,
+      "maximumTowingWeight": null,
+      "grossVehicleWeight": null,
+      "payload": null,
+      "loadWidth": null,
+      "loadHeight": null,
+      "loadLength": null,
+      "loadVolume": null,
+      "productionYear": null,
+      "hasCarRegistration": false,
+      "offerType": "U",
+      "newDriverSuitable": null,
+      "rawData": {
+        "totalLength": null,
+        "engineHours": null,
+        "usageState": "U",
+        "productionDate": null,
+        "legalCategories": [
+          {
+            "formatted": "Used",
+            "raw": "UsedVehicle"
+          }
+        ],
+        "classification": {
+          "type": "Car",
+          "modelYear": null,
+          "make": {
+            "raw": 9,
+            "formatted": "Audi"
+          },
+          "model": {
+            "raw": 16416,
+            "formatted": "A2"
+          },
+          "modelGroups": [
+            {
+              "raw": 16416,
+              "formatted": "A2"
+            }
+          ],
+          "modelGeneration": {
+            "raw": 726,
+            "formatted": "8Z"
+          },
+          "modelVariant": null,
+          "motorType": {
+            "raw": 3158,
+            "formatted": "1.4"
+          },
+          "trimLine": {
+            "raw": 479948
+          },
+          "modelVersionInput": "1.4 /Panorama /",
+          "modelVersionCustom": null,
+          "germanHsnTsn": {
+            "formatted": "0588/734"
+          }
+        },
+        "fuels": {
+          "isPluginHybrid": null,
+          "primary": {
+            "type": {
+              "raw": 1,
+              "formatted": "Regular/Benzine 91"
+            },
+            "consumption": {
+              "combinedWithFallback": {
+                "raw": null,
+                "formatted": "- (l/100 km)",
+                "isFallback": false
+              },
+              "urban": null,
+              "extraUrban": null
+            },
+            "co2emissionInGramPerKmWithFallback": {
+              "raw": null,
+              "formatted": "- (g/km)",
+              "isFallback": false
+            }
+          },
+          "additional": [],
+          "fuelCategory": {
+            "raw": "B",
+            "formatted": "Gasoline"
+          },
+          "wltp": {
+            "co2EmissionsCombinedWithFallback": {
+              "raw": 146,
+              "formatted": "146 g/km (comb.)",
+              "isFallback": false
+            },
+            "co2EmissionsCombinedWeightedWithFallback": null,
+            "consumptionCombinedWithFallback": {
+              "raw": 6.1,
+              "formatted": "6.1 l/100 km (comb.)",
+              "isFallback": false
+            },
+            "consumptionElectricCombinedWithFallback": null,
+            "consumptionCombinedWeightedWithFallback": null,
+            "consumptionElectricCombinedWeightedWithFallback": null,
+            "co2ClassWithFallback": null,
+            "co2ClassDischarged": null,
+            "consumptionCombinedDischarged": null,
+            "consumptionCity": null,
+            "consumptionSuburban": null,
+            "consumptionRural": null,
+            "consumptionHighway": null,
+            "consumptionElectricCity": null,
+            "consumptionElectricSuburban": null,
+            "consumptionElectricRural": null,
+            "consumptionElectricHighway": null,
+            "consumptionCityDischarged": null,
+            "consumptionSuburbanDischarged": null,
+            "consumptionRuralDischarged": null,
+            "consumptionHighwayDischarged": null,
+            "co2EmissionsDischarged": null
+          },
+          "electricRangeWithFallback": null,
+          "electricRangeCity": null,
+          "allFuelTypes": [],
+          "battery": null
+        },
+        "engine": {
+          "engineDisplacementInCCM": {
+            "raw": 1390,
+            "formatted": "1,390 cc"
+          },
+          "power": {
+            "kw": {
+              "raw": 55,
+              "formatted": "55 kW"
+            },
+            "hp": {
+              "raw": 75,
+              "formatted": "75 hp"
+            }
+          },
+          "transmissionType": {
+            "raw": "Manual",
+            "formatted": "Manual"
+          },
+          "numberOfCylinders": 4,
+          "cylinderCapacity": {
+            "raw": 1390,
+            "unit": "ccm",
+            "formatted": "1,390 cc"
+          },
+          "numberOfGears": null,
+          "driveTrain": {
+            "formatted": "Front Wheel Drive"
+          }
+        },
+        "condition": {
+          "firstRegistrationDate": {
+            "raw": "2004-03-01",
+            "formatted": "03/2004"
+          },
+          "mileageInKm": {
+            "raw": 214000,
+            "formatted": "214,000 km"
+          },
+          "numberOfPreviousOwnersExtended": {
+            "raw": null,
+            "formatted": "- (Previous Owners)"
+          },
+          "damage": {
+            "isCurrentlyDamaged": false,
+            "isRoadworthy": true,
+            "accidentFree": true,
+            "hasRepairedDamages": null,
+            "damageConditions": []
+          },
+          "nonSmoking": false,
+          "newInspection": false,
+          "isCabinClean": null,
+          "carpassMileageUrl": null
+        },
+        "bodyType": {
+          "formatted": "Compact",
+          "raw": "Compact"
+        },
+        "bodyColor": {
+          "raw": "Blue",
+          "formatted": "Blue"
+        },
+        "numberOfBeds": {
+          "raw": null,
+          "formatted": "- (Number of sleeps)"
+        },
+        "numberOfAxles": {
+          "raw": null,
+          "formatted": "- (Axle count)"
+        },
+        "grossVehicleWeight": null,
+        "wheelBase": null,
+        "costModel": null,
+        "numberOfDoors": 4,
+        "paintType": {
+          "formatted": "Metallic"
+        },
+        "bodyColorOriginal": "Kobaltblau Metallic",
+        "interior": {
+          "numberOfSeats": 5,
+          "upholstery": {
+            "formatted": "Cloth"
+          },
+          "upholsteryColor": {
+            "formatted": "Black"
+          }
+        },
+        "emptyWeight": {
+          "formatted": "895 kg"
+        },
+        "identifier": {
+          "licensePlate": null
+        },
+        "totalHeight": null,
+        "totalWidth": null,
+        "maximumTowingWeight": null,
+        "payload": null,
+        "loadWidth": null,
+        "loadHeight": null,
+        "loadLength": null,
+        "loadVolume": null,
+        "hasCarRegistration": {
+          "raw": false
+        },
+        "environment": {
+          "particulateFilter": false,
+          "environmentLabelsWithFallback": [
+            {
+              "norm": "BImSchV_35",
+              "description": null,
+              "formatted": "4 (Green)",
+              "label": "Green",
+              "isFallback": false
+            },
+            {
+              "norm": "EU_Directive_70_220_EEC_LDV",
+              "description": null,
+              "formatted": "Euro 4",
+              "label": "EURO4",
+              "isFallback": false
+            }
+          ]
+        },
+        "equipment": {
+          "as24": [
+            {
+              "id": {
+                "raw": 5,
+                "formatted": "Air conditioning"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 134,
+                "formatted": "Armrest"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 30,
+                "formatted": "Automatic climate control"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 121,
+                "formatted": "Electrical side mirrors"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 135,
+                "formatted": "Electrically heated windshield"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 50,
+                "formatted": "Panorama roof"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 13,
+                "formatted": "Power windows"
+              },
+              "equipmentCategory": {
+                "raw": "comfortAndConvenience",
+                "formatted": "Comfort & Convenience"
+              }
+            },
+            {
+              "id": {
+                "raw": 132,
+                "formatted": "CD player"
+              },
+              "equipmentCategory": {
+                "raw": "entertainmentAndMedia",
+                "formatted": "Entertainment & Media"
+              }
+            },
+            {
+              "id": {
+                "raw": 10,
+                "formatted": "Radio"
+              },
+              "equipmentCategory": {
+                "raw": "entertainmentAndMedia",
+                "formatted": "Entertainment & Media"
+              }
+            },
+            {
+              "id": {
+                "raw": 231,
+                "formatted": "Winter package"
+              },
+              "equipmentCategory": {
+                "raw": "extras",
+                "formatted": "Extras"
+              }
+            },
+            {
+              "id": {
+                "raw": 1,
+                "formatted": "ABS"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 17,
+                "formatted": "Central door lock"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 115,
+                "formatted": "Daytime running lights"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 2,
+                "formatted": "Driver-side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 42,
+                "formatted": "Electronic stability control"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 26,
+                "formatted": "Immobilizer"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 125,
+                "formatted": "Isofix"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 3,
+                "formatted": "Passenger-side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 12,
+                "formatted": "Power steering"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 32,
+                "formatted": "Side airbag"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            },
+            {
+              "id": {
+                "raw": 150,
+                "formatted": "Tire pressure monitoring system"
+              },
+              "equipmentCategory": {
+                "raw": "safetyAndSecurity",
+                "formatted": "Safety & Security"
+              }
+            }
+          ]
+        },
+        "alloyWheelInches": null,
+        "originalMarket": null,
+        "maintenance": {
+          "nextVehicleSafetyInspection": null,
+          "lastBeltServiceDate": null,
+          "hasFullServiceHistory": {
+            "raw": true
+          },
+          "lastTechnicalServiceDate": null
+        },
+        "newDriverSuitable": null
+      }
+    },
+    "identifier": {
+      "offerReference": null,
+      "legacyId": null,
+      "crossReferenceId": "434881662"
+    },
+    "seals": null,
+    "location": {
+      "countryCode": "DE",
+      "zip": "54311",
+      "city": "Trierweiler",
+      "street": "Roderstraße 9-11",
+      "latitude": 49.77071,
+      "longitude": 6.58329
+    },
+    "seller": {
+      "id": 63169494,
+      "sellId": 2142053119,
+      "isDealer": true,
+      "type": "Dealer",
+      "companyName": "Autohandel Younes K.",
+      "contactName": "Kassem Younes",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/63169494-original-bb088643-8e9d-4646-a07a-288448b757fb.jpg/resize/100x50%3E/quality/90"
+        },
+        "big": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/63169494-original-bb088643-8e9d-4646-a07a-288448b757fb.jpg/resize/200x100%3E/quality/90"
+        }
+      },
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler/about-us",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler/imprint",
+        "stockLink": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler?atype=C"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)651 - 60344265",
+          "callTo": "+4965160344265"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1523 - 6947025",
+          "callTo": "+4915236947025"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1515 - 1143143",
+          "callTo": "+4915151143143"
+        }
+      ],
+      "dealer": {
+        "maxImages": 50,
+        "isSMSLeadsEnabled": false,
+        "culture": "de-DE",
+        "isFreespeeCallTrackingEnabled": true,
+        "isBestPricedDealer": false,
+        "tieredPricingPackage": "PRO",
+        "autoMatchPackage": {
+          "tier": "high"
+        },
+        "hasMyVehiclesRecommenderCarousel": true,
+        "similarVehiclesRecommenderTop": false,
+        "superbranding": {
+          "images": {
+            "dealershipExterior": null,
+            "dealershipInterior": null,
+            "mediumDealershipExterior": null,
+            "smallDealershipExterior": null,
+            "smallDealershipInterior": null,
+            "mediumDealershipInterior": null
+          },
+          "contactPerson": {
+            "image": null,
+            "languages": null,
+            "name": null,
+            "position": null
+          }
+        },
+        "covidServices": null,
+        "openingHours": {
+          "department": "Verkauf ",
+          "state": "open",
+          "statusLabel": "Open",
+          "infoLabel": "Closes at 18:00"
+        },
+        "openingHoursRaw": [
+          {
+            "department": "Verkauf ",
+            "timetable": [
+              [
+                900,
+                1800
+              ],
+              [
+                900,
+                1800
+              ],
+              [
+                900,
+                1800
+              ],
+              [
+                900,
+                1800
+              ],
+              [
+                900,
+                1800
+              ],
+              [
+                1000,
+                1500
+              ],
+              []
+            ]
+          }
+        ],
+        "homepageUrl": null,
+        "googleRatings": null,
+        "customerSince": 2026,
+        "region": null,
+        "nationwideListingsData": null
+      }
+    },
+    "whatsappNumber": null,
+    "webPage": "https://www.autoscout24.com/offers/audi-a2-1-4-panorama-gasoline-blue-cat_ma9mo16416-0b6c654f-cd2c-452c-a559-4904c696cae8",
+    "status": "Active",
+    "leasingDetails": null,
+    "warranty": null,
+    "warrantyExists": false,
+    "ocsInfo": {
+      "__typename": "NotOcs"
+    },
+    "financingAndInsurance": {
+      "buttonWithFinance": [
+        {
+          "id": null,
+          "location": "Stage",
+          "productType": "Procheck24",
+          "stage": {
+            "rate": 28.43333360010617,
+            "link": {
+              "url": "https://www.autoscout24.de/financeboost-consumer?guid=0b6c654f-cd2c-452c-a559-4904c696cae8&variant=funnel&downpayment=0&duration=84&subId=dp_web_stage_ENG&pid=55bd95b6-1274-4ea4-b5fb-56b617d97d6d&ptcId=true",
+              "caption": "",
+              "text": "Calculate financing",
+              "tracking": {
+                "linkId": "procheck24-stage-widget",
+                "linkGroup": {
+                  "click": "dp-finance-click",
+                  "impr": "dp-finance-impr"
+                }
+              }
+            }
+          },
+          "overlay": {
+            "price": {
+              "raw": 1900,
+              "formatted": "€ 1.900,-",
+              "translation": {
+                "value": "Cash price"
+              }
+            },
+            "pageTitle": {
+              "value": "Financing example"
+            },
+            "rate": {
+              "raw": 28.43333360010617,
+              "formatted": "€ 28,-",
+              "translation": {
+                "value": "Monthly rate"
+              }
+            },
+            "staticTexts": null,
+            "financingDisclaimer": {
+              "linear": {
+                "value": "<BANK_NAME>・representative example (§ 17 Abs. 4 PAngV): 2/3 of all customers receive an annual percentage rate of <INTEREST>・fixed borrowing rate of <DEBIT_INTEREST> p.a.・total amount payable: <TOTAL_AMOUNT>・net loan amount: <CREDIT_AMOUNT>・<DURATION> instalments・monthly instalment: <RATE>・subject to creditworthiness・The financing service is non-binding and free of charge for users."
+              },
+              "balloon": null,
+              "additional": null
+            },
+            "duration": {
+              "raw": 84,
+              "formatted": "84 Months",
+              "translation": {
+                "value": "Duration"
+              }
+            },
+            "creditAmount": {
+              "raw": 1900,
+              "formatted": "€ 1.900,-",
+              "translation": {
+                "value": "Net loan"
+              }
+            },
+            "interest": {
+              "raw": 6.95,
+              "formatted": "6,95 %",
+              "translation": {
+                "value": "Effective annual interest"
+              }
+            },
+            "debitInterest": {
+              "raw": 6.74,
+              "formatted": "6,74 %",
+              "translation": {
+                "value": "fixed borrowing rate p.a."
+              }
+            },
+            "totalAmount": {
+              "raw": 2388.400022408918,
+              "formatted": "€ 2.388,40",
+              "translation": {
+                "value": "Gross loan amount"
+              }
+            },
+            "offerDuration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "deposit": {
+              "raw": 0,
+              "formatted": "€ 0,-",
+              "translation": {
+                "value": "Down payment"
+              }
+            },
+            "disclaimer": {
+              "value": "2/3 of all customers receive 6,95 % eff. Annual interest・6,74 % fixed interest rate p.a.・Gesamtbetrag € 2.388,40・Net loan € 1.900,-・84 installments・monthly € 28,43"
+            },
+            "bank": {
+              "value": "Credit brokerage by CHECK24 Vergleichsportal Finanzen GmbH, Trappentreustr. 1–3, 80339 Munich."
+            },
+            "balloon": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "firstInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "finalInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "automobileLiability": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "jsonData": null,
+            "proxyOffering": null,
+            "serviceFee": {
+              "raw": null,
+              "formatted": "-",
+              "translation": {
+                "value": ""
+              }
+            },
+            "durations": null,
+            "loanThreshold": null,
+            "buttons": [
+              {
+                "value": {
+                  "text": "Calculate financing",
+                  "url": "https://www.autoscout24.de/financeboost-consumer?guid=0b6c654f-cd2c-452c-a559-4904c696cae8&variant=funnel&downpayment=0&duration=84&subId=dp_web_stage_ENG&pid=55bd95b6-1274-4ea4-b5fb-56b617d97d6d&ptcId=true",
+                  "tracking": {
+                    "linkId": "procheck24-stage-overlay",
+                    "linkGroup": {
+                      "click": "dp-finance-click",
+                      "impr": "dp-finance-impr"
+                    }
+                  }
+                }
+              }
+            ],
+            "partiallyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "fullyComprehensive": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "check24Disclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "extendedDisclaimer": {
+              "text": {
+                "value": null
+              },
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "stage": {
+              "rate": null,
+              "link": {
+                "url": null,
+                "caption": null,
+                "text": null,
+                "tracking": {
+                  "linkId": null,
+                  "linkGroup": {
+                    "click": null,
+                    "impr": null
+                  }
+                }
+              }
+            },
+            "hasLowestInterestRate": null
+          }
+        },
+        {
+          "id": null,
+          "location": "Slice",
+          "productType": "Procheck24",
+          "stage": {
+            "rate": 28.43333360010617,
+            "link": {
+              "url": "https://www.autoscout24.de/financeboost-consumer?guid=0b6c654f-cd2c-452c-a559-4904c696cae8&variant=funnel&downpayment=0&duration=84&subId=dp_web_slice_ENG&pid=55bd95b6-1274-4ea4-b5fb-56b617d97d6d&ptcId=true",
+              "caption": "",
+              "text": "Calculate financing",
+              "tracking": {
+                "linkId": "procheck24-slice-widget",
+                "linkGroup": {
+                  "click": "dp-finance-click",
+                  "impr": "dp-finance-impr"
+                }
+              }
+            }
+          },
+          "overlay": {
+            "price": {
+              "raw": 1900,
+              "formatted": "€ 1.900,-",
+              "translation": {
+                "value": "Cash price"
+              }
+            },
+            "pageTitle": {
+              "value": "Financing example"
+            },
+            "rate": {
+              "raw": 28.43333360010617,
+              "formatted": "€ 28,-",
+              "translation": {
+                "value": "Monthly rate"
+              }
+            },
+            "staticTexts": null,
+            "financingDisclaimer": {
+              "linear": {
+                "value": "<BANK_NAME>・representative example (§ 17 Abs. 4 PAngV): 2/3 of all customers receive an annual percentage rate of <INTEREST>・fixed borrowing rate of <DEBIT_INTEREST> p.a.・total amount payable: <TOTAL_AMOUNT>・net loan amount: <CREDIT_AMOUNT>・<DURATION> instalments・monthly instalment: <RATE>・subject to creditworthiness・The financing service is non-binding and free of charge for users."
+              },
+              "balloon": null,
+              "additional": null
+            },
+            "duration": {
+              "raw": 84,
+              "formatted": "84 Months",
+              "translation": {
+                "value": "Duration"
+              }
+            },
+            "creditAmount": {
+              "raw": 1900,
+              "formatted": "€ 1.900,-",
+              "translation": {
+                "value": "Net loan"
+              }
+            },
+            "interest": {
+              "raw": 6.95,
+              "formatted": "6,95 %",
+              "translation": {
+                "value": "Effective annual interest"
+              }
+            },
+            "debitInterest": {
+              "raw": 6.74,
+              "formatted": "6,74 %",
+              "translation": {
+                "value": "fixed borrowing rate p.a."
+              }
+            },
+            "totalAmount": {
+              "raw": 2388.400022408918,
+              "formatted": "€ 2.388,40",
+              "translation": {
+                "value": "Gross loan amount"
+              }
+            },
+            "offerDuration": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "deposit": {
+              "raw": 0,
+              "formatted": "€ 0,-",
+              "translation": {
+                "value": "Down payment"
+              }
+            },
+            "disclaimer": {
+              "value": "2/3 of all customers receive 6,95 % eff. Annual interest・6,74 % fixed interest rate p.a.・Gesamtbetrag € 2.388,40・Net loan € 1.900,-・84 installments・monthly € 28,43"
+            },
+            "bank": {
+              "value": "Credit brokerage by CHECK24 Vergleichsportal Finanzen GmbH, Trappentreustr. 1–3, 80339 Munich."
+            },
+            "balloon": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "firstInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "finalInstallment": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "automobileLiability": {
+              "raw": null,
+              "formatted": null,
+              "translation": null
+            },
+            "jsonData": null,
+            "proxyOffering": null,
+            "serviceFee": {
+              "raw": null,
+              "formatted": "-",
+              "translation": {
+                "value": ""
+              }
+            },
+            "durations": null,
+            "loanThreshold": null,
+            "buttons": [
+              {
+                "value": {
+                  "text": "Calculate financing",
+                  "url": "https://www.autoscout24.de/financeboost-consumer?guid=0b6c654f-cd2c-452c-a559-4904c696cae8&variant=funnel&downpayment=0&duration=84&subId=dp_web_slice_ENG&pid=55bd95b6-1274-4ea4-b5fb-56b617d97d6d&ptcId=true",
+                  "tracking": {
+                    "linkId": "procheck24-slice-overlay",
+                    "linkGroup": {
+                      "click": "dp-finance-click",
+                      "impr": "dp-finance-impr"
+                    }
+                  }
+                }
+              }
+            ],
             "partiallyComprehensive": {
               "raw": null,
               "formatted": null,
@@ -1714,11 +3984,11 @@
           "location": "Stage",
           "productType": "Check24",
           "stage": {
-            "rate": 10.78,
+            "rate": 9.54,
             "link": {
-              "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_stage_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+              "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_stage_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
               "caption": "",
-              "text": "Compare car insurance",
+              "text": "Compare insurance",
               "tracking": {
                 "linkId": "check24-stage-widget",
                 "linkGroup": {
@@ -1811,8 +4081,8 @@
               "translation": null
             },
             "automobileLiability": {
-              "raw": 10.78,
-              "formatted": "€ 10,78",
+              "raw": 9.54,
+              "formatted": "€ 9,54",
               "translation": {
                 "value": "Liability insurance"
               }
@@ -1830,7 +4100,7 @@
               {
                 "value": {
                   "text": "Compare insurances now",
-                  "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_stage_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+                  "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_stage_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
                   "tracking": {
                     "linkId": "check24-stage-overlay",
                     "linkGroup": {
@@ -1842,15 +4112,15 @@
               }
             ],
             "partiallyComprehensive": {
-              "raw": 13.42,
-              "formatted": "€ 13,42",
+              "raw": 11.91,
+              "formatted": "€ 11,91",
               "translation": {
                 "value": "Partial cover"
               }
             },
             "fullyComprehensive": {
-              "raw": 17.96,
-              "formatted": "€ 17,96",
+              "raw": 13.19,
+              "formatted": "€ 13,19",
               "translation": {
                 "value": "Comprehensive"
               }
@@ -1890,11 +4160,11 @@
               }
             },
             "stage": {
-              "rate": 10.78,
+              "rate": 9.54,
               "link": {
-                "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_stage_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+                "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_stage_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
                 "caption": "",
-                "text": "Compare car insurance",
+                "text": "Compare insurance",
                 "tracking": {
                   "linkId": "check24-stage-widget",
                   "linkGroup": {
@@ -1912,11 +4182,11 @@
           "location": "Slice",
           "productType": "Check24",
           "stage": {
-            "rate": 10.78,
+            "rate": 9.54,
             "link": {
-              "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_slice_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+              "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_slice_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
               "caption": "",
-              "text": "Compare car insurance",
+              "text": "Compare insurance",
               "tracking": {
                 "linkId": "check24-slice-widget",
                 "linkGroup": {
@@ -2009,8 +4279,8 @@
               "translation": null
             },
             "automobileLiability": {
-              "raw": 10.78,
-              "formatted": "€ 10,78",
+              "raw": 9.54,
+              "formatted": "€ 9,54",
               "translation": {
                 "value": "Liability insurance"
               }
@@ -2028,7 +4298,7 @@
               {
                 "value": {
                   "text": "Compare insurances now",
-                  "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_slice_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+                  "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_slice_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
                   "tracking": {
                     "linkId": "check24-slice-overlay",
                     "linkGroup": {
@@ -2040,15 +4310,15 @@
               }
             ],
             "partiallyComprehensive": {
-              "raw": 13.42,
-              "formatted": "€ 13,42",
+              "raw": 11.91,
+              "formatted": "€ 11,91",
               "translation": {
                 "value": "Partial cover"
               }
             },
             "fullyComprehensive": {
-              "raw": 17.96,
-              "formatted": "€ 17,96",
+              "raw": 13.19,
+              "formatted": "€ 13,19",
               "translation": {
                 "value": "Comprehensive"
               }
@@ -2088,11 +4358,11 @@
               }
             },
             "stage": {
-              "rate": 10.78,
+              "rate": 9.54,
               "link": {
-                "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Fiat&model=500&cpref=dp_slice_widget_EN&HSN=1727&TSN=AUD&ERSTZUL=102022&ZUST=GEBR",
+                "url": "https://www.check24.de/kfz-versicherung/versicherungsangebot/?wpset=autoscout24_kfz_01&image=IMAGE_URL&make=Audi&model=A2&cpref=dp_slice_widget_EN&HSN=0588&TSN=734&ERSTZUL=032004&ZUST=GEBR",
                 "caption": "",
-                "text": "Compare car insurance",
+                "text": "Compare insurance",
                 "tracking": {
                   "linkId": "check24-slice-widget",
                   "linkGroup": {
@@ -2109,2724 +4379,37 @@
       "buttonWithLeasing": []
     },
     "trackingParams": {
-      "classified_recency": "regular",
-      "classified_makeId": 28,
-      "classified_makeTxt": "fiat",
-      "classified_modelID": 15160,
-      "classified_modelGroupID": 200524,
-      "classified_modelTxt": "500",
-      "classified_mileage": 28558,
-      "classified_power": 52,
-      "classified_price": 13270,
-      "classified_fueltype": "2",
+      "classified_recency": "new",
+      "classified_makeId": 9,
+      "classified_makeTxt": "audi",
+      "classified_modelID": 16416,
+      "classified_modelGroupID": 16416,
+      "classified_modelTxt": "a2",
+      "classified_mileage": 214000,
+      "classified_power": 55,
+      "classified_price": 1900,
+      "classified_fueltype": "b",
       "classified_transmission": "m",
-      "classified_equipment": "5,38,121,137,142,114,50,40,129,13,127,113,222,221,122,138,124,43,41,10,161,15,173,159,1,47,2,42,46,26,125,141,3,12,32,227,150,31",
+      "classified_equipment": "5,134,30,121,135,50,13,132,10,231,1,17,115,2,42,26,125,3,12,32,150",
       "classified_offerType": "u",
-      "classified_prevOwners": 1,
-      "classified_doors": 3,
-      "classified_seats": 4,
+      "classified_doors": 4,
+      "classified_seats": 5,
       "classified_customer_type": "d",
-      "classified_customerID": "50433550",
-      "classified_zipcode": "37574",
-      "classified_year": "2022",
-      "classified_capacity": 999,
-      "classified_bodyType": 6,
-      "classified_carSegment": "microcar,sedan",
+      "classified_customerID": "63169494",
+      "classified_zipcode": "54311",
+      "classified_year": "2004",
+      "classified_capacity": 1390,
+      "classified_bodyType": 1,
+      "classified_carSegment": "subcompact",
       "classified_country": "D",
-      "classified_emissionStandard": 8,
+      "classified_emissionStandard": 4,
       "classified_tier": "t50",
       "classified_applied_tier": "t50",
       "classified_images_threesixty": "standard",
       "classified_dealerPackage": "pro",
       "classified_exclusiveOffer": "false",
-      "classified_leadsRange": "some",
-      "classified_imageContent": "no-placeholder|0.24435598882892529",
-      "classified_isSmyleEligible": "true",
-      "classified_ownershipModels": "tr"
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "specialConditions": [],
-    "hasPremiumListingTreatment": true,
-    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"microcar,sedan\",\"did\":\"50433550\",\"stmil\":\"28558\",\"gear\":\"M\",\"make\":\"28\",\"stmak\":\"Fiat\",\"model\":\"15160\",\"stmod\":\"500\",\"cost\":\"13270\",\"stmon\":\"10\",\"styea\":\"2022\",\"ad\":\"dealer\",\"vat\":\"1\",\"art\":\"6\",\"carby\":\"0\",\"fr\":\"10\",\"stccm\":\"999\",\"buyonline\":\"false\",\"stkw\":\"52\",\"sthp\":\"71\",\"equi\":\"1,129,2,3,5,137,10,138,12,13,141,142,15,150,26,221,222,159,31,32,161,227,38,41,42,43,173,46,47,113,50,114,121,122,124,125,127,120,49,110,40\",\"miles\":\"3\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/117b7cf9-f7e8-449c-bfdd-cfd449484f99_fcc4639e-2ba9-4778-881e-6eba43729aab.jpg/720x540.webp\",\"price\":\"3\",\"rnd\":\"98\",\"ECO\":\"YES\",\"tsn\":\"AUD\",\"fuel\":\"2\",\"kenteken\":\"false\",\"hsn\":\"1727\",\"acc\":\"U\",\"hp\":\"2\",\"mgroupid\":\"200524\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"DE37574\",\"zip2\":\"37574\",\"articleType\":\"C\",\"tiered\":\"pro\"}",
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "imgAltText": "Fiat 500 Lim. Dolcevita 1.0*PDCh*DAB*Klima*uvm White",
-    "createdTimestampWithOffset": "2026-04-20T13:25:03.238Z",
-    "vehicleType": "phev",
-    "searchTrackingParams": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "organic"
-      },
-      {
-        "key": "boosting_product",
-        "value": "none"
-      }
-    ],
-    "articleType": "car",
-    "isNew": false
-  },
-  {
-    "id": "2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc",
-    "searchResultType": "Organic",
-    "isDeliverable": false,
-    "description": "Per chiedere informazioni o prenotare l&#x27;auto, chiamare il 351 659 1699!<br /><br />STOCK UNICO, AUTO A PARTIRE DA 2.000 KM FINO A 50.000 KM<br /><br />Fiat 500 del 2022 con 50.000 km, in elegante colore bianco, una citycar iconica che unisce stile italiano, praticità e comfort in ogni utilizzo. Compatta e chic, è perfetta per la città grazie alle dimensioni contenute e alla facilità di guida, rendendo ogni spostamento semplice e piacevole.<br /><br />Alla guida risulta fluida e intuitiva, ideale sia per neopatentati che per chi cerca un’auto pratica per tutti i giorni. Gli interni curati e la dotazione completa rendono l’esperienza a bordo superiore alla media della categoria, offrendo comfort e tecnologia in ogni viaggio.<br /><br />Accessori: Interni in pelle, cerchi in lega, tetto panoramico, volante multifunzione in pelle, comandi al volante, climatizzatore, alzacristalli elettrici, chiusura centralizzata con telecomando, Bluetooth, autoradio, USB, display touchscreen, Apple CarPlay e Android Auto, fendinebbia, cruise control, limitatore di velocità, sensori di parcheggio posteriori, start &amp; stop, servosterzo, ISOFIX.<br /><br />SI NOTI CHE: La vettura è di importazione estera, pertanto sono da aggiungere i costi di immatricolazione.<br /><br />PROMO &amp; VANTAGGI<br />Super Promo Finanziamento: 5.000 € di vantaggio<br />Garanzia 12 mesi inclusa<br />Garanzia estendibile fino a 5 anni<br />Copertura assicurativa personalizzabile su richiesta<br />Offerta valida esclusivamente a chi aderisce alla promo.<br />CHIAMACI SUBITO! +39 351 6591699<br /><br />I nostri servizi:<br />• Consegna in tutta Italia;<br />• Valutazione permute;<br />• Pagamenti personalizzati con mini rate!!<br /><br />Live Chat Whatsapp scrivici, invia foto del tuo usato,<br />richiedi un video a 360° della nostra vettura:<br />+39 351 6591699<br /><br />Siamo iscritti alla community: <br />Non prendermi per il Chilometro:<br />più del 50% delle auto usate in vendita può avere i chilometri scalati!<br />Tanti privati, rivenditori, autosaloni, concessionari e &quot;professionisti&quot; del settore, quotidianamente,<br />&quot;SCHILOMETRANO&quot; i contachilometri e si arricchiscono TRUFFANDO gli acquirenti.<br />Acquistare un&#x27;auto usata evitando la truffa non è semplice.<br /><br /><br />Questa auto è visibile nella nostra sede di Roma in:<br />Via di Vallerano, 151 - 00128 Roma<br />Tel. +39 06 45763040 - +39 351 6591699<br /><br />Le informazioni contenute negli annunci online e nel proprio sito web sono state compilate con cura affinché siano il più complete e precise; tuttavia possono contenere errori e omissioni. Si declina ogni responsabilità per eventuali involontarie incongruenze che non rappresentano un impegno contrattuale.<br />[PB:vacdb38:x141b4b83953940478e8f20ad8cb5d794]",
-    "ratings": {
-      "customerCulture": "it-IT",
-      "urlName": "https://www.autoscout24.com/dealerinfo/roma-car-trade-srl/ratings",
-      "ratingsCount": 112,
-      "ratingsStars": 4.5,
-      "ratingsAverage": "4,0",
-      "recommendPercentage": 82,
-      "ratingsByCategory": [
-        {
-          "stars": 4,
-          "label": "Gesamteindruck"
-        },
-        {
-          "stars": 4.5,
-          "label": "Erreichbarkeit"
-        },
-        {
-          "stars": 4,
-          "label": "Zuverlässigkeit"
-        },
-        {
-          "stars": 4,
-          "label": "Angebotsbeschreibung"
-        },
-        {
-          "stars": 4.5,
-          "label": "Kaufprozess"
-        },
-        {
-          "stars": 4,
-          "label": "Consultancy"
-        }
-      ]
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_12cfe665-b1e9-45c4-934f-9daa8525c0fa.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_1fc508e5-a6f8-4981-880c-154bc1e5858d.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_d27e7b1c-234a-479a-90cf-1adf2a985bf1.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_051a8d72-46ce-4965-98d2-4a7437f60f2a.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_3ad0f9bc-24a8-464f-a291-cf05e2e77641.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_758feeb3-953e-4181-9556-922284aad168.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_2de6d397-4f44-44ad-ac5d-bada3cdb5c35.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_cb108e41-809b-47e2-896a-47143e6ff9dc.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_324552b5-7b69-4fb7-b9ec-6eb21180cf47.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_6e41700e-6e9b-45e0-9b1e-d78b532f96d7.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_828774a4-23a9-4c1a-8431-0f5bf726da3a.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_ae2671f6-61d0-42a4-a499-b7c3b825e17d.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_c79eb461-7d66-4e8f-80f1-8952bb5f76ff.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_ddb32978-8b3f-496a-9d05-1bdef4aab26c.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_0df515d8-9ded-4b87-a981-378a2023de97.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_4edcbc1b-78cb-4c8e-bf8d-4e8d276df586.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_557dbb8d-ff73-40b8-9530-2bf54a07dd36.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_9fb7b7f8-b71a-41c5-b377-b3fa833a31c8.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_df4e5ecf-21e0-4a4e-a999-32c8b9d8c876.jpg/1280x960.webp"
-    ],
-    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_12cfe665-b1e9-45c4-934f-9daa8525c0fa.jpg/120x90.webp",
-    "youtubeLink": null,
-    "twinnerUrl": null,
-    "isCoverImagePlaceholder": false,
-    "coverImageAttractiveness": 0.16942387802384296,
-    "hasThreeSixtyContent": false,
-    "threeSixty": null,
-    "prices": {
-      "isFinalPrice": false,
-      "public": {
-        "price": "€ 7,880",
-        "priceRaw": 7880,
-        "taxDeductible": true,
-        "negotiable": false,
-        "onRequestOnly": false,
-        "netPrice": null,
-        "netPriceRaw": null,
-        "vatRate": 22,
-        "category": null,
-        "evaluationRanges": null
-      },
-      "dealer": {
-        "price": "€ 7,880",
-        "priceRaw": 7880,
-        "taxDeductible": true,
-        "negotiable": false,
-        "onRequestOnly": false,
-        "netPrice": null,
-        "netPriceRaw": null,
-        "vatRate": 22,
-        "category": null,
-        "evaluationRanges": null
-      },
-      "suggestedRetail": null,
-      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc?culture=en-GB",
-      "error": null
-    },
-    "superDeal": null,
-    "price": {
-      "priceFormatted": "€ 7,880",
-      "isVatLabelLegallyRequired": false,
-      "priceSuperscriptString": "1",
-      "isConditionalPrice": true
-    },
-    "availability": {
-      "rawFromDate": null,
-      "fromDate": null,
-      "inDays": null
-    },
-    "financingFlags": {
-      "showStageFinancingAmvLegendSpain": false
-    },
-    "vehicle": {
-      "licensePlate": null,
-      "carpassMileageUrl": null,
-      "makeId": 28,
-      "modelOrModelLineId": 15160,
-      "make": "Fiat",
-      "model": "500",
-      "modelGroup": "500",
-      "variant": "500 Hybrid",
-      "modelId": 15160,
-      "modelGroupIds": [
-        200524
-      ],
-      "modelGenerationId": 789,
-      "modelVariantId": 3090,
-      "motorTypeId": 1762,
-      "trimLineId": 2586,
-      "modelVersionInput": "1.0 Hybrid Dolcevita",
-      "type": "Car",
-      "hsnTsn": null,
-      "mileageInKmRaw": 58114,
-      "mileageInKm": "58,114 km",
-      "firstRegistrationDateRaw": "2022-01-01",
-      "firstRegistrationDate": "01/2022",
-      "bodyType": "Sedan",
-      "numberOfSeats": 4,
-      "numberOfDoors": 3,
-      "bodyColor": "White",
-      "bodyColorRaw": "White",
-      "paintType": "Others",
-      "bodyColorOriginal": "Bianco",
-      "engineHours": "",
-      "fuelDeliveryType": "",
-      "engineCoolingSystem": "",
-      "slideOutCount": null,
-      "chassisManufacturerName": "",
-      "exteriorMaterial": "",
-      "extendedLength": "",
-      "flooringMaterial": "",
-      "fridgePowerType": "",
-      "fridgeCapacity": "",
-      "waterTankCapacity": "",
-      "wasteTankCapacity": "",
-      "engineManufacturerName": "",
-      "axleSpread": "",
-      "brakeType": "",
-      "cabinAxleDistance": "",
-      "differentialRatio": "",
-      "frameType": "",
-      "rearAxleWeightRating": "",
-      "frontAxleWeightRating": "",
-      "trackDimension": "",
-      "skiStanceWidth": "",
-      "fuelCapacity": "",
-      "headCount": null,
-      "hullMaterial": null,
-      "steeringType": null,
-      "auxiliaryPower": null,
-      "engineMountingType": null,
-      "engineCount": null,
-      "isCabinClean": false,
-      "upholstery": "Full leather",
-      "upholsteryColor": "Beige",
-      "marketingDescription": "",
-      "controlModuleName": "",
-      "powerInKw": "51 kW",
-      "powerInHp": "69 hp",
-      "rawPowerInKw": 51,
-      "rawPowerInHp": 69,
-      "transmissionType": "Manual",
-      "gears": 6,
-      "cylinders": null,
-      "driveTrain": "Front Wheel Drive",
-      "displacementInCCM": "999 cc",
-      "rawDisplacementInCCM": 999,
-      "cylinderCapacity": "999 cc",
-      "rawCylinderCapacity": 999,
-      "weight": "1,055 kg",
-      "hasParticleFilter": false,
-      "fuelCategory": {
-        "raw": "2",
-        "formatted": "Electric/Gasoline"
-      },
-      "batteryOwnershipType": {
-        "raw": null,
-        "formatted": null
-      },
-      "batteryChargingTime": {
-        "raw": null,
-        "formatted": null
-      },
-      "electricRangeWithFallback": {
-        "raw": null,
-        "formatted": null
-      },
-      "electricRangeCity": {
-        "raw": null,
-        "formatted": null
-      },
-      "primaryFuel": {
-        "raw": 12,
-        "formatted": "Electricity"
-      },
-      "additionalFuel": [
-        {
-          "raw": 1,
-          "formatted": "Regular/Benzine 91",
-          "consumptionCombined": {
-            "raw": 3.9,
-            "formatted": "3.90 l/100 km (comb.)",
-            "isFallback": false
-          },
-          "co2emissionInGramPerKmWithFallback": {
-            "raw": null,
-            "formatted": "- (g/km)",
-            "isFallback": false
-          }
-        }
-      ],
-      "fuelConsumptionCombined": {
-        "raw": 3.9,
-        "formatted": "4",
-        "isFallback": false
-      },
-      "fuelConsumptionUrban": {
-        "raw": null,
-        "formatted": null
-      },
-      "fuelConsumptionExtraUrban": {
-        "raw": null,
-        "formatted": null
-      },
-      "co2emissionInGramPerKmWithFallback": {
-        "raw": null,
-        "formatted": null,
-        "isFallback": null
-      },
-      "wltp": null,
-      "allFuelTypes": [
-        {
-          "raw": 1,
-          "formatted": "Regular/Benzine 91"
-        }
-      ],
-      "equipment": {
-        "comfortAndConvenience": [
-          {
-            "id": "Air conditioning",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Automatic climate control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Cruise control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Electrical side mirrors",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Leather seats",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Leather steering wheel",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Multi-function steering wheel",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Navigation system",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Panorama roof",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Park Distance Control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system camera",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system sensors front",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system sensors rear",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Power windows",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Start-stop system",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          }
-        ],
-        "entertainmentAndMedia": [
-          {
-            "id": "Android Auto",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Apple CarPlay",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Bluetooth",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Digital radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Hands-free equipment",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "On-board computer",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "USB",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          }
-        ],
-        "extras": [
-          {
-            "id": "Alloy wheels",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Ambient lighting",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Electronic parking brake",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Voice Control",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          }
-        ],
-        "safetyAndSecurity": [
-          {
-            "id": "ABS",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Central door lock",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Central door lock with remote control",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Daytime running lights",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Driver-side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Emergency brake assistant",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Emergency system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Fog lights",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Full-LED headlights",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Isofix",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Passenger-side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Power steering",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Speed limit control system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Tire pressure monitoring system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Traction control",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          }
-        ]
-      },
-      "environmentPkwEnVKV": null,
-      "environmentEuDirective": {
-        "description": null,
-        "formatted": "Euro 6d-TEMP",
-        "label": "EURO6dTemp",
-        "isFallback": false,
-        "co2EfficiencyClass": "EURO6dTemp"
-      },
-      "environmentBImSchV35": null,
-      "originalMarket": null,
-      "legalCategories": [
-        "Used"
-      ],
-      "legalCategoriesRaw": [
-        "UsedVehicle"
-      ],
-      "hadAccident": null,
-      "damageConditions": [],
-      "newInspection": false,
-      "lastBeltServiceDate": null,
-      "lastTechnicalServiceDate": null,
-      "hasFullServiceHistory": false,
-      "nonSmoking": false,
-      "noOfPreviousOwners": 1,
-      "nextVehicleSafetyInspection": null,
-      "isRental": false,
-      "numberOfBeds": null,
-      "numberOfAxles": null,
-      "wheelBase": null,
-      "totalHeight": null,
-      "totalWidth": null,
-      "totalLength": null,
-      "maximumTowingWeight": null,
-      "grossVehicleWeight": null,
-      "payload": null,
-      "loadWidth": null,
-      "loadHeight": null,
-      "loadLength": null,
-      "loadVolume": null,
-      "productionYear": null,
-      "hasCarRegistration": false,
-      "offerType": "U",
-      "newDriverSuitable": null,
-      "rawData": {
-        "totalLength": null,
-        "engineHours": null,
-        "usageState": "U",
-        "productionDate": null,
-        "legalCategories": [
-          {
-            "formatted": "Used",
-            "raw": "UsedVehicle"
-          }
-        ],
-        "classification": {
-          "type": "Car",
-          "modelYear": null,
-          "make": {
-            "raw": 28,
-            "formatted": "Fiat"
-          },
-          "model": {
-            "raw": 15160,
-            "formatted": "500"
-          },
-          "modelGroups": [
-            {
-              "raw": 200524,
-              "formatted": "500"
-            }
-          ],
-          "modelGeneration": {
-            "raw": 789,
-            "formatted": "312"
-          },
-          "modelVariant": {
-            "raw": 3090,
-            "formatted": "500 Hybrid"
-          },
-          "motorType": {
-            "raw": 1762
-          },
-          "trimLine": {
-            "raw": 2586
-          },
-          "modelVersionInput": "1.0 Hybrid Dolcevita",
-          "germanHsnTsn": null
-        },
-        "fuels": {
-          "isPluginHybrid": null,
-          "primary": {
-            "type": {
-              "raw": 12,
-              "formatted": "Electricity"
-            },
-            "consumption": {
-              "combinedWithFallback": {
-                "raw": 3.9,
-                "formatted": "4",
-                "isFallback": false
-              },
-              "urban": null,
-              "extraUrban": null
-            },
-            "co2emissionInGramPerKmWithFallback": null
-          },
-          "additional": [
-            {
-              "type": {
-                "raw": 1,
-                "formatted": "Regular/Benzine 91"
-              },
-              "consumption": {
-                "combinedWithFallback": {
-                  "raw": 3.9,
-                  "formatted": "3.90 l/100 km (comb.)",
-                  "isFallback": false
-                }
-              },
-              "co2emissionInGramPerKmWithFallback": {
-                "raw": null,
-                "formatted": "- (g/km)",
-                "isFallback": false
-              }
-            }
-          ],
-          "fuelCategory": {
-            "raw": "2",
-            "formatted": "Electric/Gasoline"
-          },
-          "wltp": null,
-          "electricRangeWithFallback": null,
-          "electricRangeCity": null,
-          "allFuelTypes": [
-            {
-              "raw": 1,
-              "formatted": "Regular/Benzine 91"
-            }
-          ],
-          "battery": null
-        },
-        "engine": {
-          "engineDisplacementInCCM": {
-            "raw": 999,
-            "formatted": "999 cc"
-          },
-          "power": {
-            "kw": {
-              "raw": 51,
-              "formatted": "51 kW"
-            },
-            "hp": {
-              "raw": 69,
-              "formatted": "69 hp"
-            }
-          },
-          "transmissionType": {
-            "raw": "Manual",
-            "formatted": "Manual"
-          },
-          "numberOfCylinders": null,
-          "cylinderCapacity": {
-            "raw": 999,
-            "unit": "ccm",
-            "formatted": "999 cc"
-          },
-          "numberOfGears": 6,
-          "driveTrain": {
-            "formatted": "Front Wheel Drive"
-          }
-        },
-        "condition": {
-          "firstRegistrationDate": {
-            "raw": "2022-01-01",
-            "formatted": "01/2022"
-          },
-          "mileageInKm": {
-            "raw": 58114,
-            "formatted": "58,114 km"
-          },
-          "numberOfPreviousOwnersExtended": {
-            "raw": 1,
-            "formatted": "1 previous owner"
-          },
-          "damage": {
-            "isCurrentlyDamaged": null,
-            "isRoadworthy": null,
-            "accidentFree": null,
-            "hasRepairedDamages": null,
-            "damageConditions": []
-          },
-          "nonSmoking": false,
-          "newInspection": false,
-          "isCabinClean": null,
-          "carpassMileageUrl": null
-        },
-        "bodyType": {
-          "formatted": "Sedan",
-          "raw": "Sedan"
-        },
-        "bodyColor": {
-          "raw": "White",
-          "formatted": "White"
-        },
-        "numberOfBeds": {
-          "raw": null,
-          "formatted": "- (Number of sleeps)"
-        },
-        "numberOfAxles": {
-          "raw": null,
-          "formatted": "- (Axle count)"
-        },
-        "grossVehicleWeight": null,
-        "wheelBase": null,
-        "costModel": null,
-        "numberOfDoors": 3,
-        "paintType": {
-          "formatted": "Others"
-        },
-        "bodyColorOriginal": "Bianco",
-        "interior": {
-          "numberOfSeats": 4,
-          "upholstery": {
-            "formatted": "Full leather"
-          },
-          "upholsteryColor": {
-            "formatted": "Beige"
-          }
-        },
-        "emptyWeight": {
-          "formatted": "1,055 kg"
-        },
-        "identifier": {
-          "licensePlate": null,
-          "vin": "ZFACF1CJ8NJG84393"
-        },
-        "totalHeight": null,
-        "totalWidth": null,
-        "maximumTowingWeight": null,
-        "payload": null,
-        "loadWidth": null,
-        "loadHeight": null,
-        "loadLength": null,
-        "loadVolume": null,
-        "hasCarRegistration": {
-          "raw": false
-        },
-        "environment": {
-          "particulateFilter": false,
-          "environmentLabelsWithFallback": [
-            {
-              "norm": "EU_Directive_70_220_EEC_LDV",
-              "description": null,
-              "formatted": "Euro 6d-TEMP",
-              "label": "EURO6dTemp",
-              "isFallback": false
-            }
-          ]
-        },
-        "equipment": {
-          "as24": [
-            {
-              "id": {
-                "raw": 5,
-                "formatted": "Air conditioning"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 30,
-                "formatted": "Automatic climate control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 38,
-                "formatted": "Cruise control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 121,
-                "formatted": "Electrical side mirrors"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 6,
-                "formatted": "Leather seats"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 142,
-                "formatted": "Leather steering wheel"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 114,
-                "formatted": "Multi-function steering wheel"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 23,
-                "formatted": "Navigation system"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 50,
-                "formatted": "Panorama roof"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 40,
-                "formatted": "Park Distance Control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 130,
-                "formatted": "Parking assist system camera"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 128,
-                "formatted": "Parking assist system sensors front"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 129,
-                "formatted": "Parking assist system sensors rear"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 13,
-                "formatted": "Power windows"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 113,
-                "formatted": "Start-stop system"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 222,
-                "formatted": "Android Auto"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 221,
-                "formatted": "Apple CarPlay"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 122,
-                "formatted": "Bluetooth"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 138,
-                "formatted": "Digital radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 124,
-                "formatted": "Hands-free equipment"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 41,
-                "formatted": "On-board computer"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 10,
-                "formatted": "Radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 161,
-                "formatted": "USB"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 15,
-                "formatted": "Alloy wheels"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 219,
-                "formatted": "Ambient lighting"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 240,
-                "formatted": "Electronic parking brake"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 156,
-                "formatted": "Voice Control"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 1,
-                "formatted": "ABS"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 17,
-                "formatted": "Central door lock"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 47,
-                "formatted": "Central door lock with remote control"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 115,
-                "formatted": "Daytime running lights"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 2,
-                "formatted": "Driver-side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 148,
-                "formatted": "Emergency brake assistant"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 149,
-                "formatted": "Emergency system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 19,
-                "formatted": "Fog lights"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 239,
-                "formatted": "Full-LED headlights"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 125,
-                "formatted": "Isofix"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 3,
-                "formatted": "Passenger-side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 12,
-                "formatted": "Power steering"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 227,
-                "formatted": "Speed limit control system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 150,
-                "formatted": "Tire pressure monitoring system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 31,
-                "formatted": "Traction control"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            }
-          ]
-        },
-        "alloyWheelInches": null,
-        "originalMarket": null,
-        "maintenance": {
-          "nextVehicleSafetyInspection": null,
-          "lastBeltServiceDate": null,
-          "hasFullServiceHistory": {
-            "raw": false
-          },
-          "lastTechnicalServiceDate": null
-        },
-        "newDriverSuitable": null
-      },
-      "identifier": {
-        "vin": "ZFACF1CJ8NJG84393"
-      }
-    },
-    "identifier": {
-      "offerReference": "14015571004-U821",
-      "legacyId": null
-    },
-    "seals": null,
-    "location": {
-      "countryCode": "IT",
-      "zip": "00128",
-      "city": "Roma - RM",
-      "street": "Via di Vallerano 151",
-      "latitude": 41.78747,
-      "longitude": 12.45527
-    },
-    "seller": {
-      "id": 22013569,
-      "sellId": 2142151820,
-      "isDealer": true,
-      "type": "Dealer",
-      "companyName": "Roma Car Trade srl",
-      "contactName": "Roma Car Trade",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/22013569-original-d225a4fa-9fd9-43ee-bd86-a1b43542a8ba/resize/100x50%3E/quality/90"
-        },
-        "big": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/22013569-original-d225a4fa-9fd9-43ee-bd86-a1b43542a8ba/resize/200x100%3E/quality/90"
-        }
-      },
-      "links": {
-        "infoPage": "https://www.autoscout24.com/dealerinfo/roma-car-trade-srl/about-us",
-        "imprint": "https://www.autoscout24.com/dealerinfo/roma-car-trade-srl/imprint",
-        "stockLink": "https://www.autoscout24.com/dealerinfo/roma-car-trade-srl?atype=C"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+39 351 - 6591699",
-          "callTo": "+393516591699"
-        },
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+39 06 - 45763040",
-          "callTo": "+390645763040"
-        }
-      ],
-      "dealer": {
-        "maxImages": 50,
-        "culture": "it-IT",
-        "isFreespeeCallTrackingEnabled": true,
-        "tieredPricingPackage": "Active",
-        "autoMatchPackage": {
-          "tier": "medium"
-        },
-        "hasMyVehiclesRecommenderCarousel": false,
-        "superbranding": {
-          "images": {
-            "dealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/22013569-original-09151602-610d-48f0-86b9-d35e2c4aa503.jpg/resize/800x500%3E/quality/90",
-            "dealershipInterior": null,
-            "mediumDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/22013569-original-09151602-610d-48f0-86b9-d35e2c4aa503.jpg/resize/800x500%3E/quality/90",
-            "smallDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/22013569-original-09151602-610d-48f0-86b9-d35e2c4aa503.jpg/resize/800x500%3E/quality/90",
-            "smallDealershipInterior": null,
-            "mediumDealershipInterior": null
-          },
-          "contactPerson": {
-            "image": null,
-            "languages": [
-              {
-                "id": "ENGLISH",
-                "name": "English"
-              },
-              {
-                "id": "ITALIAN",
-                "name": "Italiano"
-              }
-            ],
-            "name": "✅Finanziamenti anticpo 0 ✅Mini Rate Mensili ✅Garanzia fino a 84 mesi",
-            "position": "🟠 VETTURE REALMENTE DISPONIBILI 🟠 PRENOTA IL TUO TEST DRIVE 🟠"
-          }
-        },
-        "covidServices": null,
-        "openingHours": {
-          "department": "12",
-          "state": "closed",
-          "statusLabel": "Closed",
-          "infoLabel": "Opens at 15:00"
-        },
-        "openingHoursRaw": [
-          {
-            "department": "12",
-            "timetable": [
-              [
-                900,
-                1300,
-                1500,
-                1900
-              ],
-              [
-                900,
-                1300,
-                1500,
-                1900
-              ],
-              [
-                900,
-                1300,
-                1500,
-                1900
-              ],
-              [
-                900,
-                1300,
-                1500,
-                1900
-              ],
-              [
-                900,
-                1300,
-                1500,
-                1900
-              ],
-              [
-                1000,
-                1300,
-                1500,
-                1800
-              ],
-              [
-                1000,
-                1300
-              ]
-            ]
-          }
-        ],
-        "homepageUrl": null,
-        "googleRatings": null,
-        "customerSince": 2016,
-        "region": null,
-        "nationwideListingsData": null
-      }
-    },
-    "whatsappNumber": "+39 351 - 6591699",
-    "webPage": "https://www.autoscout24.com/offers/fiat-500-1-0-hybrid-dolcevita-electric-gasoline-white-2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc",
-    "status": "Active",
-    "leasingDetails": null,
-    "warranty": null,
-    "warrantyExists": false,
-    "ocsInfo": {
-      "__typename": "NotOcs"
-    },
-    "financingAndInsurance": {
-      "buttonWithFinance": [],
-      "buttonWithInsurance": [],
-      "buttonWithLeasing": []
-    },
-    "trackingParams": {
-      "classified_recency": "regular",
-      "classified_makeId": 28,
-      "classified_makeTxt": "fiat",
-      "classified_modelID": 15160,
-      "classified_modelGroupID": 200524,
-      "classified_modelTxt": "500",
-      "classified_mileage": 58114,
-      "classified_power": 51,
-      "classified_price": 7880,
-      "classified_fueltype": "2",
-      "classified_transmission": "m",
-      "classified_equipment": "5,30,38,121,6,142,114,23,50,40,130,128,129,13,113,222,221,122,138,124,41,10,161,15,219,240,156,1,17,47,115,2,148,149,19,239,125,3,12,227,150,31",
-      "classified_offerType": "u",
-      "classified_prevOwners": 1,
-      "classified_doors": 3,
-      "classified_seats": 4,
-      "classified_customer_type": "d",
-      "classified_customerID": "22013569",
-      "classified_zipcode": "00128",
-      "classified_year": "2022",
-      "classified_consumption": 3.9,
-      "classified_capacity": 999,
-      "classified_bodyType": 6,
-      "classified_carSegment": "microcar,sedan",
-      "classified_country": "I",
-      "classified_emissionStandard": 9,
-      "classified_tier": "t50",
-      "classified_applied_tier": "t50",
-      "classified_images_threesixty": "standard",
-      "classified_dealerPackage": "active",
-      "classified_exclusiveOffer": "false",
-      "classified_leadsRange": "some",
-      "classified_imageContent": "no-placeholder|0.16942387802384296",
-      "classified_isSmyleEligible": "true",
-      "classified_ownershipModels": "tr"
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "specialConditions": [],
-    "hasPremiumListingTreatment": true,
-    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"microcar,sedan\",\"did\":\"22013569\",\"stmil\":\"58114\",\"gear\":\"M\",\"make\":\"28\",\"stmak\":\"Fiat\",\"model\":\"15160\",\"stmod\":\"500\",\"cost\":\"7880\",\"stmon\":\"1\",\"styea\":\"2022\",\"ad\":\"dealer\",\"vat\":\"1\",\"art\":\"6\",\"carby\":\"0\",\"fr\":\"10\",\"stccm\":\"999\",\"buyonline\":\"false\",\"stkw\":\"51\",\"sthp\":\"69\",\"equi\":\"128,1,129,2,130,3,5,10,138,12,13,142,15,17,19,148,149,150,23,219,156,221,30,222,31,161,227,38,41,239,47,240,113,50,114,115,121,122,124,125,6,40\",\"miles\":\"4\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc_12cfe665-b1e9-45c4-934f-9daa8525c0fa.jpg/720x540.webp\",\"price\":\"2\",\"rnd\":\"15\",\"ECO\":\"YES\",\"fuel\":\"2\",\"kenteken\":\"false\",\"acc\":\"U\",\"hp\":\"2\",\"mgroupid\":\"200524\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"IT00128\",\"zip2\":\"00128\",\"articleType\":\"C\",\"tiered\":\"active\"}",
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "imgAltText": "Fiat 500 1.0 Hybrid Dolcevita White",
-    "createdTimestampWithOffset": "2026-05-07T19:58:19.800Z",
-    "vehicleType": "phev",
-    "searchTrackingParams": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "organic"
-      },
-      {
-        "key": "boosting_product",
-        "value": "none"
-      }
-    ],
-    "articleType": "car",
-    "isNew": false
-  },
-  {
-    "id": "7bc1efe2-6741-46d9-9af1-9c1e525bdd86",
-    "searchResultType": "Organic",
-    "isDeliverable": false,
-    "description": "VETTURA : EY887RM<br /><ul><li>EURO 6</li><li>INTERNI TENUTI BENE</li><li>MECCANICA IN ORDINE</li><li>PNEUMATICI IN BUONO STATO</li><li>REVISIONE VALIDA FINO A 11/2027</li><li>KM ULTIMA REVISIONE 11/2025 20000 KM</li><li>KM REVISIONE 11/2023 162000 KM</li><li>KM REVISIONE 11/2021 131000 KM</li><li>KM REVISIONE 05/2019 89000   KM</li><li>Si consiglia di verificare la disponibilità effettiva della vettura previo invio mail oppure contattando il numero di telefono segnalato sull’annuncio.</li><li>La dotazione tecnica e gli optional potrebbero in alcuni casi differire dall&#x27;effettivo equipaggiamento della vettura.</li><li>Ci scusiamo per l’inconveniente e La invitiamo, pertanto, a verificare le caratteristiche dello specifico veicolo.</li><li>Il prezzo non è comprensivo delle spese di passaggio di proprietà.</li><li>Ricevimento clientela alla stazione ferroviaria di: Bergamo Centro - Stezzano - Verdello/Dalmine.</li><li> </li></ul>L&#x27;esposizione della vettura è a LALLIO (BG)VIA PROVINCIALE 31 (EX CONSORZIO AGRARIO ).",
-    "ratings": {
-      "customerCulture": "it-IT",
-      "urlName": "https://www.autoscout24.com/dealerinfo/suv-e-city-car/ratings",
-      "ratingsCount": 130,
-      "ratingsStars": 4.5,
-      "ratingsAverage": "4,1",
-      "recommendPercentage": 82,
-      "ratingsByCategory": [
-        {
-          "stars": 4.5,
-          "label": "Gesamteindruck"
-        },
-        {
-          "stars": 4.5,
-          "label": "Erreichbarkeit"
-        },
-        {
-          "stars": 4.5,
-          "label": "Zuverlässigkeit"
-        },
-        {
-          "stars": 4.5,
-          "label": "Angebotsbeschreibung"
-        },
-        {
-          "stars": 5,
-          "label": "Kaufprozess"
-        },
-        {
-          "stars": 4,
-          "label": "Consultancy"
-        }
-      ]
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_8b890c88-6442-4a61-bfb2-e1ca02e3b554.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_901932d9-6c45-4c30-800f-89c02fe36300.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_58513aa4-c1c5-4008-82c7-9a78cca723f4.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_4e22a5b2-b1f7-42d6-9ee7-5d1c70dd2262.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_c6788ade-4f54-4c95-ac88-9f20ff1da240.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_09743750-9acf-4a5b-ae8d-2011ef1be7dc.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_3aa0dc43-e6fe-4d58-b129-fc2e1446c982.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_d222ad69-b42e-4f7a-88be-851a17065809.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_88a34fcf-bdb7-4067-8b7d-57bc3022244b.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_d25e39b4-cbba-4860-8538-7be73adf8b16.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_2ca22689-4c73-4947-ae63-71111a933fea.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_540d667b-e69a-44b1-b1e7-988682e24b0d.jpg/1280x960.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_256fbaf7-fec1-4e9f-8618-9492e3efcb45.jpg/1280x960.webp"
-    ],
-    "headerImage": "https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_8b890c88-6442-4a61-bfb2-e1ca02e3b554.jpg/120x90.webp",
-    "youtubeLink": null,
-    "twinnerUrl": null,
-    "isCoverImagePlaceholder": false,
-    "coverImageAttractiveness": 0.18844014991930824,
-    "hasThreeSixtyContent": false,
-    "threeSixty": null,
-    "prices": {
-      "isFinalPrice": false,
-      "public": {
-        "price": "€ 7,900",
-        "priceRaw": 7900,
-        "taxDeductible": false,
-        "negotiable": false,
-        "onRequestOnly": false,
-        "netPrice": null,
-        "netPriceRaw": null,
-        "vatRate": null,
-        "category": null,
-        "evaluationRanges": null
-      },
-      "dealer": {
-        "price": "€ 7,900",
-        "priceRaw": 7900,
-        "taxDeductible": false,
-        "negotiable": false,
-        "onRequestOnly": false,
-        "netPrice": null,
-        "netPriceRaw": null,
-        "vatRate": null,
-        "category": null,
-        "evaluationRanges": null
-      },
-      "suggestedRetail": null,
-      "popupUrl": "https://www.autoscout24.com/priceevaluation/price-label-explanation-page/7bc1efe2-6741-46d9-9af1-9c1e525bdd86?culture=en-GB",
-      "error": null
-    },
-    "superDeal": null,
-    "price": {
-      "priceFormatted": "€ 7,900",
-      "isVatLabelLegallyRequired": false,
-      "isConditionalPrice": false
-    },
-    "availability": {
-      "rawFromDate": null,
-      "fromDate": null,
-      "inDays": null
-    },
-    "financingFlags": {
-      "showStageFinancingAmvLegendSpain": false
-    },
-    "vehicle": {
-      "licensePlate": null,
-      "carpassMileageUrl": null,
-      "makeId": 13,
-      "modelOrModelLineId": 18480,
-      "make": "BMW",
-      "model": "116",
-      "modelGroup": "1 Series",
-      "variant": null,
-      "modelId": 18480,
-      "modelGroupIds": [
-        100037
-      ],
-      "modelGenerationId": 192,
-      "modelVariantId": null,
-      "motorTypeId": 518,
-      "trimLineId": 479256,
-      "modelVersionInput": "116d EURO 6",
-      "type": "Car",
-      "hsnTsn": null,
-      "mileageInKmRaw": 200000,
-      "mileageInKm": "200,000 km",
-      "firstRegistrationDateRaw": "2015-05-01",
-      "firstRegistrationDate": "05/2015",
-      "bodyType": "Sedan",
-      "numberOfSeats": 5,
-      "numberOfDoors": 5,
-      "bodyColor": "White",
-      "bodyColorRaw": "White",
-      "paintType": "Others",
-      "bodyColorOriginal": null,
-      "engineHours": "",
-      "fuelDeliveryType": "",
-      "engineCoolingSystem": "",
-      "slideOutCount": null,
-      "chassisManufacturerName": "",
-      "exteriorMaterial": "",
-      "extendedLength": "",
-      "flooringMaterial": "",
-      "fridgePowerType": "",
-      "fridgeCapacity": "",
-      "waterTankCapacity": "",
-      "wasteTankCapacity": "",
-      "engineManufacturerName": "",
-      "axleSpread": "",
-      "brakeType": "",
-      "cabinAxleDistance": "",
-      "differentialRatio": "",
-      "frameType": "",
-      "rearAxleWeightRating": "",
-      "frontAxleWeightRating": "",
-      "trackDimension": "",
-      "skiStanceWidth": "",
-      "fuelCapacity": "",
-      "headCount": null,
-      "hullMaterial": null,
-      "steeringType": null,
-      "auxiliaryPower": null,
-      "engineMountingType": null,
-      "engineCount": null,
-      "isCabinClean": false,
-      "upholstery": "Cloth",
-      "upholsteryColor": "Grey",
-      "marketingDescription": "",
-      "controlModuleName": "",
-      "powerInKw": "85 kW",
-      "powerInHp": "116 hp",
-      "rawPowerInKw": 85,
-      "rawPowerInHp": 116,
-      "transmissionType": "Manual",
-      "gears": 6,
-      "cylinders": 3,
-      "driveTrain": null,
-      "displacementInCCM": "1,496 cc",
-      "rawDisplacementInCCM": 1496,
-      "cylinderCapacity": "1,496 cc",
-      "rawCylinderCapacity": 1496,
-      "weight": "1,395 kg",
-      "hasParticleFilter": true,
-      "fuelCategory": {
-        "raw": "D",
-        "formatted": "Diesel"
-      },
-      "batteryOwnershipType": {
-        "raw": null,
-        "formatted": null
-      },
-      "batteryChargingTime": {
-        "raw": null,
-        "formatted": null
-      },
-      "electricRangeWithFallback": {
-        "raw": null,
-        "formatted": null
-      },
-      "electricRangeCity": {
-        "raw": null,
-        "formatted": null
-      },
-      "primaryFuel": {
-        "raw": 7,
-        "formatted": "Diesel"
-      },
-      "additionalFuel": [],
-      "fuelConsumptionCombined": {
-        "raw": 4.2,
-        "formatted": "4.20 l/100 km (comb.)",
-        "isFallback": false
-      },
-      "fuelConsumptionUrban": {
-        "raw": null,
-        "formatted": null
-      },
-      "fuelConsumptionExtraUrban": {
-        "raw": null,
-        "formatted": null
-      },
-      "co2emissionInGramPerKmWithFallback": {
-        "raw": null,
-        "formatted": "- (g/km)",
-        "isFallback": false
-      },
-      "wltp": null,
-      "allFuelTypes": [],
-      "equipment": {
-        "comfortAndConvenience": [
-          {
-            "id": "Air conditioning",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Armrest",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Cruise control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Electrical side mirrors",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Fold flat passenger seat",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Leather steering wheel",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Light sensor",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Multi-function steering wheel",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Park Distance Control",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system sensors front",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Parking assist system sensors rear",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Power windows",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Rain sensor",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Split rear seats",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          },
-          {
-            "id": "Start-stop system",
-            "categoryName": "Comfort & Convenience",
-            "categoryId": "comfortAndConvenience"
-          }
-        ],
-        "entertainmentAndMedia": [
-          {
-            "id": "Bluetooth",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "CD player",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Digital radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "MP3",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "On-board computer",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "Radio",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          },
-          {
-            "id": "USB",
-            "categoryName": "Entertainment & Media",
-            "categoryId": "entertainmentAndMedia"
-          }
-        ],
-        "extras": [
-          {
-            "id": "Alloy wheels",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Particle filter",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          },
-          {
-            "id": "Steel wheels",
-            "categoryName": "Extras",
-            "categoryId": "extras"
-          }
-        ],
-        "safetyAndSecurity": [
-          {
-            "id": "ABS",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Alarm system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Central door lock",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Central door lock with remote control",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Distance warning system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Driver-side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Electronic stability control",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Fog lights",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Head airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "High beam assist",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Isofix",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Passenger-side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Power steering",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Side airbag",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          },
-          {
-            "id": "Tire pressure monitoring system",
-            "categoryName": "Safety & Security",
-            "categoryId": "safetyAndSecurity"
-          }
-        ]
-      },
-      "environmentPkwEnVKV": null,
-      "environmentEuDirective": {
-        "description": null,
-        "formatted": "Euro 6",
-        "label": "EURO6",
-        "isFallback": false,
-        "co2EfficiencyClass": "EURO6"
-      },
-      "environmentBImSchV35": null,
-      "originalMarket": null,
-      "legalCategories": [
-        "Used"
-      ],
-      "legalCategoriesRaw": [
-        "UsedVehicle"
-      ],
-      "hadAccident": null,
-      "damageConditions": [],
-      "newInspection": false,
-      "lastBeltServiceDate": null,
-      "lastTechnicalServiceDate": null,
-      "hasFullServiceHistory": false,
-      "nonSmoking": false,
-      "noOfPreviousOwners": null,
-      "nextVehicleSafetyInspection": null,
-      "isRental": false,
-      "numberOfBeds": null,
-      "numberOfAxles": null,
-      "wheelBase": null,
-      "totalHeight": null,
-      "totalWidth": null,
-      "totalLength": null,
-      "maximumTowingWeight": null,
-      "grossVehicleWeight": null,
-      "payload": null,
-      "loadWidth": null,
-      "loadHeight": null,
-      "loadLength": null,
-      "loadVolume": null,
-      "productionYear": null,
-      "hasCarRegistration": false,
-      "offerType": "U",
-      "newDriverSuitable": null,
-      "rawData": {
-        "totalLength": null,
-        "engineHours": null,
-        "usageState": "U",
-        "productionDate": null,
-        "legalCategories": [
-          {
-            "formatted": "Used",
-            "raw": "UsedVehicle"
-          }
-        ],
-        "classification": {
-          "type": "Car",
-          "modelYear": null,
-          "make": {
-            "raw": 13,
-            "formatted": "BMW"
-          },
-          "model": {
-            "raw": 18480,
-            "formatted": "116"
-          },
-          "modelGroups": [
-            {
-              "raw": 100037,
-              "formatted": "1 Series"
-            }
-          ],
-          "modelGeneration": {
-            "raw": 192,
-            "formatted": "F20/F21"
-          },
-          "modelVariant": null,
-          "motorType": {
-            "raw": 518
-          },
-          "trimLine": {
-            "raw": 479256
-          },
-          "modelVersionInput": "116d EURO 6",
-          "germanHsnTsn": null
-        },
-        "fuels": {
-          "isPluginHybrid": null,
-          "primary": {
-            "type": {
-              "raw": 7,
-              "formatted": "Diesel"
-            },
-            "consumption": {
-              "combinedWithFallback": {
-                "raw": 4.2,
-                "formatted": "4.20 l/100 km (comb.)",
-                "isFallback": false
-              },
-              "urban": null,
-              "extraUrban": null
-            },
-            "co2emissionInGramPerKmWithFallback": {
-              "raw": null,
-              "formatted": "- (g/km)",
-              "isFallback": false
-            }
-          },
-          "additional": [],
-          "fuelCategory": {
-            "raw": "D",
-            "formatted": "Diesel"
-          },
-          "wltp": null,
-          "electricRangeWithFallback": null,
-          "electricRangeCity": null,
-          "allFuelTypes": [],
-          "battery": null
-        },
-        "engine": {
-          "engineDisplacementInCCM": {
-            "raw": 1496,
-            "formatted": "1,496 cc"
-          },
-          "power": {
-            "kw": {
-              "raw": 85,
-              "formatted": "85 kW"
-            },
-            "hp": {
-              "raw": 116,
-              "formatted": "116 hp"
-            }
-          },
-          "transmissionType": {
-            "raw": "Manual",
-            "formatted": "Manual"
-          },
-          "numberOfCylinders": 3,
-          "cylinderCapacity": {
-            "raw": 1496,
-            "unit": "ccm",
-            "formatted": "1,496 cc"
-          },
-          "numberOfGears": 6,
-          "driveTrain": null
-        },
-        "condition": {
-          "firstRegistrationDate": {
-            "raw": "2015-05-01",
-            "formatted": "05/2015"
-          },
-          "mileageInKm": {
-            "raw": 200000,
-            "formatted": "200,000 km"
-          },
-          "numberOfPreviousOwnersExtended": {
-            "raw": null,
-            "formatted": "- (Previous Owners)"
-          },
-          "damage": {
-            "isCurrentlyDamaged": null,
-            "isRoadworthy": null,
-            "accidentFree": null,
-            "hasRepairedDamages": null,
-            "damageConditions": []
-          },
-          "nonSmoking": false,
-          "newInspection": false,
-          "isCabinClean": null,
-          "carpassMileageUrl": null
-        },
-        "bodyType": {
-          "formatted": "Sedan",
-          "raw": "Sedan"
-        },
-        "bodyColor": {
-          "raw": "White",
-          "formatted": "White"
-        },
-        "numberOfBeds": {
-          "raw": null,
-          "formatted": "- (Number of sleeps)"
-        },
-        "numberOfAxles": {
-          "raw": null,
-          "formatted": "- (Axle count)"
-        },
-        "grossVehicleWeight": null,
-        "wheelBase": null,
-        "costModel": null,
-        "numberOfDoors": 5,
-        "paintType": {
-          "formatted": "Others"
-        },
-        "bodyColorOriginal": null,
-        "interior": {
-          "numberOfSeats": 5,
-          "upholstery": {
-            "formatted": "Cloth"
-          },
-          "upholsteryColor": {
-            "formatted": "Grey"
-          }
-        },
-        "emptyWeight": {
-          "formatted": "1,395 kg"
-        },
-        "identifier": {
-          "licensePlate": null,
-          "vin": null
-        },
-        "totalHeight": null,
-        "totalWidth": null,
-        "maximumTowingWeight": null,
-        "payload": null,
-        "loadWidth": null,
-        "loadHeight": null,
-        "loadLength": null,
-        "loadVolume": null,
-        "hasCarRegistration": {
-          "raw": false
-        },
-        "environment": {
-          "particulateFilter": true,
-          "environmentLabelsWithFallback": [
-            {
-              "norm": "EU_Directive_70_220_EEC_LDV",
-              "description": null,
-              "formatted": "Euro 6",
-              "label": "EURO6",
-              "isFallback": false
-            }
-          ]
-        },
-        "equipment": {
-          "as24": [
-            {
-              "id": {
-                "raw": 5,
-                "formatted": "Air conditioning"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 134,
-                "formatted": "Armrest"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 38,
-                "formatted": "Cruise control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 121,
-                "formatted": "Electrical side mirrors"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 229,
-                "formatted": "Fold flat passenger seat"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 142,
-                "formatted": "Leather steering wheel"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 126,
-                "formatted": "Light sensor"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 114,
-                "formatted": "Multi-function steering wheel"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 40,
-                "formatted": "Park Distance Control"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 128,
-                "formatted": "Parking assist system sensors front"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 129,
-                "formatted": "Parking assist system sensors rear"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 13,
-                "formatted": "Power windows"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 127,
-                "formatted": "Rain sensor"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 21,
-                "formatted": "Split rear seats"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 113,
-                "formatted": "Start-stop system"
-              },
-              "equipmentCategory": {
-                "raw": "comfortAndConvenience",
-                "formatted": "Comfort & Convenience"
-              }
-            },
-            {
-              "id": {
-                "raw": 122,
-                "formatted": "Bluetooth"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 132,
-                "formatted": "CD player"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 138,
-                "formatted": "Digital radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 43,
-                "formatted": "MP3"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 41,
-                "formatted": "On-board computer"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 10,
-                "formatted": "Radio"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 161,
-                "formatted": "USB"
-              },
-              "equipmentCategory": {
-                "raw": "entertainmentAndMedia",
-                "formatted": "Entertainment & Media"
-              }
-            },
-            {
-              "id": {
-                "raw": 15,
-                "formatted": "Alloy wheels"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 212,
-                "formatted": "Steel wheels"
-              },
-              "equipmentCategory": {
-                "raw": "extras",
-                "formatted": "Extras"
-              }
-            },
-            {
-              "id": {
-                "raw": 1,
-                "formatted": "ABS"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 18,
-                "formatted": "Alarm system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 17,
-                "formatted": "Central door lock"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 47,
-                "formatted": "Central door lock with remote control"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 232,
-                "formatted": "Distance warning system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 2,
-                "formatted": "Driver-side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 42,
-                "formatted": "Electronic stability control"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 19,
-                "formatted": "Fog lights"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 46,
-                "formatted": "Head airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 189,
-                "formatted": "High beam assist"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 125,
-                "formatted": "Isofix"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 3,
-                "formatted": "Passenger-side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 12,
-                "formatted": "Power steering"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 32,
-                "formatted": "Side airbag"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            },
-            {
-              "id": {
-                "raw": 150,
-                "formatted": "Tire pressure monitoring system"
-              },
-              "equipmentCategory": {
-                "raw": "safetyAndSecurity",
-                "formatted": "Safety & Security"
-              }
-            }
-          ]
-        },
-        "alloyWheelInches": null,
-        "originalMarket": null,
-        "maintenance": {
-          "nextVehicleSafetyInspection": null,
-          "lastBeltServiceDate": null,
-          "hasFullServiceHistory": {
-            "raw": false
-          },
-          "lastTechnicalServiceDate": null
-        },
-        "newDriverSuitable": null
-      },
-      "identifier": {
-        "vin": null
-      }
-    },
-    "identifier": {
-      "offerReference": null,
-      "legacyId": null
-    },
-    "seals": null,
-    "location": {
-      "countryCode": "IT",
-      "zip": "24040",
-      "city": "Lallio - Bergamo - BG",
-      "street": "Via Provinciale, 31",
-      "latitude": 45.65772,
-      "longitude": 9.62729
-    },
-    "seller": {
-      "id": 26458411,
-      "sellId": 2142176058,
-      "isDealer": true,
-      "type": "Dealer",
-      "companyName": "Suv&City Car",
-      "contactName": "AMEDEO/ALESSANDRO Amedeo / Alessandro",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/26458411-original-cc01d42c-daef-45bc-a387-dd6b5f704d2b.jpg/resize/100x50%3E/quality/90"
-        },
-        "big": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/26458411-original-cc01d42c-daef-45bc-a387-dd6b5f704d2b.jpg/resize/200x100%3E/quality/90"
-        }
-      },
-      "links": {
-        "infoPage": "https://www.autoscout24.com/dealerinfo/suv-e-city-car/about-us",
-        "imprint": "https://www.autoscout24.com/dealerinfo/suv-e-city-car/imprint",
-        "stockLink": "https://www.autoscout24.com/dealerinfo/suv-e-city-car?atype=C"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 320 - 8440980",
-          "callTo": "+393208440980"
-        }
-      ],
-      "dealer": {
-        "maxImages": 15,
-        "culture": "it-IT",
-        "isFreespeeCallTrackingEnabled": false,
-        "tieredPricingPackage": "Easy",
-        "autoMatchPackage": {
-          "tier": "low"
-        },
-        "hasMyVehiclesRecommenderCarousel": false,
-        "superbranding": {
-          "images": {
-            "dealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/26458411-original-156443c9-b725-4ecd-af05-49bd6dde1576/resize/800x500%3E/quality/90",
-            "dealershipInterior": null,
-            "mediumDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/26458411-original-156443c9-b725-4ecd-af05-49bd6dde1576/resize/800x500%3E/quality/90",
-            "smallDealershipExterior": "https://prod.pictures.autoscout24.net/dealer-info/26458411-original-156443c9-b725-4ecd-af05-49bd6dde1576/resize/800x500%3E/quality/90",
-            "smallDealershipInterior": null,
-            "mediumDealershipInterior": null
-          },
-          "contactPerson": {
-            "image": null,
-            "languages": null,
-            "name": null,
-            "position": null
-          }
-        },
-        "covidServices": null,
-        "openingHours": {
-          "department": "Lallio BG ",
-          "state": "opening-soon",
-          "statusLabel": "Opens soon",
-          "infoLabel": "Opens at 14:00"
-        },
-        "openingHoursRaw": [
-          {
-            "department": "Lallio BG ",
-            "timetable": [
-              [
-                900,
-                1230,
-                1400,
-                1830
-              ],
-              [
-                900,
-                1230,
-                1400,
-                1830
-              ],
-              [
-                900,
-                1230,
-                1400,
-                1830
-              ],
-              [
-                900,
-                1230,
-                1400,
-                1830
-              ],
-              [
-                900,
-                1230,
-                1400,
-                1830
-              ],
-              [
-                930,
-                1230,
-                1400,
-                1600
-              ],
-              []
-            ]
-          }
-        ],
-        "homepageUrl": null,
-        "googleRatings": null,
-        "customerSince": 2018,
-        "region": null,
-        "nationwideListingsData": null
-      }
-    },
-    "whatsappNumber": "+39 320 - 8440980",
-    "webPage": "https://www.autoscout24.com/offers/bmw-116-116d-euro-6-diesel-white-7bc1efe2-6741-46d9-9af1-9c1e525bdd86",
-    "status": "Active",
-    "leasingDetails": null,
-    "warranty": null,
-    "warrantyExists": false,
-    "ocsInfo": {
-      "__typename": "NotOcs"
-    },
-    "financingAndInsurance": {
-      "buttonWithFinance": [],
-      "buttonWithInsurance": [],
-      "buttonWithLeasing": []
-    },
-    "trackingParams": {
-      "classified_recency": "regular",
-      "classified_makeId": 13,
-      "classified_makeTxt": "bmw",
-      "classified_modelID": 18480,
-      "classified_modelGroupID": 100037,
-      "classified_modelTxt": "116",
-      "classified_mileage": 200000,
-      "classified_power": 85,
-      "classified_price": 7900,
-      "classified_fueltype": "d",
-      "classified_transmission": "m",
-      "classified_equipment": "5,134,38,121,229,142,126,114,40,128,129,13,127,21,113,122,132,138,43,41,10,161,15,212,1,18,17,47,232,2,42,19,46,189,125,3,12,32,150",
-      "classified_offerType": "u",
-      "classified_doors": 5,
-      "classified_seats": 5,
-      "classified_customer_type": "d",
-      "classified_customerID": "26458411",
-      "classified_zipcode": "24040",
-      "classified_year": "2015",
-      "classified_consumption": 4.2,
-      "classified_capacity": 1496,
-      "classified_bodyType": 6,
-      "classified_carSegment": "sedan,compact",
-      "classified_country": "I",
-      "classified_emissionStandard": 6,
-      "classified_tier": "t50",
-      "classified_applied_tier": "t50",
-      "classified_images_threesixty": "standard",
-      "classified_dealerPackage": "easy",
-      "classified_exclusiveOffer": "false",
-      "classified_leadsRange": "some",
-      "classified_imageContent": "no-placeholder|0.18844014991930824",
+      "classified_leadsRange": "zero",
+      "classified_imageContent": "no-placeholder|0.18517955248082607",
       "classified_isSmyleEligible": "false",
       "classified_ownershipModels": "tr"
     },
@@ -4834,12 +4417,12 @@
     "adTier": "T50",
     "specialConditions": [],
     "hasPremiumListingTreatment": true,
-    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"sedan,compact\",\"did\":\"26458411\",\"stmil\":\"200000\",\"gear\":\"M\",\"make\":\"13\",\"stmak\":\"BMW\",\"model\":\"18480\",\"stmod\":\"116\",\"cost\":\"7900\",\"stmon\":\"5\",\"styea\":\"2015\",\"ad\":\"dealer\",\"vat\":\"0\",\"art\":\"6\",\"carby\":\"0\",\"fr\":\"6\",\"stccm\":\"1496\",\"buyonline\":\"false\",\"stkw\":\"85\",\"sthp\":\"116\",\"equi\":\"128,129,1,2,3,132,5,134,138,10,12,13,142,15,17,18,19,212,21,150,32,161,229,38,232,41,42,43,46,47,113,114,121,122,189,125,126,127,53,40\",\"miles\":\"10\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/7bc1efe2-6741-46d9-9af1-9c1e525bdd86_8b890c88-6442-4a61-bfb2-e1ca02e3b554.jpg/720x540.webp\",\"price\":\"2\",\"rnd\":\"64\",\"ECO\":\"YES\",\"fuel\":\"D\",\"kenteken\":\"false\",\"acc\":\"U\",\"hp\":\"5\",\"mgroupid\":\"100037\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"IT24040\",\"zip2\":\"24040\",\"articleType\":\"C\",\"tiered\":\"easy\"}",
+    "adTargetingString": "{\"mia\":\"true\",\"leasing\":\"false\",\"seg\":\"subcompact\",\"did\":\"63169494\",\"stmil\":\"214000\",\"gear\":\"M\",\"make\":\"9\",\"stmak\":\"Audi\",\"model\":\"16416\",\"stmod\":\"A2\",\"cost\":\"1900\",\"stmon\":\"3\",\"styea\":\"2004\",\"ad\":\"dealer\",\"vat\":\"0\",\"art\":\"1\",\"carby\":\"0\",\"fr\":\"5\",\"stccm\":\"1390\",\"buyonline\":\"false\",\"stkw\":\"55\",\"sthp\":\"75\",\"equi\":\"32,1,2,3,132,5,134,231,135,42,10,12,13,17,50,115,150,121,26,125,30,49\",\"miles\":\"10\",\"img\":\"https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_77bfe203-d39e-4372-934f-87d56dd73a33.jpg/720x540.webp\",\"price\":\"1\",\"rnd\":\"56\",\"ECO\":\"NO\",\"tsn\":\"734\",\"fuel\":\"B\",\"kenteken\":\"false\",\"hsn\":\"0588\",\"acc\":\"U\",\"hp\":\"3\",\"mgroupid\":\"16416\",\"type\":\"U\",\"atsd\":\"\",\"zip\":\"DE54311\",\"zip2\":\"54311\",\"articleType\":\"C\",\"tiered\":\"pro\"}",
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
-    "imgAltText": "BMW 116 116d EURO 6 White",
-    "createdTimestampWithOffset": "2026-05-06T10:32:02.567Z",
+    "imgAltText": "Audi A2 1.4 /Panorama / Blue",
+    "createdTimestampWithOffset": "2026-08-19T10:01:11.148Z",
     "vehicleType": "ice",
     "searchTrackingParams": [
       {
@@ -4860,6 +4443,6 @@
       }
     ],
     "articleType": "car",
-    "isNew": false
+    "isNew": true
   }
 ]

--- a/autoscout24-scraper/results/listings.json
+++ b/autoscout24-scraper/results/listings.json
@@ -1,83 +1,106 @@
 [
   {
-    "id": "f2cb02e6-7631-4a43-a54b-e2d245e86bbf",
+    "id": "0b6c654f-cd2c-452c-a559-4904c696cae8",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "445093342"
+      "crossReferenceId": "434881662"
     },
-    "crossReferenceId": "445093342",
+    "crossReferenceId": "434881662",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_ed748a96-1c5f-4f44-83db-f6472baafd0c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_e07818f1-0793-476e-a7a2-819499423597.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_3dcb25f9-d452-4d5f-b6d7-c7613974da14.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_f59b0af8-a93d-422f-ae1a-2d30ac857b86.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_c29b5217-57d8-4711-96e4-93b620bfdd93.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_d70e4db8-5915-4de8-a291-2cd37ffa453f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_5f8cc931-2a25-4cfd-a862-e1077f722060.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_31e797ed-97b8-445e-96c8-e9db770e8003.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_91947a3f-85c2-4ea4-bdb6-cc5ca70f1a58.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_2c622073-c4ed-41d9-820f-169a212023ac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_cbf59f29-776d-4232-8fc7-290623808026.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_fc319952-6d9e-4080-b7c9-e41a14f44331.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_95622bf6-ee64-46c6-8778-6e41272f15b1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_b05f583f-0bf0-4d28-a70c-44c9aa2bc6b9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/f2cb02e6-7631-4a43-a54b-e2d245e86bbf_aa716763-9dd9-494d-9ef1-371b0c5d4d31.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_77bfe203-d39e-4372-934f-87d56dd73a33.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_cb03cf8d-4168-47e7-8d6a-ef4fff8b8502.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_a9078254-56a9-4bc2-acbe-4dc1a688c639.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_b40e72c4-fabf-4e88-940d-5cd835218472.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_78adb742-f132-469b-8901-4092fab8ae39.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_a92b5404-f295-4e3e-9cd3-8a084376a051.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_4b83278e-31a2-4ac6-b92b-edc61a2a6afb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_dc8e39e0-cee4-4e20-8e06-990d6d7d6d9c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_fcd21b1e-7265-4691-a4d2-7c2a65ffd854.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_562a0462-b141-4656-96a5-73b87ccdac46.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_3aeeea8e-c26c-456e-93e4-5cef4d3f44a5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_0fe4bfe0-062c-433b-8181-103bd15bb8ea.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_58766cf6-d223-4ea7-9148-42d18c1bb9ee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_92aff917-da6a-40d9-bd7b-1e6111cca581.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0b6c654f-cd2c-452c-a559-4904c696cae8_605b1e8e-487d-4476-8117-8fbc33278aef.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 2,450"
+      "priceFormatted": "€ 1,900",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1900,
+      "isConditionalPrice": true
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/opel-corsa-d-150-jahre-opel-mit-lpg-lpg-white-f2cb02e6-7631-4a43-a54b-e2d245e86bbf",
+    "url": "/offers/audi-a2-1-4-panorama-gasoline-blue-cat_ma9mo16416-0b6c654f-cd2c-452c-a559-4904c696cae8",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Opel",
-      "model": "Corsa",
-      "modelGroup": "Corsa",
+      "make": "Audi",
+      "model": "A2",
+      "modelGroup": "A2",
       "variant": null,
-      "modelId": 1918,
-      "modelVersionInput": "D 150 Jahre Opel mit LPG",
+      "motorTypeName": "1.4",
+      "modelId": 16416,
+      "modelVersionInput": "1.4 /Panorama /",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
-      "fuel": "LPG",
-      "mileageInKm": "152,877 km"
+      "fuel": "Gasoline",
+      "mileageInKm": "214,000 km",
+      "engineDisplacementInCCM": "1,390 cc",
+      "isCurrentlyDamaged": false
     },
     "location": {
       "countryCode": "DE",
-      "zip": "41363",
-      "city": "Juechen",
-      "street": "Waat 45"
-    },
-    "ratings": {
-      "ratingsCount": 3,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
+      "zip": "54311",
+      "city": "Trierweiler",
+      "street": "Roderstraße 9-11"
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
       },
-      "id": "48372802",
+      "id": "63169494",
       "type": "Dealer",
-      "companyName": "Mr. Cars",
-      "contactName": "Melis Tatar",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/63169494-original-bb088643-8e9d-4646-a07a-288448b757fb.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autohandel Younes K.",
+      "contactName": "Kassem Younes",
       "links": {
-        "infoPage": "/lst?atype=C&cid=48372802",
-        "imprint": "https://www.autoscout24.com/dealerinfo/mr-cars-juechen/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)651 - 60344265",
+          "callTo": "+4965160344265"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1577 - 3565165",
-          "callTo": "+4915773565165"
+          "formattedNumber": "+49 (0)1523 - 6947025",
+          "callTo": "+4915236947025"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1515 - 1143143",
+          "callTo": "+4915151143143"
         }
       ]
     },
@@ -86,26 +109,26 @@
     "isOcs": false,
     "specialConditions": [],
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
     "searchResultType": "Nfm",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "05-2012",
-      "fuelType": "l",
-      "imageContent": "no-placeholder|0.25193019393913196",
+      "firstRegistration": "03-2004",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18517955248082607",
       "isSmyleEligible": "false",
-      "mileage": "152877",
-      "priceLabel": "top-price",
-      "price": "2450",
+      "mileage": "214000",
+      "priceLabel": "unknown",
+      "price": "1900",
       "orderBucket": "0",
-      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:, generation_id:264, motortype_id:625, trim_id:739];"
+      "modelTaxonomy": "[make_id:9, model_group_id:16416, variant_id:, generation_id:726, motortype_id:3158, trim_id:479948];"
     },
-    "coverImageAttractiveness": 0.25193019393913196,
+    "coverImageAttractiveness": 0.18517955248082607,
     "vehicleDetails": [
       {
-        "data": "152,877 km",
-        "iconName": "mileage_road",
+        "data": "214,000 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -114,26 +137,25 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "05/2012",
+        "data": "03/2004",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
       {
-        "data": "LPG",
+        "data": "Gasoline",
         "iconName": "gas_pump",
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "63 kW (86 hp)",
+        "data": "55 kW (75 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
-      "7.1 l/100 km (comb.)",
-      "- (g/km)"
+      "6.1 l/100 km (comb.)",
+      "146 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -154,1187 +176,63 @@
     ]
   },
   {
-    "id": "2d3ac094-0d43-482a-98f3-7db4d25cf2d1",
+    "id": "0c344a98-edd9-46bd-b0d4-bf24792ecc77",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "445002082"
+      "crossReferenceId": "51126661"
     },
-    "crossReferenceId": "445002082",
+    "crossReferenceId": "51126661",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_b56b31d4-cff9-4890-9983-88ccbbd78861.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_296c8663-37c6-42df-8960-5649e9dc5d3a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_1afcbbba-5708-48d6-9cc0-03e396a1f960.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_8a2a22ef-3435-41f6-b7dd-c0846d2e0145.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_9bb5c8be-ca00-4264-bf4c-0d6608c30dac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_89d1bcac-d812-4e2a-a593-5e6493be89c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6331d7b9-a118-4155-999d-49658c9763f5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_a02a7971-1cb7-468f-9e04-737e1dbb3da2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_bf6b42f5-5f05-48e3-b4ec-66111c12ffc9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_38dda5c5-346f-4d7b-be7f-67439f707bb0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_7b4082f0-ed97-4fee-ba00-7dfd897cbd99.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6a46de77-5727-4110-bef3-0eb0b4e923d6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_ab10091c-75b3-4204-882c-dfa8fa80006e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_acbeca3f-88f9-4de1-a0ae-3c4240f17da5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_41e39932-aed4-4d7e-916c-55f3afd5f7f7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_4f6a2058-56da-42d4-8498-e2149f645260.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6f0078af-e7bf-4dba-99ef-70b08e1cbff5.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_66335ab8-96ff-4dcb-962f-29ebf73055d2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_9954ff6f-d386-45c7-9e12-6731b6bfd8eb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_4013e350-37dd-4c44-8f6d-7e2d0c685501.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_32c6318c-cb35-4d3d-a7a3-a1372bcfa138.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_0656ec8d-919c-434c-b1ed-75997a7984af.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_def191e7-4f08-46e6-b888-24e572551ffd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_0ef19f93-cdb6-4d91-89e5-e4c430204095.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_dadd2941-d283-4291-a0e5-e9d319489425.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_5478804b-eea4-4818-939f-9fa3f292ce33.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_88ec53e3-3b3b-4c4d-a456-cfa9c18e3fba.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_bbf9270a-f736-4980-8838-86f05edcf716.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_852166e3-b998-4b67-8e86-eea88001d2e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0c344a98-edd9-46bd-b0d4-bf24792ecc77_e4f8a8e0-d5bf-48e7-81bb-62dde4ba7fc8.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 1,900"
+      "priceFormatted": "€ 1,885",
+      "suggestedRetailPrice": "€ 10,585",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1885,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/ford-fiesta-trend-gasoline-blue-2d3ac094-0d43-482a-98f3-7db4d25cf2d1",
+    "url": "/offers/citroen-c1-1-0-12v-ambiance-airco-elektrische-ramen-toe-gasoline-white-cat_ma21mo18651-0c344a98-edd9-46bd-b0d4-bf24792ecc77",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Ford",
-      "model": "Fiesta",
-      "modelGroup": "Fiesta",
-      "variant": null,
-      "modelId": 1758,
-      "modelVersionInput": "Trend",
+      "make": "Citroen",
+      "model": "C1",
+      "modelGroup": "C1",
+      "variant": "C1",
+      "motorTypeName": "1.0",
+      "modelId": 18651,
+      "modelVersionInput": "1.0-12V Ambiance | Airco | Elektrische Ramen | Toe",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "199,890 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "65428",
-      "city": "Rüsselsheim",
-      "street": "Marktstraße 19"
-    },
-    "ratings": {
-      "ratingsCount": 5,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "46345061",
-      "type": "Dealer",
-      "companyName": "Autoagentur Rhein Main",
-      "contactName": "Yusein Hakif Yusein",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=46345061",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autoagentur-rhein-main/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1521 - 9417281",
-          "callTo": "+4915219417281"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)1521 - 9417281",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "06-2011",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.24857714954914834",
-      "isSmyleEligible": "false",
-      "mileage": "199890",
-      "priceLabel": "toolow-price ",
-      "price": "1900",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:29, model_group_id:1758, variant_id:, generation_id:447, motortype_id:832, trim_id:371];"
-    },
-    "coverImageAttractiveness": 0.24857714954914834,
-    "vehicleDetails": [
-      {
-        "data": "199,890 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "06/2011",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "60 kW (82 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "5.7 l/100 km (comb.)",
-      "135 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "3e6b5e11-2d35-4e16-ba9b-7c962e62e26e",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325172303"
-    },
-    "crossReferenceId": "325172303",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_77b29530-6037-49b5-bd19-28bfb51399f6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_c8f5a6ba-34e1-4da6-86ca-bb6bbc07dd09.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_4441f7bc-150b-471e-b6f1-a2ea6dbae33d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_a17ba111-13a6-4b43-b688-69c18bc00c50.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_3c148271-bf7f-4cb4-9ce2-d62a26991b16.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_e902716e-528a-40fe-acbe-861fd476b910.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_4087dcbe-ad89-4585-8bad-e417f57dcbfb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_06be53ff-b36e-4caa-8f9e-25d7b3bb5ed1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_e885c056-f835-492e-8ae7-a0cc3f3693a4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_79113237-6ea8-4762-9839-3e076afaf206.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_eb2ddb5d-3041-44f3-84fc-239df67071d5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_e1e88d8e-022b-4f5b-ada8-54b41c7bb03d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_e8c34884-bf4d-435a-bfcb-25a3101a3969.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_e6036ce7-052a-4131-bd32-f55fb3a3c985.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_a36c426c-7f92-4795-8fd9-b31b48f8b686.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_4ae5509c-a277-46a0-9896-9335fc94c6aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3e6b5e11-2d35-4e16-ba9b-7c962e62e26e_f33a7e3b-ad44-4a6b-807e-cca50bddff6a.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,250"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/opel-corsa-1-2-16v-enjoy-climatecontrol-5-drs-lm-velgen-trekh-gasoline-blue-3e6b5e11-2d35-4e16-ba9b-7c962e62e26e",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Opel",
-      "model": "Corsa",
-      "modelGroup": "Corsa",
-      "variant": null,
-      "modelId": 1918,
-      "modelVersionInput": "1.2-16V Enjoy Climatecontrol 5 Drs Lm Velgen Trekh",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "273,579 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "3882 AJ",
-      "city": "PUTTEN",
-      "street": "Engweg 23a"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "49071481",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/49071481-original-d3d23ee6-191b-41a9-ae2e-3d16fd2311a6.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "STM Autos",
-      "contactName": "Andre Hoegen",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=49071481",
-        "imprint": "https://www.autoscout24.com/dealerinfo/stm-autos-putten-3882-aj/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 19444579",
-          "callTo": "+31619444579"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 19444579",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "08-2007",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.19169412680820075",
-      "isSmyleEligible": "false",
-      "mileage": "273579",
-      "priceLabel": "top-price",
-      "price": "1250",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:, generation_id:263, motortype_id:625, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.19169412680820075,
-    "vehicleDetails": [
-      {
-        "data": "273,579 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "08/2007",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "60 kW (82 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "139 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "c7e22dc5-7c0b-4075-8955-9f1eafb77623",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325414228"
-    },
-    "crossReferenceId": "325414228",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_adffa77d-b7b5-497d-9d66-021888c8c299.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_9394c352-a2f2-4b7b-bc9c-2ee0f2683525.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_592474ca-560d-48ba-8e41-7f8649477bba.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_52adc3f9-179a-457c-aae5-2faf7f72031e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_05e71322-a198-4c73-bd50-f3732ce978d7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_1d359b2a-4b6f-4c33-af39-c7d995e5b552.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_d25f0937-434a-4c31-862c-7ec4a051e193.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_f1712a91-200c-4b16-8b75-26346e7fd89d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_68250e26-73f7-41e9-9db5-7caa0d71ac00.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_603f8235-2dd5-4f96-a517-091be43d1d88.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_fbbef51c-26f6-4513-a483-3d1ab3d03874.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_34bf5160-264a-4af8-8f39-144a5fe6429a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_013a67a9-edb5-4b07-9d09-e49d2241a7cc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_df9e8d26-70ab-493c-8f0f-6e31f7263986.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_7fef2862-2dec-43e8-bf35-d519de7a614d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_e52b8d17-e505-49b8-94dd-ba83bdedfd3a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_e602534e-1e06-420c-a17f-5534a39ae014.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_f8cd4683-1beb-48fb-a9f5-dbfcb4d266d7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_8b46d35e-7f65-4170-9941-ba9dabe86efb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_bba7283f-4984-4845-ad87-a50094709d9b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_a1483147-bf7f-4981-b469-45cda9826253.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_e013ad2e-2b43-4a47-938a-9fd0752467ef.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_0fb537ae-530f-478f-a195-5aaa7ad51b63.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_3f710f11-168d-42de-a06b-327da8cbcd8f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_528a7040-8405-44da-9ffb-f1d950bb320e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_908343da-510c-4e98-a7c0-8620e562c86c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_bddcc37a-5c2f-4577-ac2e-35ef3f638312.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7e22dc5-7c0b-4075-8955-9f1eafb77623_003666b8-7766-4fa9-b406-005471f9776c.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 4,449"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/kia-rio-1-2-cvvt-comfortline-trekhaak-airco-navi-cruise-el-gasoline-black-c7e22dc5-7c0b-4075-8955-9f1eafb77623",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Kia",
-      "model": "Rio",
-      "modelGroup": "Rio",
-      "variant": null,
-      "modelId": 16476,
-      "modelVersionInput": "1.2 CVVT ComfortLine Trekhaak,Airco,Navi,Cruise,El",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "233,227 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "8223 EH",
-      "city": "LELYSTAD",
-      "street": "Wartelstraat 22"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "48059624",
-      "type": "Dealer",
-      "companyName": "Carwell",
-      "contactName": "Devlet Karvel",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=48059624",
-        "imprint": "https://www.autoscout24.com/dealerinfo/carwell/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 25308444",
-          "callTo": "+31625308444"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 25308444",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "12-2015",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2158052605823827",
-      "isSmyleEligible": "false",
-      "mileage": "233227",
-      "priceLabel": "good-price",
-      "price": "4449",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:39, model_group_id:200742, variant_id:, generation_id:985, motortype_id:2463, trim_id:1229];"
-    },
-    "coverImageAttractiveness": 0.2158052605823827,
-    "vehicleDetails": [
-      {
-        "data": "233,227 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "12/2015",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "62 kW (84 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "109 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "dc03b308-bf8b-4d1e-9759-81e6aa1bc668",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "444375136"
-    },
-    "crossReferenceId": "444375136",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_6431a395-8a8a-4134-97e9-5ecacb7208e5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_8de15e67-60ec-4792-9086-9138c44286c5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_b275cfe7-8120-4399-b5be-b314166fa273.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_55d7e51a-20d0-429f-ab7e-1898a9a355f2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_85b2d087-ed0e-456b-95db-87999e8eb174.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_0feb89c9-619a-4e9b-ac52-0dbb9a88c8b7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_82a9d998-f550-4f65-a2c1-ed721f4134ba.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_8c3f19e2-69b3-42e1-a6b9-33f2e6e074fa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_8ee4727d-d1ab-468a-9640-8761647dbfd5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_cb33cf4d-bdf4-4373-b7e4-7860d4961dda.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_c4f72e21-cb86-436f-8945-ab0026598a1c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_06526f02-e33f-41b8-9209-3116ea8f5987.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_1014cde6-8f27-4c87-ac98-3d58979fcf96.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_375e8d09-c983-4c6f-92f9-3fb1ba180e3d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_d24da18d-d97b-49bb-ad5b-8a41a68caf3d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc03b308-bf8b-4d1e-9759-81e6aa1bc668_db364684-d440-4fb4-9899-c3ce74eb6525.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,500"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-polo-v-1-6-tdi-comfortline-diesel-black-dc03b308-bf8b-4d1e-9759-81e6aa1bc668",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Polo",
-      "modelGroup": "Polo",
-      "variant": "Sedan",
-      "modelId": 2090,
-      "modelVersionInput": "V 1.6 TDi Comfortline",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "259,236 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "48282",
-      "city": "Emsdetten",
-      "street": "Reckenfelder Str. 112"
-    },
-    "ratings": {
-      "ratingsCount": 19,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "3996",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/3996-original-7d6c2329-aa6f-4e10-aac8-d88d3b9501a8/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autohaus Czekalla GmbH",
-      "contactName": "Verkaufsteam Verkaufsteam",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=3996",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-czekalla-gmbh/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)2572 - 93000",
-          "callTo": "+49257293000"
-        },
-        {
-          "phoneType": "Private",
-          "formattedNumber": "+49 (0)2572 - 93000",
-          "callTo": "+49257293000"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2011",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.1759019586443531",
-      "isSmyleEligible": "false",
-      "mileage": "259236",
-      "priceLabel": "good-price",
-      "price": "3500",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:162, generation_id:175, motortype_id:281, trim_id:217];"
-    },
-    "coverImageAttractiveness": 0.1759019586443531,
-    "vehicleDetails": [
-      {
-        "data": "259,236 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "05/2011",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "66 kW (90 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "4.2 l/100 km (comb.)",
-      "109 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "d8da0ff4-3969-49cf-bb65-7a3dbff60a0e",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325487922"
-    },
-    "crossReferenceId": "325487922",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_0175bc53-c69d-4c25-9ff6-9aff7d65fa59.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_f83ac5d8-54ce-4a2c-83fd-fd3c7436eedb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_b8b8e4b5-70da-4a1c-90c1-cd22f89e77ff.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_10a1902d-d924-47fa-83e4-ae49595e7a6a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_3c758056-09be-486b-8535-b9e51b6d4496.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_36379065-d274-4238-902b-c026655e196e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_20ece8a6-e69c-4c0f-99b2-acb8bc760b61.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_345fd537-a5fd-4a74-91b3-a8d329cb50c6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_f33b46fb-e190-4a2b-8f71-13894eaacf43.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_d458e4ac-1645-4e0b-8734-67fff9a7368d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_e9229ebf-d14b-43fb-a7a5-d668bd5987d5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_940bc311-c253-45b3-bce0-25a37570d7e1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_042ad62f-521b-469f-b33f-5d0a4e511a66.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_e08dd4e9-9f06-494b-9df0-5ef0b6beb8c2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_35ffed09-3b0d-4610-a561-38e5c8ae5a08.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_942ce4da-1214-4792-bb71-0c7b1d004734.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_d33f1eb7-4261-472d-8dcb-e26f76d5115d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_3844cb62-3fb6-4153-94b8-e06b1deca248.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_d3c87696-af23-437e-904d-3250e26e3925.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_e43c1fe9-b534-4cbf-91f2-b4799c2e15f3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_e7e40a9e-f8a5-4d55-9835-c2e7d587456a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_6d11f2c2-0efb-4242-9288-071bc31c3b64.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d8da0ff4-3969-49cf-bb65-7a3dbff60a0e_93d07aaa-cf4f-43aa-be45-1e54c0cf45f6.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 4,450"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/audi-a3-sportback-1-4-tfsi-ambition-pro-line-s-gasoline-black-d8da0ff4-3969-49cf-bb65-7a3dbff60a0e",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Audi",
-      "model": "A3",
-      "modelGroup": "A3",
-      "variant": "Sportback",
-      "modelId": 1624,
-      "modelVersionInput": "Sportback 1.4 TFSI Ambition Pro Line S",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "262,593 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "3113 AH",
-      "city": "SCHIEDAM",
-      "street": "Nieuw-Mathenesserstraat 32a"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "20632688",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/20632688-original-9075d4e4-8c14-4340-bf15-1e18e66ffe74/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autocentrale Schiedam",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=20632688",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autocentrale-schiedam/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)10 - 7859151",
-          "callTo": "+31107859151"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 42415989",
-          "callTo": "+31642415989"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 42415989",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "08-2011",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.17255870801761686",
-      "isSmyleEligible": "false",
-      "mileage": "262593",
-      "priceLabel": "fair-price",
-      "price": "4450",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:9, model_group_id:1624, variant_id:152, generation_id:152, motortype_id:229, trim_id:131];"
-    },
-    "coverImageAttractiveness": 0.17255870801761686,
-    "vehicleDetails": [
-      {
-        "data": "262,593 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "08/2011",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "92 kW (125 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "134 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "516f93af-fbcc-4614-a69e-3369f3334ad1",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "310037048"
-    },
-    "crossReferenceId": "310037048",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_01c7a2c7-d4a4-4d40-81d3-a94f00a1c294.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_7daca2bf-1958-4952-ac1d-769037b8127a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_50926dc7-e5fc-4941-862d-2983cd546812.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_1c1a6d15-e860-4234-9510-267b87f631f0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_26db60da-ca60-4e8c-b7f4-c93b23ceb218.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_c7224654-7b3e-4b21-80f7-745534ee8f91.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_b0bc20be-bedd-4657-a743-9764462145bd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_9244f355-e739-4c60-a2c5-21f811521ea2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_94609ff1-ea84-41cc-87b9-e5e6e7b56311.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_a709e502-e819-489d-a51a-e6d698c2a110.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_c418fd87-202e-49bb-8c9f-b029dd92dd7d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_327b96c8-2308-41dc-8f86-efdeb03eb6bb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_7b23dc94-293f-4060-9ecd-03cc979a1c5c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_353b5ae1-9937-4f78-a98f-d3139fb64107.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_d83c0ff8-59fb-47da-a4b3-dbd1fbab6e59.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_f988e7e3-6f1e-4916-967d-5f3deb751ba0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_c0f696c5-adff-4ca5-81da-ab9765b66247.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/516f93af-fbcc-4614-a69e-3369f3334ad1_6509cd72-2afe-41f6-a6f8-04dd54b9f7cf.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,499"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/fiat-500-1-2-sport-pano-gasoline-red-516f93af-fbcc-4614-a69e-3369f3334ad1",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Fiat",
-      "model": "500",
-      "modelGroup": "500",
-      "variant": null,
-      "modelId": 15160,
-      "modelVersionInput": "1.2 Sport |Pano|",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "172,606 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "4905 AA",
-      "city": "OOSTERHOUT",
-      "street": "Havenweg 37c"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "31847520",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/31847520-original-9a3d1790-60fc-4f1c-9c1c-79742901d52a.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "KL Auto's B.V.",
-      "contactName": "Arnold Sterrenborg",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=31847520",
-        "imprint": "https://www.autoscout24.com/dealerinfo/kl-auto-s-b-v/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 11500958",
-          "callTo": "+31611500958"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 11500958",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "03-2008",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.21142872511043398",
-      "isSmyleEligible": "false",
-      "mileage": "172606",
-      "priceLabel": "top-price",
-      "price": "2499",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:, generation_id:789, motortype_id:1763, trim_id:7178];"
-    },
-    "coverImageAttractiveness": 0.21142872511043398,
-    "vehicleDetails": [
-      {
-        "data": "172,606 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "03/2008",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "51 kW (69 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "119 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "d248ec74-2792-430e-b961-bc94271758c9",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_dca3ec9c-6f87-4c0a-bacd-ff01b7ccd253.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_3d9ec397-ac34-4426-aa3d-b0fd437a5ff5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_3d9994bb-54da-4fc1-80ed-55ff9d50ea2e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_eeced5be-f830-4bed-b12c-2f258227da1f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_1f217569-dc0b-4daa-afca-1386aa4e32aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_e0bac94e-a9fc-4e7f-b288-da72c814d111.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_c8bb9dfd-53f9-425e-ac04-e62eaf1e3326.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_ddfce90d-f96c-49ad-82a7-e6fde5f4605a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_16e370af-0fdc-40bf-b8d3-00b4c9e1d7bb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_dbbe3b2e-5f53-4a1a-ac1f-ef3b853fd8c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_6ade26e5-e7ad-4091-b6ee-c0a48bbc8c48.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_9ec4426b-2ad9-439f-81b9-1ca1b08786fd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_482bf9ff-7059-4613-bdc0-ec77eb945b53.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_d493c466-ad0e-4bb7-a93d-2fa9de09ce78.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_7fa6d735-66c9-4859-81cb-2e5aec085f1b.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,490"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/alfa-romeo-mito-1-4-78-cv-distinctive-sport-pack-gasoline-grey-d248ec74-2792-430e-b961-bc94271758c9",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Alfa Romeo",
-      "model": "MiTo",
-      "modelGroup": "MiTo",
-      "variant": null,
-      "modelId": 19161,
-      "modelVersionInput": "1.4 78 CV Distinctive Sport Pack",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "196,758 km"
-    },
-    "location": {
-      "countryCode": "IT",
-      "zip": "20045",
-      "city": "Lainate - Mi",
-      "street": "Via Rho 37"
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "30125861",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/30125861-original-9679370b-2a4d-4cd5-acbc-fc7f9ae01057.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Auto7 srl",
-      "contactName": "Auto7 Ilenia",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=30125861",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto7-srl/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 344 - 1150881",
-          "callTo": "+393441150881"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+39 344 - 1150881",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2009",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.31011704660233486",
-      "isSmyleEligible": "false",
-      "mileage": "196758",
-      "priceLabel": "good-price",
-      "price": "3490",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:6, model_group_id:200054, variant_id:, generation_id:2285, motortype_id:5512, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.31011704660233486,
-    "vehicleDetails": [
-      {
-        "data": "196,758 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2009",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "58 kW (79 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "ff8447a1-5086-4c0f-b135-367a89329264",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325478985"
-    },
-    "crossReferenceId": "325478985",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_636eaffc-21c0-4d9a-8d6f-2e1e3bec9dd1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_2e2485c6-ae2c-4b24-ad0c-e45a03fb386f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_c2979bb2-b759-48e1-9ba5-c28a3f72b369.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_20f1f52a-15f6-4754-8d08-9468ffd92206.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_514cb5a2-fb22-4c1c-ad9b-39eb6577d826.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_333f9dbd-0908-4ebe-8fd1-3543022eb448.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_bb5208ae-169a-4c25-9b53-d8f7f70f693c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_fd3eccdf-9988-4e93-8002-2b8bf2e53097.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_bf4fe15f-5d7c-46af-af0d-b09e3d3924aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_d5947017-22a9-4a0d-848f-1ea0fa24a4b3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_67ac9bc6-9d29-453e-b40e-a2dea5fbccab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_ea601bb2-c7ca-4e66-ba5f-ad105485e614.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_2cb47db3-5383-4b01-b9e2-458c2e59dbe2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_6f7fa53a-5848-4775-a0a0-05220e2cf92b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_e6d617b4-9ca4-448e-9dd9-01bede78a49e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/ff8447a1-5086-4c0f-b135-367a89329264_f9b1138b-daee-4f3d-b687-7170515ffab9.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 4,885"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-polo-1-4-tdi-bluemotion-navigatie-cruise-airco-diesel-black-ff8447a1-5086-4c0f-b135-367a89329264",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Polo",
-      "modelGroup": "Polo",
-      "variant": "Sedan",
-      "modelId": 2090,
-      "modelVersionInput": "1.4 TDI BlueMotion | Navigatie | Cruise | Airco |",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "267,306 km"
+      "mileageInKm": "167,850 km",
+      "engineDisplacementInCCM": "998 cc"
     },
     "location": {
       "countryCode": "NL",
@@ -1343,13 +241,16 @@
       "street": "De Grift 4"
     },
     "seller": {
-      "dealer": {},
+      "dealer": {
+        "maxImages": 50,
+        "culture": "nl-NL"
+      },
       "id": "38182565",
       "type": "Dealer",
       "companyName": "van der Kolk auto's",
       "contactName": "Ian van der Kolk",
       "links": {
-        "infoPage": "/lst?atype=C&cid=38182565",
+        "infoPage": "https://www.autoscout24.com/dealerinfo/van-der-kolk-auto-s?atype=C",
         "imprint": "https://www.autoscout24.com/dealerinfo/van-der-kolk-auto-s/imprint"
       },
       "phones": [
@@ -1365,188 +266,26 @@
     "isOcs": false,
     "specialConditions": [],
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "12-2014",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.1601299449418626",
-      "isSmyleEligible": "false",
-      "mileage": "267306",
-      "priceLabel": "somewhat-expensive",
-      "price": "4885",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:162, generation_id:175, motortype_id:277, trim_id:212];"
-    },
-    "coverImageAttractiveness": 0.1601299449418626,
-    "vehicleDetails": [
-      {
-        "data": "267,306 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "12/2014",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "55 kW (75 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "82 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "6c933ac2-a6bb-42c0-9039-79d8f3e3296a",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "1097120"
-    },
-    "crossReferenceId": "1097120",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_2189f420-b3de-446e-92ef-1f30b8e8f05e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_e9deac16-62f8-42be-b3ae-d10cfcd78019.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_3f63c7c1-7d47-42d1-b0e6-e770a3da6404.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_db2e98e6-13e7-4c97-adc8-772c70c334ac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_554b68e0-47e1-4972-bf60-a4ab4e4c70ae.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_009c001d-85fe-4460-9dae-87963078b2a0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_707d152d-40d3-40ca-882b-027fd9a0509c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_282afa7f-6a4c-449f-886e-cc8149d348ad.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_aa26f132-e800-495c-bf1c-59292a518490.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_40e5a41a-d64f-4883-98d2-c6fa5d7bbbaa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_8915ed10-6ece-47c4-819e-fab10c640905.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_efb75348-5dc0-4cc8-9ae5-1aacf780116c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_9d27168d-ad77-4c56-9b68-235efec35f60.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_5e499123-f75a-48ee-8615-5ad5bc0388b3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_ad98a6ca-cf19-4814-8853-ba2bb7513b71.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_e76102d6-e294-4ce4-9d5d-819ac673a1ed.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_89d8a45c-783e-4195-96ec-54ac07dbeac0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_de8bbd89-f0e5-41cf-b25e-74f87389b437.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6c933ac2-a6bb-42c0-9039-79d8f3e3296a_b02b7e74-01a6-4cd4-abb5-299af2bcd06c.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,900"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/skoda-fabia-monte-carlo-ohne-tuev-reparaturbeduerftig-gasoline-white-6c933ac2-a6bb-42c0-9039-79d8f3e3296a",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Skoda",
-      "model": "Fabia",
-      "modelGroup": "Fabia",
-      "variant": "Combi",
-      "modelId": 15878,
-      "modelVersionInput": "Monte Carlo ohne TÜV, reparaturbedürftig",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "187,741 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "38444",
-      "city": "Wolfsburg Heiligendorf",
-      "street": "Neue Straße 53"
-    },
-    "ratings": {
-      "ratingsCount": 551,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "hasDealerInformationOnResultList": true
-      },
-      "id": "17031",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/17031-original-ffece146-0426-4c14-9746-e1746801af45.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Hoffmann Automobile",
-      "contactName": "Team Verkauf",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=17031",
-        "imprint": "https://www.autoscout24.com/dealerinfo/hoffmann-automobile/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)5365 - 96062",
-          "callTo": "+49536596062"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2012",
+      "firstRegistration": "07-2010",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.26632203331626836",
+      "imageContent": "no-placeholder|0.2619919708389691",
       "isSmyleEligible": "false",
-      "mileage": "187741",
+      "mileage": "167850",
       "priceLabel": "top-price",
-      "price": "2900",
+      "price": "1885",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:65, model_group_id:15878, variant_id:353, generation_id:402, motortype_id:766, trim_id:5514];"
+      "modelTaxonomy": "[make_id:21, model_group_id:200305, variant_id:3411, generation_id:2122, motortype_id:1430, trim_id:988];"
     },
-    "coverImageAttractiveness": 0.26632203331626836,
+    "coverImageAttractiveness": 0.2619919708389691,
     "vehicleDetails": [
       {
-        "data": "187,741 km",
-        "iconName": "mileage_road",
+        "data": "167,850 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -1555,637 +294,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "05/2012",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "77 kW (105 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "d14bcd02-1f4c-4328-b333-82983d38fd11",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "322605350"
-    },
-    "crossReferenceId": "322605350",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d14bcd02-1f4c-4328-b333-82983d38fd11_491ee4b0-2c49-4ce1-b09e-5dbffbafcb46.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d14bcd02-1f4c-4328-b333-82983d38fd11_bf43d8ad-2a8d-41b9-9469-253e98b28d6f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d14bcd02-1f4c-4328-b333-82983d38fd11_05c6e52a-037e-45f0-8606-cf25fec49002.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d14bcd02-1f4c-4328-b333-82983d38fd11_0666cdec-1ccc-48c9-9d17-e8fca34e8944.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d14bcd02-1f4c-4328-b333-82983d38fd11_d9420a33-a9c0-4fde-9f3d-b453a1f056c0.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,490"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/seat-ibiza-1-2-tdi-style-eco-diesel-white-d14bcd02-1f4c-4328-b333-82983d38fd11",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "SEAT",
-      "model": "Ibiza",
-      "modelGroup": "Ibiza",
-      "variant": "ST",
-      "modelId": 2006,
-      "modelVersionInput": "1.2 TDI Style Eco.",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "338,930 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "6466 GW",
-      "city": "KERKRADE",
-      "street": "Locht 54"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "15534985",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/15534985-original-f44506fd-9443-46fd-84c7-5a096a786053/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Horsmans Auto de Locht",
-      "contactName": "J. Horsmans",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=15534985",
-        "imprint": "https://www.autoscout24.com/dealerinfo/horsmans-auto-de-locht/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 39215356",
-          "callTo": "+31639215356"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 43195073",
-          "callTo": "+31643195073"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 43195073",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "11-2010",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.18314976649226888",
-      "isSmyleEligible": "false",
-      "mileage": "338930",
-      "priceLabel": "good-price",
-      "price": "1490",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:64, model_group_id:2006, variant_id:1946, generation_id:1195, motortype_id:4128, trim_id:7515];"
-    },
-    "coverImageAttractiveness": 0.18314976649226888,
-    "vehicleDetails": [
-      {
-        "data": "338,930 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "11/2010",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "55 kW (75 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "89 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "e0341d73-0ec7-4fbc-97a4-328838cfe6f9",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325298256"
-    },
-    "crossReferenceId": "325298256",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_fe5c50a3-b878-4f09-afd2-2aeddd33aff5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_a5e71d72-5316-4fa3-b3cc-f5c4d557b024.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_e6003b1e-f6e9-4a35-8d50-038c34631457.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_7bdeea1b-ceb6-403f-816a-071698e24ce6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_dd8e08b2-7357-4909-a1ac-fecd4efbdf11.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_dc39ca53-65eb-4cff-a573-6b15d2e23ce6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_c33a1d9d-4485-407b-ba22-1ed3b8bd0ea9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_eb4f1d01-81ba-4b77-9f63-17195fce2ca8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_af6e8da5-60da-4bc4-861d-56dc991fe6cf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_0ebaf9ea-eea9-4460-8f5b-605617a3e56d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e0341d73-0ec7-4fbc-97a4-328838cfe6f9_3396b91f-fab8-4015-93d2-82a8aaee88e2.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 11,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/mercedes-benz-a-180-business-solution-aut-amg-17-stoelverw-led-gasoline-black-e0341d73-0ec7-4fbc-97a4-328838cfe6f9",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Mercedes-Benz",
-      "model": "A 180",
-      "modelGroup": "A-Class",
-      "variant": "Kompaktlimousine",
-      "modelId": 18486,
-      "modelVersionInput": "Business Solution aut. AMG 17\" stoelverw. LED",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Automatic",
-      "fuel": "Gasoline",
-      "mileageInKm": "269,475 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "6603 BV",
-      "city": "WIJCHEN",
-      "street": "Nieuweweg 204"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "28701555",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/28701555-original-853b59b4-0c99-4ed3-b237-a416d8bc0d05.JPG/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "HDA Wijchen B.V.",
-      "contactName": "Hans Dekker",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=28701555",
-        "imprint": "https://www.autoscout24.com/dealerinfo/hda-wijchen-b-v/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)24 - 3573059",
-          "callTo": "+31243573059"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 53284115",
-          "callTo": "+31653284115"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "11-2017",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.16941634130851113",
-      "isSmyleEligible": "false",
-      "mileage": "269475",
-      "priceLabel": "fair-price",
-      "price": "11950",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:47, model_group_id:100054, variant_id:190, generation_id:182, motortype_id:507, trim_id:1193];"
-    },
-    "coverImageAttractiveness": 0.16941634130851113,
-    "vehicleDetails": [
-      {
-        "data": "269,475 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Automatic",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "11/2017",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "90 kW (122 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "126 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "8e68eec6-5431-41c6-9cc2-219ed5180ce8",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "442764800"
-    },
-    "crossReferenceId": "442764800",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_6466ab9c-c8cb-46f4-865a-dd6ee335709b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_74f3312c-d58c-49c0-95fc-6e23e5d63536.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_79313a60-5731-4a90-b2f3-37bc9da62d07.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_ea60b334-3d3d-4740-baa0-7ea09e0261a7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_7c20fda9-ef96-4ee3-80dd-ab445cd7831a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_9644cd56-fc87-4a81-b732-ede43f48759e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_cc9046a7-d230-432e-8649-8546c621fb1a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_7004be2f-0512-402e-a735-a6692638c6fc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_345cceff-480d-4411-b46d-2c188ee883f7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_2168d85c-c634-4551-b6a1-6c2c5c5475d6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_b9630c95-74dc-4d2f-b214-5c91e467159f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_ced25bc9-23d8-4a25-a217-1b21cfe6f0ab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_13614fc0-4070-4ddf-9486-64c3ed0a99d2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_2664007c-b093-4fb2-9fb3-fa3c94045790.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_004d6b07-4302-4d9e-b028-496329b46ff5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_bfab75fa-d9ac-4155-9ba2-3d1566cd6a16.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_ac3dc27f-e7ec-4d22-b2a8-d984167d1df7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_14816553-4a70-45ef-887e-e2e7feb35240.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/8e68eec6-5431-41c6-9cc2-219ed5180ce8_0b6deeae-2343-4e94-b380-5c178ba357dc.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,480"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/renault-clio-ii-1-2-camp-yahoo-klima-allwetter-tuev-10-26-gasoline-red-8e68eec6-5431-41c6-9cc2-219ed5180ce8",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Renault",
-      "model": "Clio",
-      "modelGroup": "Clio",
-      "variant": null,
-      "modelId": 1961,
-      "modelVersionInput": "II 1.2 Camp.YAHOO/Klima/Allwetter/Tüv 10.26",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "185,642 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "10315",
-      "city": "Berlin",
-      "street": "Rhinstr.125a"
-    },
-    "ratings": {
-      "ratingsCount": 70,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "15240092",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/15240092-original-705a0801-7ffb-4baa-931d-a7495b782317.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Seibold Automobile GmbH",
-      "contactName": "Frank Seibold",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=15240092",
-        "imprint": "https://www.autoscout24.com/dealerinfo/seibold-automobile-gmbh/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)30 - 98194800",
-          "callTo": "+493098194800"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1573 - 5202930",
-          "callTo": "+4915735202930"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "03-2012",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.16515834816008124",
-      "isSmyleEligible": "false",
-      "mileage": "185642",
-      "priceLabel": "top-price",
-      "price": "1480",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:60, model_group_id:201266, variant_id:, generation_id:1122, motortype_id:3824, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.16515834816008124,
-    "vehicleDetails": [
-      {
-        "data": "185,642 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "03/2012",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "55 kW (75 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "6.2 l/100 km (comb.)",
-      "147 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "7713abe8-b168-4de5-b649-dd268ec2c2f9",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "324823712"
-    },
-    "crossReferenceId": "324823712",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_85892db8-3e0d-4b9d-b1ad-f044bcf920a2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_f164fb8e-74bd-4710-9e2a-993f90f10c4a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_37b18865-5712-4f28-8fee-5f48d7d82b20.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_37768f3c-21de-4a09-b926-42dae41e0bc0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_45f2a8af-bfd7-4984-a788-1c782b1a5e2f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_a6081231-5e70-4e70-82b3-3915f687431a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_76bd0235-be3f-4613-8238-0e69289de246.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_0ec11ef4-0bf3-43ff-9190-0d628891afdc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_2cacbd2c-4256-4d5d-b1d2-b4ac09259c47.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_ac71d4cb-ace0-410a-b1a6-fa003370573e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_82768a6a-3246-43fc-973e-e19599dc0183.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_4fc2df2c-6af7-4e7a-824e-ca335c27c215.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_51622044-b838-4581-8e86-fed47244e602.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_06e7b8e0-6484-46d0-b3fd-49cdacf38d71.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_88bf94f3-a817-4150-b945-ec940418f014.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_f198f382-28de-4687-a0c3-db9c853f94bc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_411ec2c4-a2e2-4c64-b6ac-fc8bc6d97510.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_c0fbb406-1002-4652-95a7-d8a32f48dab5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/7713abe8-b168-4de5-b649-dd268ec2c2f9_6bbc5720-138d-4882-8d0b-fd06150d53e3.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,499"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/peugeot-107-1-0-12v-xr-airco-gasoline-white-7713abe8-b168-4de5-b649-dd268ec2c2f9",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Peugeot",
-      "model": "107",
-      "modelGroup": "107",
-      "variant": null,
-      "modelId": 18647,
-      "modelVersionInput": "1.0-12V XR AIRCO",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "214,331 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "8191 JH",
-      "city": "WAPENVELD",
-      "street": "Ir. R.R. van der Zeelaan 1"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "48479913",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/48479913-original-38ed75af-e6fa-4b4d-8c61-fe9124ce999d.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Andreas Auto's",
-      "contactName": "Andreas Ilbrink",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=48479913",
-        "imprint": "https://www.autoscout24.com/dealerinfo/andreas-auto-s-wapenveld-8191-jh-1/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 49396366",
-          "callTo": "+31649396366"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 49396366",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "12-2011",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.18240241840003468",
-      "isSmyleEligible": "false",
-      "mileage": "214331",
-      "priceLabel": "unknown",
-      "price": "1499",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:55, model_group_id:201165, variant_id:, generation_id:1066, motortype_id:3197, trim_id:913];"
-    },
-    "coverImageAttractiveness": 0.18240241840003468,
-    "vehicleDetails": [
-      {
-        "data": "214,331 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "12/2011",
+        "data": "07/2010",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -2202,9 +311,8 @@
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "103 g/km (comb.)"
+      "106 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -2225,268 +333,106 @@
     ]
   },
   {
-    "id": "0f780d50-0836-41f2-bf5b-1fa6a96beea2",
+    "id": "56fe41bc-c72f-4fa2-8fc3-310340b0a82d",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "441266825"
+      "crossReferenceId": "50476874"
     },
-    "crossReferenceId": "441266825",
+    "crossReferenceId": "50476874",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_41fc6e8d-ebc6-4369-a969-12387a88d504.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_12c4fa72-6960-4d64-8983-348d2e8ac81e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_92cc92a9-736e-4c51-9c34-e7ec182302bc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_66e6ee36-6d5a-4af4-bc2a-0a45146e9f72.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_bddad4d5-aebb-498a-8f5f-c3392d112364.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_4a95d53c-fbfd-4d37-884d-bbbdaf4dd139.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_7a2466dc-2ea8-42a1-b3ca-afbb091abbfa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_6a788c0e-b697-490d-b775-40ab88b110f9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_33fdde4a-dff7-4a5e-9115-7d7466ef8ba1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_5395a01d-8ca2-403d-b255-806162095671.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_dacb7201-6d15-4290-8b9e-378d7ad88f59.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_e7abfd2c-d894-431b-8e38-a87a5f89ce96.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_46a4f91f-ad08-432e-b2d7-676cb6d96ea0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_896e14d6-b54c-4419-afc9-0ee29deb939d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_c0d3e85c-978c-4ac0-99d3-6642544b7ecf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_1b69f306-695d-4d77-8fdf-afc71592efa7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_be0064e1-f150-4a2e-9545-b83cccefc7b7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_2a54f46d-b241-41c5-bb8d-7f20b90f91b0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_0ac63dc5-aafe-47ac-95e2-3a3ccf82d4d2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0f780d50-0836-41f2-bf5b-1fa6a96beea2_c9690303-9e70-4fe0-aad3-d87e5470d242.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_c5a34cdf-a907-4416-a56d-9918bb4a4030.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_b11bc820-33e8-4727-9e89-44e03c4fed7d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_826f51b3-e2e6-4db3-8dca-5319c9d511a7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_9029516a-c2ab-4e51-b5fb-aabc5449f4c5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_634f0e6f-9319-4477-a626-0401b6009ec7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_2b426b45-f568-477d-8f8a-75bd99c38f12.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_72ae1fde-0e26-42fb-b70b-0a2ef9400c98.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_e2a35be2-82af-4fc5-a328-49636426d53e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_5d5c5151-a130-47f6-907b-8200b1e53929.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_74d513ce-02fc-4cd2-99d1-d2c24028680f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_61926956-478e-4ba8-892d-86599209cdf0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_ad540762-817d-40b6-98dc-810d89e31211.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_a434dcc0-20be-40a8-bae8-8f42ef992c0b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_663adace-7d16-4c08-b3a3-f0d437e2352f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_11b2c756-46ce-4eda-b7a1-895deddeb806.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/56fe41bc-c72f-4fa2-8fc3-310340b0a82d_1216c7e8-e433-4297-94d0-a5633d86b44c.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
+    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 949"
+      "priceFormatted": "€ 3,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3950,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/renault-modus-avantage-gasoline-blue-0f780d50-0836-41f2-bf5b-1fa6a96beea2",
+    "url": "/offers/toyota-aygo-1-0-vvt-i-x-play-cruise-control-gasoline-red-cat_ma70mo18655-56fe41bc-c72f-4fa2-8fc3-310340b0a82d",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Renault",
-      "model": "Modus",
-      "modelGroup": "Modus",
-      "variant": null,
-      "modelId": 18522,
-      "modelVersionInput": "Avantage",
+      "make": "Toyota",
+      "model": "Aygo",
+      "modelGroup": "Aygo",
+      "variant": "5 Door",
+      "motorTypeName": null,
+      "modelId": 18655,
+      "modelVersionInput": "1.0 VVT-i x-play Cruise control",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "177,000 km"
+      "mileageInKm": "194,048 km",
+      "engineDisplacementInCCM": "998 cc"
     },
     "location": {
-      "countryCode": "DE",
-      "zip": "26129",
-      "city": "Oldenburg",
-      "street": "Bäkeplacken 25-27"
-    },
-    "ratings": {
-      "ratingsCount": 43,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
+      "countryCode": "NL",
+      "zip": "1704 RM",
+      "city": "HEERHUGOWAARD",
+      "street": "Nobelstraat 8"
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "34008",
+      "id": "60485689",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/34008-original-ca856765-ed6c-44df-8304-9d6b43fd5194/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/60485689-original-53059786-0912-486e-a08a-5147bfd0d8fa.jpeg/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "A4-Mobile GbR",
-      "contactName": "Martin Nowotny",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=34008",
-        "imprint": "https://www.autoscout24.com/dealerinfo/a4-mobile-gbr/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)441 - 7703151",
-          "callTo": "+494417703151"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)176 - 81208335",
-          "callTo": "+4917681208335"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)176 - 81208335",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2007",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.13318377354865074",
-      "isSmyleEligible": "false",
-      "mileage": "177000",
-      "priceLabel": "unknown",
-      "price": "949",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:60, model_group_id:201282, variant_id:, generation_id:1154, motortype_id:4478, trim_id:1276];"
-    },
-    "coverImageAttractiveness": 0.13318377354865074,
-    "vehicleDetails": [
-      {
-        "data": "177,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "05/2007",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "55 kW (75 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "6.1 l/100 km (comb.)",
-      "145 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "a451c5d7-c04b-452e-b26a-a65c87711c7f",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325060521"
-    },
-    "crossReferenceId": "325060521",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_cb933337-cd67-4789-9341-e4e92990944e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_97b623e5-a1ab-4bc7-b980-b3a0fcf26034.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_77d37b0e-c334-4b5d-893b-047811587cd2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_7eded411-6410-47c2-a4fa-0ebdf04732fd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_01595154-4b7e-437d-8a4a-dd1c2adbd5f8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_58f0426d-23b2-4193-89fe-ee9d689537d3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_77824a6b-da43-4ce4-a8d9-2b2ac7f3783c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_d6ee8c97-4f63-461e-9f20-0a21a97b4808.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_b6ee6fe9-27c4-400a-82a0-0b4f0c1b0c3c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_23a5efc0-33fb-421d-9aae-756dca6483a1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_802f3d32-bf00-4c7c-9a18-2e65d49877d9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_2e35f50f-24f6-41a3-a7e2-5518daa8f75c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_0479b1ad-f46b-4bb9-aa9b-548be6023567.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_e6a44287-e388-408f-b9d3-abc73ce0f6ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_c0f11de1-5a2d-448b-ad16-8d8c1b9a726f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_466822a4-114f-4082-acca-fdeda60fb3ff.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_d3993548-a0a8-4729-9454-e6fb89ec05c8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_e9db49e3-870d-4b96-af7b-e50997ff8ed6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_4ee5137f-b0a5-4245-a637-6d66fa85e30e.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,550"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/fiat-500-1-4-16v-lounge-gasoline-red-a451c5d7-c04b-452e-b26a-a65c87711c7f",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Fiat",
-      "model": "500",
-      "modelGroup": "500",
-      "variant": null,
-      "modelId": 15160,
-      "modelVersionInput": "1.4-16V Lounge",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "218,076 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "3113 AH",
-      "city": "SCHIEDAM",
-      "street": "Nieuw-Mathenesserstraat 32a"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "20632688",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/20632688-original-9075d4e4-8c14-4340-bf15-1e18e66ffe74/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autocentrale Schiedam",
+      "companyName": "DVW Automotive",
       "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=20632688",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autocentrale-schiedam/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/dvw-automotive?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/dvw-automotive/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)10 - 7859151",
-          "callTo": "+31107859151"
+          "formattedNumber": "+31 (0)728 - 080666",
+          "callTo": "+31728080666"
         },
         {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 42415989",
-          "callTo": "+31642415989"
+          "formattedNumber": "+31 (0)6 - 18601870",
+          "callTo": "+31618601870"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 42415989",
+          "formattedNumber": "+31 (0)6 - 18601870",
           "callTo": null
         }
       ]
@@ -2496,26 +442,26 @@
     "isOcs": false,
     "specialConditions": [],
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "09-2008",
+      "firstRegistration": "10-2014",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.17612457211720256",
+      "imageContent": "no-placeholder|0.20131681993242156",
       "isSmyleEligible": "false",
-      "mileage": "218076",
-      "priceLabel": "fair-price",
-      "price": "2550",
+      "mileage": "194048",
+      "priceLabel": "top-price",
+      "price": "3950",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:, generation_id:789, motortype_id:1765, trim_id:5101];"
+      "modelTaxonomy": "[make_id:70, model_group_id:201443, variant_id:3888, generation_id:1214, motortype_id:, trim_id:8523];"
     },
-    "coverImageAttractiveness": 0.17612457211720256,
+    "coverImageAttractiveness": 0.20131681993242156,
     "vehicleDetails": [
       {
-        "data": "218,076 km",
-        "iconName": "mileage_road",
+        "data": "194,048 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -2524,7 +470,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "09/2008",
+        "data": "10/2014",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -2534,16 +480,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "74 kW (101 hp)",
+        "data": "51 kW (69 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "149 g/km (comb.)"
+      "88 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -2564,233 +509,124 @@
     ]
   },
   {
-    "id": "11a3e93f-49c3-42d0-858e-4cc789a2c418",
+    "id": "40cc2f22-aadd-48be-b0ab-c3990eabd083",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": null
+      "crossReferenceId": "49817382"
     },
+    "crossReferenceId": "49817382",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_4d1b748b-841f-47a4-95a3-e157894d57d1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_8e317844-b5a2-4e9e-99c2-d2583d10f609.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_dc278f39-bfd4-4657-8a8b-3f5f78161080.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_1cbbc455-7410-4ba2-b598-8ff0b2bbe006.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_f9b290ae-3f2e-43f1-bd2c-44750cdd862e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_f39b3949-80ae-43da-adb7-20f400ce27cc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_0be28e74-d1e7-4fdb-85c4-1b9c2005beda.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_fd94d4d0-36a8-4478-8aa7-5031689783e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_64208064-6937-467b-bbac-257d7d7df062.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a3dc28bc-b632-4e7c-9f89-d0aa5f3139fc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a9ff5b74-311d-4644-b3b9-551c39885d69.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_839378dd-e2c2-4797-9a29-4f569854fcf3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_54391242-e4ea-4cc2-a076-a159e7c929ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a75b55cc-6fce-4e9c-8eea-6e5c5deb136a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_8e1af15f-aa07-467b-9440-02282ee00fb3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_9c6f9e37-5e1f-471c-a5b1-a1e293494c86.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_9ae601b6-6743-477e-8765-d798745d7ee0.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_7e10068e-b660-40ba-9061-640f20640e79.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_1b9aff06-19cc-4d1e-92b1-82787cd759cd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_28db3d51-89b2-4b5b-afaa-af8795e7335f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_2c1a0008-6750-4803-963d-5a600c5400fd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_45d397bd-172f-4d63-9266-9a107e1d96ae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_f18a6ab0-be01-45e4-98cb-2cbbfb99f630.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_74bec725-901c-4728-b42b-84bbb2352458.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_3c3d8d8f-0730-49b7-b7af-bf1bbcbcf41a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_5e86e8c8-ed31-438f-bad1-0fc28e027639.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_bd210b99-6e52-47c5-9767-359bb5e97cef.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_2296c305-5c12-46ae-907e-7586310e58b3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_e86b0e66-cb5e-4ab4-8171-e9c958798972.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_45ea4026-df53-4db2-80e3-a5e5e70598ca.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_1499cb52-7df7-4dd8-bcec-bf83f82eb63e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_073ac702-8368-4ce3-9224-9add1c198c8a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_732d3d3d-8763-4596-afca-5cfb660e4037.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_84454731-bf8e-41e4-800c-2ea46f54f180.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_4aa844cf-803b-4095-9b62-da0f12fd19d1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_54480d1f-060e-407f-8e43-869a8624d889.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_5ff64af2-4d68-46c8-871a-0e6bd1ca875d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_147e8bc7-abd9-454f-9780-3c7ec536ef74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_4aa3b68c-f021-4477-9816-bfa2db57434b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_c1cf47f5-d34d-44d4-af89-3ded3ed3392e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_4607afc6-56bf-4847-a90a-b3880e37ba68.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_14d9e432-334f-4954-9cd7-749a403d1f47.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_e52519be-b3ce-499c-90b8-67efce65c757.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_4b7caeba-2468-4d75-86f7-2e4085e17bff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_1b7770cc-adf6-4c2e-95f4-071778738e72.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_842d9902-2c42-4f44-b027-138b2c96d571.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/40cc2f22-aadd-48be-b0ab-c3990eabd083_f4d9cd88-2545-488c-bb93-c705595b1a54.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 7,990"
+      "priceFormatted": "€ 1,645",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1645,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/hyundai-i20-allwetterr-sitz-lenkradhzg-tuev-serviceneu-garant-gasoline-black-11a3e93f-49c3-42d0-858e-4cc789a2c418",
+    "url": "/offers/bmw-118-1-serie-118d-corporate-business-line-clima-leer-diesel-blue-cat_ma13mo18481-40cc2f22-aadd-48be-b0ab-c3990eabd083",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Hyundai",
-      "model": "i20",
-      "modelGroup": "i20",
-      "variant": null,
-      "modelId": 19188,
-      "modelVersionInput": "Allwetterr.*Sitz-lenkradhzg*TÜV&ServiceNeu*Garant",
+      "make": "BMW",
+      "model": "118",
+      "modelGroup": "1 Series",
+      "variant": "Coupe",
+      "motorTypeName": "118d",
+      "modelId": 18481,
+      "modelVersionInput": "1-serie 118d Corporate Business Line - Clima, Leer",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "65,000 km"
+      "fuel": "Diesel",
+      "mileageInKm": "386,661 km",
+      "engineDisplacementInCCM": "1,995 cc"
     },
     "location": {
-      "countryCode": "DE",
-      "zip": "28816",
-      "city": "Stuhr",
-      "street": "Am Hufschlag 2"
+      "countryCode": "NL",
+      "zip": "7711 AL",
+      "city": "NIEUWLEUSEN",
+      "street": "Burg. Backxlaan 206"
+    },
+    "ratings": {
+      "ratingsCount": 2041,
+      "ratingsStars": 4.5,
+      "ratingsEnabled": true
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "49027072",
+      "id": "11261",
       "type": "Dealer",
-      "companyName": "A.K.H. Autopark",
-      "contactName": "Ali Achour",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=49027072",
-        "imprint": "https://www.autoscout24.com/dealerinfo/a-k-h-autopark/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)173 - 6049860",
-          "callTo": "+491736049860"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)173 - 6049860",
-          "callTo": "+491736049860"
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/11261-original-0cb90df1-edac-4e0c-ba01-01f85c3e33d7.jpg/resize/100x50%3E/quality/90"
         }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2016",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.14465111827198218",
-      "isSmyleEligible": "false",
-      "mileage": "65000",
-      "priceLabel": "top-price",
-      "price": "7990",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:33, model_group_id:19188, variant_id:, generation_id:920, motortype_id:2250, trim_id:1024];"
-    },
-    "coverImageAttractiveness": 0.14465111827198218,
-    "vehicleDetails": [
-      {
-        "data": "65,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
       },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2016",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "62 kW (84 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "be5b5bb7-b71e-4209-81ef-64f610457e4b",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "3113245"
-    },
-    "crossReferenceId": "3113245",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_8ddeeb98-f5bf-46b9-9039-aa5e49a2a71c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_a6c13288-2023-4260-8884-b8c483888bab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_d47388bc-585e-4e93-ad2d-7438f738afbd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_81bbc1d6-e79d-4e1b-923c-a101c493985a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_d7a51b13-26be-44d8-b905-c970a816975e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_893764ef-9ba8-455b-bbef-d78130fb6a9a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_b105d277-8f66-41e3-8a1b-33bbe368b042.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_7ba020e7-1079-469f-9f00-35469d3a37b5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_5027496a-7c3c-4d49-9532-c578e15606e1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_91ec8550-6231-4f2d-897d-276bbe369bbd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_57021b56-b1d9-4bed-adcd-2add5f6249ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_ff0ec275-be21-44cd-b669-2a607fb6c154.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_71ca6167-6ac1-481d-ab4e-5f95aee550de.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-up-1-0-take-up-bluemotion-nieuwe-apk-gasoline-red-be5b5bb7-b71e-4209-81ef-64f610457e4b",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "up!",
-      "modelGroup": "Up",
-      "variant": null,
-      "modelId": 19750,
-      "modelVersionInput": "1.0 take up! BlueMotion - *NIEUWE APK*",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "265,110 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "6717 LS",
-      "city": "EDE",
-      "street": "Hoefweg 20"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "49679012",
-      "type": "Dealer",
-      "companyName": "Van de Hee",
-      "contactName": "Afdeling Verkoop",
+      "companyName": "Autobedrijf Zieleman",
+      "contactName": "Wilko Zieleman",
       "links": {
-        "infoPage": "/lst?atype=C&cid=49679012",
-        "imprint": "https://www.autoscout24.com/dealerinfo/van-de-hee/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autobedrijf-zieleman?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-zieleman/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)318 - 416600",
-          "callTo": "+31318416600"
+          "formattedNumber": "+31 (0)523 - 728292",
+          "callTo": "+31523728292"
         },
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 53133144",
-          "callTo": "+31653133144"
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)529 - 481288",
+          "callTo": "+31529481288"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 53133144",
+          "formattedNumber": "+31 (0)6 - 33020049",
           "callTo": null
         }
       ]
@@ -2805,21 +641,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "01-2013",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.21636632681828705",
+      "firstRegistration": "11-2011",
+      "fuelType": "d",
+      "imageContent": "no-placeholder|0.18089819893399006",
       "isSmyleEligible": "false",
-      "mileage": "265110",
-      "priceLabel": "good-price",
-      "price": "2950",
+      "mileage": "386661",
+      "priceLabel": "top-price",
+      "price": "1645",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:19750, variant_id:, generation_id:1316, motortype_id:10342, trim_id:];"
+      "modelTaxonomy": "[make_id:13, model_group_id:100037, variant_id:193, generation_id:191, motortype_id:520, trim_id:479988];"
     },
-    "coverImageAttractiveness": 0.21636632681828705,
+    "coverImageAttractiveness": 0.18089819893399006,
     "vehicleDetails": [
       {
-        "data": "265,110 km",
-        "iconName": "mileage_road",
+        "data": "386,661 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -2828,23 +664,25 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "01/2013",
+        "data": "11/2011",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
       {
-        "data": "Gasoline",
+        "data": "Diesel",
         "iconName": "gas_pump",
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "44 kW (60 hp)",
+        "data": "100 kW (136 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [],
-    "isListingBoost": false,
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -2865,118 +703,1383 @@
     ]
   },
   {
-    "id": "607cf8c7-501e-4f85-be76-33a845fb77b6",
+    "id": "8a700623-15c7-4260-96c4-28ca10af8b44",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "325581839"
+      "crossReferenceId": "50976193"
     },
-    "crossReferenceId": "325581839",
+    "crossReferenceId": "50976193",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_56cf6936-e0fd-4a25-8f88-485f4cb7ac3b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_7f9e6b18-7cfb-4c15-887e-4f42d2f6f165.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_6d7790ec-5224-4a7d-b383-bbf206c43ff4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_fe0789c6-75b3-4ed7-8363-82df3063b9cb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_46118d5c-641d-4895-8ddf-f3b4b9c50d3c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_49c3b99b-67f4-44bc-b8e0-c2e16c6fac96.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_dab66caa-e548-4bec-96f5-18172ba78802.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_7daa172e-21f7-4854-8d58-e1b3aeed30c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_81364878-777b-49f7-b7d9-580c390b153a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_f72a8a88-a47e-4996-a003-e09d9b2a0049.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_d1ebcfe9-431a-4e31-b1fe-6b5dc0d704e3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_b7756a48-8f41-475e-baec-b3cbc2b82c9a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_34084c17-0527-4cc1-9c62-4825db713abf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_3eeae411-08e6-449b-a235-2cd3ce9b270a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_caddda8a-5443-4d29-bf0e-0ecd52b7b377.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_b3573e6e-76a3-466c-a1c3-f82e1a624ab3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_742dfc71-9f00-47f9-b786-275ee9c177f3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_2d3cc0d2-ddd3-4198-a49d-27eb692bc0d6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_289c2d24-c204-4784-9fc6-196341a50f63.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_3262102d-6d8d-4df0-97ff-537157bac598.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_b2af7702-de7a-4e05-91ae-1af872e4f67b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_429b11d7-5d20-4c88-b8d2-e5a4339d1b3f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_c84a3386-20fb-42ef-897a-a0130722c01e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_6cd94a7a-9cb5-44b0-ae41-a05808cb59cf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_a0785f9b-6c5a-43b9-b237-952cf3350d74.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_1c9e06ca-854a-43e1-afab-152d806a37e5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_ac4bb5b2-01bc-4907-a9a9-c5e7258c5c26.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_f77397ae-2f22-42c9-ac33-b2ab06bf4dce.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_d3ca97ee-f728-4750-ba4c-06f38a2e112d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_5b07de0e-4a01-4d82-94b5-750c0994f883.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_07ba2b14-7ed9-4db3-8d86-494e3eb62ffb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_eec23ac6-77c6-4a0d-8599-5fa7b071291a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_ac8ccc28-4147-405d-8c56-1c9e55279954.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_a1acd72c-36aa-45bc-81f7-9ae2e9cdb864.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_113bc804-8c96-4e33-90e2-12372141e860.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_49eabf89-8630-4baa-b46d-f401cfb24c33.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_ead86324-63a5-49bb-a4bd-ea36a07c65c2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_59b89b85-e85e-4c5c-bc69-599fea031741.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_e6961477-44a6-4bef-8ef4-49042d19ce74.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_3c81e0cc-985d-427b-af65-f29460399ded.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_e5178577-1235-4626-839c-64519783c7d3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/607cf8c7-501e-4f85-be76-33a845fb77b6_a5dfd08a-f858-4601-96e4-d7723a6baed5.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_14271c35-77aa-45fd-83db-b7870daef60a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_3385b104-16e6-44b8-a54e-72401ebed89f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_a1c0b91a-7b0b-4659-bf8f-fe022add0328.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_f3051ac6-a466-4aaf-b7d5-f0704b52c60e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_5afdeea8-08b9-47d4-87e8-a30d16a0211a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_1105034c-141d-43c0-b09c-4ef3f44a8251.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_eef52af8-e7bb-43c9-a882-9362fb2d0647.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_5eedb4c2-b659-40bd-99ba-c212713ea7ed.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_d03d0ee3-f35a-49ef-8d43-b23f8acc4aec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_80cbc0c6-e247-419f-be61-c91afb185dbb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_2b599c5a-324d-413b-9da3-a47bec82b656.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_955c8ebc-b79e-452c-9f26-d8478f6513d3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_9c6d62a9-bae2-4dc6-bd39-95402e9dbc62.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_f4255e9a-49f5-4cf7-b191-8e241fe57e64.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_466f2b5a-dc06-4004-9e33-2fe59894fea3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_e0bc69c9-2856-43a0-9295-e35e646eef8c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_358182ec-22f8-4566-b3f6-85661d1213c0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_f5ba2da9-405a-435a-8f39-c9b2c100a8e8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_95b885fc-85d9-4990-8aa0-fe7d360aec43.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_c86e95dd-1a44-4bbd-a998-63edf8d6a28c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_5e5df584-37f3-4d48-ae65-1b848ef70e89.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_cd4158ad-5ca2-44c6-b2f0-10f1096615b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_a50770d1-030a-4ad2-8b28-4cce20470a55.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_02176abd-86b9-46cb-8f35-cbed232baa93.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_2fd4ef34-ac0a-4ada-a776-430e8bfa7d22.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_b7497d50-8e2a-492c-9d0f-65ade90fe201.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_cc9f0a47-75ea-496a-a74c-c9fa08eb8a13.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_6da62e25-f5fb-4e78-b915-fae2b4e73d1a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_4cca7d36-8616-4898-a228-b183d3f0d8a6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_d2073f9c-e1bc-4f2c-8dcc-b4c0aa045952.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_8300442a-9338-4bb0-b4f0-d6bad06e4db8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_c85689f6-2b11-497c-9ab6-9c46128689a4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/8a700623-15c7-4260-96c4-28ca10af8b44_e4ff9286-1d01-4024-9444-3747f438978a.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 2,995",
+      "suggestedRetailPrice": "€ 16,585",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2995,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/renault-clio-1-2-16v-gasoline-red-cat_ma60mo1961-8a700623-15c7-4260-96c4-28ca10af8b44",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Renault",
+      "model": "Clio",
+      "modelGroup": "Clio",
+      "variant": "Clio",
+      "motorTypeName": "1.2",
+      "modelId": 1961,
+      "modelVersionInput": "1.2 16V",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "209,637 km",
+      "engineDisplacementInCCM": "1,149 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "17912423",
+      "type": "Dealer",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "04-2014",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.22186965530909752",
+      "isSmyleEligible": "false",
+      "mileage": "209637",
+      "priceLabel": "top-price",
+      "price": "2995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:60, model_group_id:201266, variant_id:3652, generation_id:1125, motortype_id:3824, trim_id:480702];"
+    },
+    "coverImageAttractiveness": 0.22186965530909752,
+    "vehicleDetails": [
+      {
+        "data": "209,637 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "04/2014",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "54 kW (73 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "127 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "05a53988-7426-4d9d-bc04-62b8147d052d",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51116487"
+    },
+    "crossReferenceId": "51116487",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_31af2cf6-0e4b-47de-9eef-db49d594ed61.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_8596df5b-b872-44e9-9159-74814a81686e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_534ca30a-7344-40d7-922c-95eac70667bc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_cd3ce4b3-1232-4e8b-a441-4dce6300659d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_6d7f49a0-1441-4d73-a3fc-80e8d50de7a9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_7dffdd4b-5c82-4994-aa3b-0bc4dfb07979.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_a43e2a77-719b-4e17-bc28-52d15414d146.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_82e470ff-8903-48eb-b944-67ce0ff07fd1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_d8b6cd20-862d-4edd-8de5-bc587703cb9b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_362c71b4-dafd-4cf3-91d7-d2117d533de7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_d1051b2e-66d9-4287-a0e5-b14bf8f691e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_e7ad3bb6-d214-4621-b43e-79ba9311c3af.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_116170f7-8cc0-40a1-9b45-e7e7b52e3384.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_cacee6b4-fa19-4365-9c9c-231e066c46e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_c39ca3f0-ff25-422b-a079-5b5a346fd49a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_cfa21895-b6aa-47d6-aa77-1f46b726318b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_86d43a01-1bb2-4e72-ab7c-578b09c9f5ee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_afd7eaf2-8f28-44ae-a220-247e670cb914.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_aed3e6f3-fd29-4cf8-a412-961ce21ea47e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_8a7d474c-6b61-4a21-8656-7ed774c106c6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_b20e573c-d6ad-4935-bf47-d632092386b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/05a53988-7426-4d9d-bc04-62b8147d052d_950533e8-7a74-4260-8a43-c9a2e45dfb59.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 6,999"
+      "priceFormatted": "€ 2,995",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2995,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/volkswagen-golf-vi-1-4-tsi-122pk-r-line-dak-clima-carplay-gasoline-black-607cf8c7-501e-4f85-be76-33a845fb77b6",
+    "url": "/offers/toyota-yaris-1-5-16v-vvt-i-t-sport-airco-cruise-1e-eigenaar-or-gasoline-black-cat_ma70mo15663-05a53988-7426-4d9d-bc04-62b8147d052d",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Volkswagen",
-      "model": "Golf",
-      "modelGroup": "Golf",
-      "variant": "Cabrio",
-      "modelId": 2084,
-      "modelVersionInput": "VI 1.4 TSI 122PK R-Line Dak! Clima! Carplay!",
+      "make": "Toyota",
+      "model": "Yaris",
+      "modelGroup": "Yaris",
+      "variant": "Yaris",
+      "motorTypeName": "1.5",
+      "modelId": 15663,
+      "modelVersionInput": "1.5-16V VVT-i T-Sport Airco Cruise 1e eigenaar! Or",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "141,259 km"
+      "mileageInKm": "126,480 km",
+      "engineDisplacementInCCM": "1,497 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "7317 AK",
+      "zip": "7317 BE",
       "city": "APELDOORN",
-      "street": "Vlijtseweg 168"
+      "street": "Lage Brink 26"
     },
     "seller": {
-      "dealer": {},
-      "id": "3766889",
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "46838809",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/3766889-original-1ee8bdca-449c-4cf4-9e0c-5b40b4d3a013.png/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/46838809-original-43d12bd7-bbce-4c58-a2ef-472da08bf560.JPG/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Garage Zuidbroek",
-      "contactName": "Afdeling verkoop",
+      "companyName": "Autohuis Ter Laare B.V.",
+      "contactName": "Justin ter Laare",
       "links": {
-        "infoPage": "/lst?atype=C&cid=3766889",
-        "imprint": "https://www.autoscout24.com/dealerinfo/garage-zuidbroek/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohuis-ter-laare-b-v?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohuis-ter-laare-b-v/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)55 - 7370060",
-          "callTo": "+31557370060"
+          "formattedNumber": "+31 (0)558 - 081314",
+          "callTo": "+31558081314"
         },
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 42641267",
-          "callTo": "+31642641267"
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)55 - 2340538",
+          "callTo": "+31552340538"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 42641267",
+          "formattedNumber": "+31 (0)6 - 15118089",
           "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "04-2004",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.1613837353974974",
+      "isSmyleEligible": "false",
+      "mileage": "126480",
+      "priceLabel": "top-price",
+      "price": "2995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:70, model_group_id:201438, variant_id:3713, generation_id:1278, motortype_id:5376, trim_id:480871];"
+    },
+    "coverImageAttractiveness": 0.1613837353974974,
+    "vehicleDetails": [
+      {
+        "data": "126,480 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "04/2004",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "77 kW (105 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "162 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "bc90824c-f80b-4a3d-9d78-719806876256",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51063128"
+    },
+    "crossReferenceId": "51063128",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_ce8e9d34-bf7b-414f-ac85-4bb7020d6776.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_a7ffd242-4307-4094-af82-f2d4b06d8761.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_260036aa-706f-4725-8e6e-d4b4496e0ba0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_92a3bb64-6722-4209-836f-c1746189e09c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_ccc6e9c0-5fc2-41a1-bad7-6b2a238fa515.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_97d9a256-c5d3-4f9b-8416-97bbaa7e1dd5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_9b8e385c-e6b8-4413-988c-cfea407a9402.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_2fb681c6-5fe5-4ace-bf77-2a0476c4e166.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_58129e82-c4d5-4495-b8ba-c0ff3ccc87c4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_eb011304-e339-4449-8396-f0b4a7b0a421.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_6aaab110-2290-4cee-b0cd-c7a090f7a207.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_340807b2-e185-4113-830b-404177b5b880.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_d7cb98dd-0479-475c-9024-d3af600b8968.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_39fcaf8f-bd9f-420c-8b56-67573abd89ec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_f29f06a6-1652-4672-ad9b-7aee95a2a653.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_f3b924c3-6882-4bf1-9131-00069eb85558.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_ba61ade3-afcc-43fd-9330-745bf370eb27.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_588eb33a-1431-47f2-ba08-655457a3748a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_a5dec8ec-6277-4535-9899-83794f8f764e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_8d587b2e-c8a4-4913-ae5f-f2fa9f0dad87.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_95bdb42f-5f41-4b0c-8714-bbf5f80b3820.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_b81a5163-ba72-4d03-b13e-637008413346.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_c83ba82f-9836-4884-b922-85922531e610.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_8a6cf4b6-c66b-4bc7-a59f-d7846f99a2c3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_85a1a304-7dfe-4495-915e-952790a7fa2c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_b50ac59e-65f8-4b98-b622-1da405f8ada7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_058b6c20-f7ec-4063-817e-9101e16967e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_66f8df94-0065-45da-8bbe-6fe4925ee650.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_b2c0a256-6798-4772-a1c3-6e2dfc03f996.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/bc90824c-f80b-4a3d-9d78-719806876256_7d298091-4734-4498-8174-1cefc1a111ad.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,499",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3499,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/toyota-aygo-1-0-12v-access-1e-eigenaar-nap-gasoline-blue-cat_ma70mo18655-bc90824c-f80b-4a3d-9d78-719806876256",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Toyota",
+      "model": "Aygo",
+      "modelGroup": "Aygo",
+      "variant": "5 Door",
+      "motorTypeName": null,
+      "modelId": 18655,
+      "modelVersionInput": "1.0-12V Access 1e Eigenaar - NAP",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "71,641 km",
+      "engineDisplacementInCCM": "998 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "5038 GP",
+      "city": "TILBURG",
+      "street": "Boomstraat 117a"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "51036003",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/51036003-original-4eb7d248-ab67-481e-b3d3-41f247eb2482.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Euromax Auto's",
+      "contactName": "Yusuf Temur",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/euromax-auto-s?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/euromax-auto-s/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)138 - 081079",
+          "callTo": "+31138081079"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 25370431",
+          "callTo": "+31625370431"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 25370431",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2009",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.16058350923914688",
+      "isSmyleEligible": "false",
+      "mileage": "71641",
+      "priceLabel": "fair-price",
+      "price": "3499",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:70, model_group_id:201443, variant_id:3888, generation_id:1214, motortype_id:, trim_id:480841];"
+    },
+    "coverImageAttractiveness": 0.16058350923914688,
+    "vehicleDetails": [
+      {
+        "data": "71,641 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2009",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "50 kW (68 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "106 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "3a264b22-83ff-4113-9fc4-035692d33a61",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "3210715"
+    },
+    "crossReferenceId": "3210715",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_d4e3cd37-98c0-4463-b7ae-d5b1d0e8b8bd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_ae226301-ee4f-4c62-83b6-0d1954c8e0c4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_8ea943ab-7909-431b-a854-9ce1ee04e7ee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_757e66ea-639d-4926-9d69-6f7259d0398b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_2b43bc10-4efc-4666-b93b-f2c11e0d417b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_edb99f0b-fa1f-4866-bcad-da4ec84dbe27.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_2c7e5c85-75ec-414d-9be9-363ae8fe40a0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_481ec6a7-8805-4fed-80d5-2c977c1d66cb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_088b07be-c0d4-462d-a5fa-aa33792be429.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_d73a5a9b-4d4e-423a-b356-65362b883887.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_f29c872a-a831-46a9-8c4a-62b3699e879f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_5ca6ed25-d3c9-4973-971b-9fb989b033af.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_8020c0a9-db47-4a72-a76a-1c8434d8360f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_74c5cfe9-011d-4bd2-9a49-1af437c7968e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_6bc8f93a-0d28-479c-9aa2-82005c25c6e5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_365c6709-9701-4d78-8260-85e0d43d4e19.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_76801ef2-811a-4241-b035-6b60f1c67b79.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_303b2355-ca8c-4513-8af2-b897dafd6f68.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_509b720b-b097-42cf-90b7-3b0e9a7eddc8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_5cf783b5-7956-46fd-94dc-625d7784de16.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_209d6f0c-2db9-498d-a379-b766afa96112.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_36f887f7-2711-4484-9b40-8e9dd54f2cbf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_b2d42e39-3255-463c-a4d1-8031e612a006.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_f683fa5a-2528-41ce-8db9-4d12193e0aec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_a8afcece-1c1b-4392-ba15-30c08ea0c203.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_b03a8e88-1601-4a9a-bfb3-ec5bd7ae672c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3a264b22-83ff-4113-9fc4-035692d33a61_f605d0ef-4cb6-4d33-ae1f-8ca7d76a1557.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 2,695",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2695,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/kia-picanto-1-0-cvvt-design-edition-4-x-elctr-ram-pdc-lmv-nap-gasoline-grey-cat_ma39mo18417-3a264b22-83ff-4113-9fc4-035692d33a61",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Kia",
+      "model": "Picanto",
+      "modelGroup": "Picanto",
+      "variant": null,
+      "motorTypeName": "1.0",
+      "modelId": 18417,
+      "modelVersionInput": "1.0 CVVT Design Edition 4 X ELCTR. RAM PDC LMV NAP",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "284,791 km",
+      "engineDisplacementInCCM": "998 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3076 JA",
+      "city": "ROTTERDAM",
+      "street": "Berkenwoudestraat 23"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "20250231",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/20250231-original-ddb5589a-dfb2-4269-8037-be90340104d5.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Ed-Kar Import en Export",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)108 - 084733",
+          "callTo": "+31108084733"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": "+31651191563"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "11-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.12703043574203898",
+      "isSmyleEligible": "false",
+      "mileage": "284791",
+      "priceLabel": "unknown",
+      "price": "2695",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:39, model_group_id:200740, variant_id:, generation_id:978, motortype_id:2452, trim_id:2900];"
+    },
+    "coverImageAttractiveness": 0.12703043574203898,
+    "vehicleDetails": [
+      {
+        "data": "284,791 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "11/2012",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "51 kW (69 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "aba4f530-6223-4212-bae3-7d1dcc822b11",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51141934"
+    },
+    "crossReferenceId": "51141934",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_5193afd7-61d7-499c-ba07-082485f9922c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_4ab3c49f-4aa1-46e6-a4a4-172da4840358.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_7ca89c64-07b1-41a1-ac40-6c75ce50a0e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_5edb92f7-924a-49f1-8ac1-a9e4c9a87a77.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_3b5b40be-e9e5-4e62-9ed4-8d41dca6ee4e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_25c0189b-94cd-4a05-9fd9-86d94f3f319c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_97a75576-e58f-462e-bb07-13982905a5db.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_3b8613ab-a23d-41e7-a8b4-29e10d6cc96e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_9cf7c49d-d6a5-4b70-b1b5-82f15bf3bf88.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_17fb84f0-2524-4bf6-b4c9-2a40ec3ef073.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_41193e93-7e9e-4dff-909d-6678c4e539a7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_a3dc5e3d-c77c-486f-bb55-e14354755dcf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_ba3aeb4b-97cd-44e1-af41-cd6546df69eb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_4a2edc01-b7ea-4af5-a6ad-f8b7d964769d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_bf234715-3ac0-4561-b129-88cf16ab0137.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_0488ba6f-6839-4487-954c-fdc708127fc9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_0151bc44-16e1-45d8-b9f4-a59cb447033f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_2e2831d8-c3dc-41d0-a7cf-96208bcf8bf5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_3623a0ee-971e-4a5f-880f-ab6b15857d48.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_ddd1fbe5-4655-4255-ac90-7cdccade6f70.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_0a985508-81eb-4ca6-9d10-bee35dd2a3dc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_d1a9941e-97c7-45f7-84a8-9ae9d0cefa9d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_77215079-cb60-48ff-9814-0bf49aea9e03.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_bbbb8f05-d9d7-4113-9bd0-ab009255a9f7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_e63aa1c9-6bef-4709-bcec-140886f462f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_19e075da-2b04-422e-9b96-8cbae31785b0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_8cfc41a1-a30d-4c59-a8b4-d08971acda4b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/aba4f530-6223-4212-bae3-7d1dcc822b11_d475fe6c-e6be-45a1-a57d-bbbd64e8029b.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 7,995",
+      "suggestedRetailPrice": "€ 19,915",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 7995,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/ford-fiesta-1-0-ecoboost-st-line-sportuitlaat-gasoline-grey-cat_ma29mo1758-aba4f530-6223-4212-bae3-7d1dcc822b11",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Ford",
+      "model": "Fiesta",
+      "modelGroup": "Fiesta",
+      "variant": "5 Door",
+      "motorTypeName": "1.0 EcoBoost",
+      "modelId": 1758,
+      "modelVersionInput": "1.0 EcoBoost ST Line Sportuitlaat|",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "109,456 km",
+      "engineDisplacementInCCM": "998 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "5145 NV",
+      "city": "WAALWIJK",
+      "street": "Duikerweg 7"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "39027134",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/39027134-original-dc9d47e9-412d-4bef-8ce7-ee69b5ca83e3.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Krabmann Automotive",
+      "contactName": "Niels Krabmann",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/krabmann-automotive?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/krabmann-automotive/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)575 - 788627",
+          "callTo": "+31575788627"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)416 - 234034",
+          "callTo": "+31416234034"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)416 - 234034",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2017",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2281592544181984",
+      "isSmyleEligible": "false",
+      "mileage": "109456",
+      "priceLabel": "top-price",
+      "price": "7995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:29, model_group_id:1758, variant_id:3900, generation_id:447, motortype_id:12307, trim_id:479156];"
+    },
+    "coverImageAttractiveness": 0.2281592544181984,
+    "vehicleDetails": [
+      {
+        "data": "109,456 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2017",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "103 kW (140 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "99 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "3f8891dc-a9ef-4173-90a1-0b7e340a6366",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51093332"
+    },
+    "crossReferenceId": "51093332",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_fd0ce5ff-a68a-450b-bc38-943693f02002.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_0fc1ece6-5ab9-4410-8e70-851990c59417.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_abcda996-4da3-4afa-b7cb-815d8004b17e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_b02d0fbd-ba61-4e32-add4-4b49d6f9b166.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_a53376dc-bc81-4a32-a434-a7e2ba4e883f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_dec018c5-6973-49ca-b11c-c1396d1e24c1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_f8348e6f-b341-468c-a0ef-68f76983a9a4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_272f4b78-ffcf-49c4-86ab-45a60ab0d485.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_9a43b0ea-7162-43a5-9cf3-0abf7e2676bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_82ade909-9c43-4da1-a6cf-07ba12d694c8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_7c54be71-0d46-4f29-96b4-aba90358e043.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_fccd2e16-59b3-484d-9afe-e3956f63d51c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_9ae6daa3-df0a-4bda-b958-ba97266f89da.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_060a3dd9-b242-48ae-b99e-65b37edfbeac.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_dd36b2b8-bf36-422b-bf3c-1d8426af52e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_9ac6337f-82b6-4121-aa69-a50c24c47ce1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_511de552-164a-49c8-84e6-d2bbc3f15487.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3f8891dc-a9ef-4173-90a1-0b7e340a6366_5540c734-4f78-4293-b387-f50630242e9e.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 6,445",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 6445,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/citroen-c3-1-2-puretech-ss-feel-airco-cruise-nette-sta-gasoline-grey-cat_ma21mo18264-3f8891dc-a9ef-4173-90a1-0b7e340a6366",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Citroen",
+      "model": "C3",
+      "modelGroup": "C3",
+      "variant": "C3",
+      "motorTypeName": "83",
+      "modelId": 18264,
+      "modelVersionInput": "1.2 PureTech S&S Feel | Airco | Cruise | Nette sta",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "103,067 km",
+      "engineDisplacementInCCM": "1,199 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3771 MT",
+      "city": "BARNEVELD",
+      "street": "Veemweg 10"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "29364806",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/29364806-original-2548f931-9832-4028-8bfe-e5a992f8ca3f.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autobedrijf van Herick B.V.",
+      "contactName": "Dick van der Wilt",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autobedrijf-van-herick-b-v?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-van-herick-b-v/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)308 - 083601",
+          "callTo": "+31308083601"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)342 - 470025",
+          "callTo": "+31342470025"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 13769191",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "06-2019",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18403224285015418",
+      "isSmyleEligible": "false",
+      "mileage": "103067",
+      "priceLabel": "top-price",
+      "price": "6445",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:21, model_group_id:200303, variant_id:3409, generation_id:2127, motortype_id:1449, trim_id:3640];"
+    },
+    "coverImageAttractiveness": 0.18403224285015418,
+    "vehicleDetails": [
+      {
+        "data": "103,067 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "06/2019",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "61 kW (83 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "110 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "0cc882a5-d690-42d7-9448-01c005ce5668",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51155687"
+    },
+    "crossReferenceId": "51155687",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_22ce50a6-48a6-47d3-97cb-6ba9a980bd59.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_ccfd7857-c105-4597-98f6-fe2954f4f888.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_13eecdcf-ed8a-42d4-8416-1b0ac4becf38.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_f96c5c1d-8176-4d02-892a-73033ffc9eae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_7be0a100-d72d-45c5-b462-456de1000ef8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_eaa6a9c4-2e19-43ef-858b-251d9ce2975c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_bc3a7a28-27bd-491c-917f-a90103ac8003.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_9841e6dc-ca6e-43e8-8ed0-bae3c12faf6a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_862d7832-0c41-4715-9a95-dd433e1690d2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_2ff8b40e-805a-4652-83ca-424eeca3a234.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_60613aab-9cf3-48a6-af6f-d7453ff4f389.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_37aea372-c04d-42d4-be43-51029c336246.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_9f0ff13e-3338-4b73-b474-6a4292b9a132.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0cc882a5-d690-42d7-9448-01c005ce5668_05c36b67-3293-47d8-aa06-d6f7eee302ed.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 2,950",
+      "suggestedRetailPrice": "€ 34,152",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/audi-a3-sportback-2-0-tdi-ambition-business-edition-diesel-grey-cat_ma9mo1624-0cc882a5-d690-42d7-9448-01c005ce5668",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Audi",
+      "model": "A3",
+      "modelGroup": "A3",
+      "variant": "Sportback",
+      "motorTypeName": "2.0 TDI",
+      "modelId": 1624,
+      "modelVersionInput": "Sportback 2.0 TDI Ambition Business Edition",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Diesel",
+      "mileageInKm": "477,661 km",
+      "engineDisplacementInCCM": "1,968 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3921 AH",
+      "city": "ELST",
+      "street": "Rijksstraatweg 243A"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "45392934",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/45392934-original-944b32e8-6f37-40ef-9d8a-31210be65397.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Heuvelrug Automotive",
+      "contactName": "Eduard de Kruijff",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/heuvelrug-automotive?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/heuvelrug-automotive/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)318 - 716343",
+          "callTo": "+31318716343"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 30026017",
+          "callTo": "+31630026017"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 30026017",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "03-2009",
+      "fuelType": "d",
+      "imageContent": "no-placeholder|0.2600786369454501",
+      "isSmyleEligible": "false",
+      "mileage": "477661",
+      "priceLabel": "good-price",
+      "price": "2950",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:9, model_group_id:1624, variant_id:152, generation_id:152, motortype_id:243, trim_id:131];"
+    },
+    "coverImageAttractiveness": 0.2600786369454501,
+    "vehicleDetails": [
+      {
+        "data": "477,661 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "03/2009",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Diesel",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "103 kW (140 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "134 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "180fa836-e3db-4ffc-984d-cdaeac2ad4b0",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "437479144"
+    },
+    "crossReferenceId": "437479144",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_ee53e3fa-5cee-426c-af98-7218acfb08a0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_feeac8de-59ed-4c9a-8e43-55bda08d9101.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_87cb2e65-5bec-4bde-8e9d-9320bb54c0d7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_0ed7ab62-3562-4221-a0d6-91a043572cbd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_db240dc5-29f0-4150-abb0-7285ce0108a3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_806a032b-5be7-4214-8a4c-b2041c99901f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_dce9e38f-4cc8-4c9f-ae85-7856729b4a3e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_079ced52-a8fa-47a4-96aa-86411daa7b17.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_c48bfae5-67d3-4a93-8adc-597709350996.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_1612869a-a3cb-4ebd-9225-25e83b8e0d20.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_69cbae03-bbc7-4db1-96ca-a7ac94629108.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_adfb3d0d-9c71-49f3-9b8e-1e9e53404536.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_1242e07c-962c-4c6b-bbe4-20a68fb0ebbf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/180fa836-e3db-4ffc-984d-cdaeac2ad4b0_336b53fd-84bf-4a8e-919c-067244c6083e.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 2,800",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2800,
+      "isConditionalPrice": true
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/fiat-500-sport-gasoline-black-cat_ma28mo15160-180fa836-e3db-4ffc-984d-cdaeac2ad4b0",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Fiat",
+      "model": "500",
+      "modelGroup": "500",
+      "variant": "Hatchback",
+      "motorTypeName": "0.9",
+      "modelId": 15160,
+      "modelVersionInput": "Sport",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "146,000 km",
+      "engineDisplacementInCCM": "875 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "54311",
+      "city": "Trierweiler",
+      "street": "Roderstraße 9-11"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "63169494",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/63169494-original-bb088643-8e9d-4646-a07a-288448b757fb.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autohandel Younes K.",
+      "contactName": "Kassem Younes",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohandel-younes-k-trierweiler/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)651 - 60344265",
+          "callTo": "+4965160344265"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1523 - 6947025",
+          "callTo": "+4915236947025"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1515 - 1143143",
+          "callTo": "+4915151143143"
         }
       ]
     },
@@ -2992,19 +2095,19 @@
     "tracking": {
       "firstRegistration": "03-2011",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.20237786391602308",
+      "imageContent": "no-placeholder|0.14120645408989807",
       "isSmyleEligible": "false",
-      "mileage": "141259",
+      "mileage": "146000",
       "priceLabel": "top-price",
-      "price": "6999",
+      "price": "2800",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100101, variant_id:128, generation_id:6, motortype_id:420, trim_id:594];"
+      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:4199, generation_id:789, motortype_id:1761, trim_id:7178];"
     },
-    "coverImageAttractiveness": 0.20237786391602308,
+    "coverImageAttractiveness": 0.14120645408989807,
     "vehicleDetails": [
       {
-        "data": "141,259 km",
-        "iconName": "mileage_road",
+        "data": "146,000 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -3023,326 +2126,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "90 kW (122 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "d248ec74-2792-430e-b961-bc94271758c9",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_dca3ec9c-6f87-4c0a-bacd-ff01b7ccd253.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_3d9ec397-ac34-4426-aa3d-b0fd437a5ff5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_3d9994bb-54da-4fc1-80ed-55ff9d50ea2e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_eeced5be-f830-4bed-b12c-2f258227da1f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_1f217569-dc0b-4daa-afca-1386aa4e32aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_e0bac94e-a9fc-4e7f-b288-da72c814d111.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_c8bb9dfd-53f9-425e-ac04-e62eaf1e3326.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_ddfce90d-f96c-49ad-82a7-e6fde5f4605a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_16e370af-0fdc-40bf-b8d3-00b4c9e1d7bb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_dbbe3b2e-5f53-4a1a-ac1f-ef3b853fd8c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_6ade26e5-e7ad-4091-b6ee-c0a48bbc8c48.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_9ec4426b-2ad9-439f-81b9-1ca1b08786fd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_482bf9ff-7059-4613-bdc0-ec77eb945b53.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_d493c466-ad0e-4bb7-a93d-2fa9de09ce78.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d248ec74-2792-430e-b961-bc94271758c9_7fa6d735-66c9-4859-81cb-2e5aec085f1b.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,490"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/alfa-romeo-mito-1-4-78-cv-distinctive-sport-pack-gasoline-grey-d248ec74-2792-430e-b961-bc94271758c9",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Alfa Romeo",
-      "model": "MiTo",
-      "modelGroup": "MiTo",
-      "variant": null,
-      "modelId": 19161,
-      "modelVersionInput": "1.4 78 CV Distinctive Sport Pack",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "196,758 km"
-    },
-    "location": {
-      "countryCode": "IT",
-      "zip": "20045",
-      "city": "Lainate - Mi",
-      "street": "Via Rho 37"
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "30125861",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/30125861-original-9679370b-2a4d-4cd5-acbc-fc7f9ae01057.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Auto7 srl",
-      "contactName": "Auto7 Ilenia",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=30125861",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto7-srl/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 344 - 1150881",
-          "callTo": "+393441150881"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+39 344 - 1150881",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Nfm",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2009",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.31011704660233486",
-      "isSmyleEligible": "false",
-      "mileage": "196758",
-      "priceLabel": "good-price",
-      "price": "3490",
-      "orderBucket": "0",
-      "modelTaxonomy": "[make_id:6, model_group_id:200054, variant_id:, generation_id:2285, motortype_id:5512, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.31011704660233486,
-    "vehicleDetails": [
-      {
-        "data": "196,758 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2009",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "58 kW (79 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "sponsored"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "a415d356-5be2-4f88-a6dd-b18fa3ce4a33",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325431556"
-    },
-    "crossReferenceId": "325431556",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_c1b0e716-0c81-40df-9667-7c2f1de62a25.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_4e44c20b-89cf-4562-b736-036f1942faae.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_f87cd613-1297-4a6b-8c7b-52e8f54e0e5c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_2fe417c4-8811-4872-98b4-7081ea8e8858.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_964bb1b7-c8c7-4c96-ba42-522d4fe39ea7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_ee1f23ed-b87e-4ddd-9d2b-3cdd143a57c2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_ff1a8499-ce1b-4baa-94f2-302530f7003d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_4eb0fb01-67cb-47d1-9d58-3959b7b0d6b4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_ca6415bf-5f46-4723-983a-dfdc14a4fed3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_a281d522-cf80-48f3-b2c9-fa016ef4657d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_db19c811-d507-470e-9abf-3d039ec3f3cc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_d3f32ce4-c1f2-4b22-8cf5-40cc17b49415.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_e08a9224-ef2e-451c-aa80-ff0e8e526c4d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_b3740c87-691f-45ed-adc0-8f5a1d6fb554.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_c562e7ea-0df8-42ed-90ea-0b12bd9c137a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_a9bd3e48-4321-4779-a661-5d5b3ada4b34.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_4af99190-b2cf-4e43-9754-f872f7b81bb7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_4d017498-0d3d-45c2-8684-7d0b3e531e6e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_42128c32-9bd2-4c88-bcf1-9f55a379f78a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_44e97e1b-9bff-4874-8e28-cecb0c252435.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_6c814ab0-8539-4cbb-9bf0-cc44d700a21e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a415d356-5be2-4f88-a6dd-b18fa3ce4a33_55cae3a0-ac08-4445-9485-f1f8916631b5.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 6,975"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volvo-v40-1-6-t4-momentum-automaat-xenon-camera-stoelverwarm-gasoline-white-a415d356-5be2-4f88-a6dd-b18fa3ce4a33",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volvo",
-      "model": "V40",
-      "modelGroup": "V40",
-      "variant": "V40",
-      "modelId": 2082,
-      "modelVersionInput": "1.6 T4 Momentum|Automaat|Xenon|Camera|Stoelverwarm",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Automatic",
-      "fuel": "Gasoline",
-      "mileageInKm": "271,509 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "9011 WH",
-      "city": "Jirnsum",
-      "street": "Industrieweg 10"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "41690866",
-      "type": "Dealer",
-      "companyName": "Autobedrijf Nugteren",
-      "contactName": "Sebastiaan Nugteren",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=41690866",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-nugteren/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 54986899",
-          "callTo": "+31654986899"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 54986899",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2013",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.23926987325018778",
-      "isSmyleEligible": "false",
-      "mileage": "271509",
-      "priceLabel": "good-price",
-      "price": "6975",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:73, model_group_id:202647, variant_id:2664, generation_id:10922, motortype_id:11813, trim_id:478556];"
-    },
-    "coverImageAttractiveness": 0.23926987325018778,
-    "vehicleDetails": [
-      {
-        "data": "271,509 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Automatic",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "05/2013",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "132 kW (179 hp)",
+        "data": "63 kW (86 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
-      "- (l/100 km)",
-      "143 g/km (comb.)"
+      "4.0 l/100 km (comb.)",
+      "95 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -3363,76 +2155,113 @@
     ]
   },
   {
-    "id": "1873bc4e-a499-4b34-bdfc-3e878f82926f",
+    "id": "27d660dd-19ce-4515-9f8b-d05e0402a7d7",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "325327379"
+      "crossReferenceId": "51120936"
     },
-    "crossReferenceId": "325327379",
+    "crossReferenceId": "51120936",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_6acf6b17-5c64-483f-a822-dfdb488278bf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_8ace6823-7a5b-4e17-b01b-8ef8451e0594.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_0c6ad028-789d-4e73-9117-c84dd7551737.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_e9f23d42-b0cd-46a9-b6a3-744f47a4b211.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_4380a9f6-8fcd-4ef4-ac31-d4b4f208fc16.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_3ffc853b-2019-468e-ad4f-d4c326f0cdb9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_58889497-a2ad-42f1-a928-ad046656cb8e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_e29c6478-4124-4794-8040-69dda6c58289.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_a8b2ed40-73ef-492a-a82a-4763cc3cdad8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/1873bc4e-a499-4b34-bdfc-3e878f82926f_0a1f25b9-4d4f-4a23-b9ff-a3ddd0e9f39d.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_cdf64513-862e-48e6-ae2e-20b79f70b6e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_d0f8587a-a83f-4ff7-b25f-509f67ddee0a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_1ed39cf3-7b6a-47ae-af75-054e71adf0aa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_4cf852ba-e88a-42f4-bf6f-af6a460c957a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_e8580903-6af6-4997-bd75-cf9c4d33c742.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_a4639fba-bda1-423e-a72a-6919a0c0a4e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_c706557c-6a4b-4ad7-abec-712556fe597a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_6140bb1a-75a7-4ad6-8303-ab9e40f4903f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_e5b3652c-c812-4d5f-b99a-6dc4f66b2bbe.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_63d3b4d2-c556-48ca-b744-32664a34222f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_0cfb8fb3-ceed-449f-be09-428ed998a453.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_17060279-2de2-4aca-a285-b5d7ce52e154.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_78b1cbf4-aee6-4e0d-a92a-48a848853b5c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_2a3110b6-ca09-44f3-b291-ce21c2c65eb4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_b408ee82-98af-4a2f-8a0c-4f93febc843e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_57eac712-4c4f-4147-ad52-e671acaeac8d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_9fd20285-5161-4709-9668-e799a4016ce9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_92548e06-3b54-49d5-a549-db0eda01ffac.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_8c4a1e67-e3a8-419e-b3dc-d780c46c27b2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_787d5bad-b4c6-4369-94e0-e87f3922580d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_caf5412c-b85d-4d8a-a8ed-9f3ce8bad769.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_4110e2eb-b9b3-4981-959e-5a564cc09c81.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_2781bc42-4dcc-4adb-aaff-9b97e829f74b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_189d1ee7-8d20-47d9-a527-20cc5f6d2854.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_0d7ff816-525c-47d5-af26-290eeb66103c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_d52a3c41-d2d9-4424-ab0f-0eed55abda7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_9abc11b3-b0f4-4f4e-940d-402acd58406d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/27d660dd-19ce-4515-9f8b-d05e0402a7d7_a0e3d2eb-8325-4592-90f9-cebdb19789d1.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
+    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 12,999"
+      "priceFormatted": "€ 5,500",
+      "suggestedRetailPrice": "€ 16,078",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 5500,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/volkswagen-polo-1-0-tsi-comfortline-navi-carplay-acc-bluetoo-gasoline-black-1873bc4e-a499-4b34-bdfc-3e878f82926f",
+    "url": "/offers/volkswagen-polo-1-2-tsi-bluemotion-comfort-airco-cruise-contro-gasoline-black-cat_ma74mo2090-27d660dd-19ce-4515-9f8b-d05e0402a7d7",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
       "make": "Volkswagen",
       "model": "Polo",
       "modelGroup": "Polo",
-      "variant": "Sedan",
+      "variant": "Hatchback 5-Door",
+      "motorTypeName": "1.2 TSI",
       "modelId": 2090,
-      "modelVersionInput": "1.0 TSI Comfortline NAVI / CARPLAY / ACC / BLUETOO",
+      "modelVersionInput": "1.2 TSI BlueMotion Comfort | Airco | Cruise contro",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "80,294 km"
+      "mileageInKm": "168,096 km",
+      "engineDisplacementInCCM": "1,197 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "8711 HP",
-      "city": "WORKUM",
-      "street": "Eniggaburren 14"
+      "zip": "7333 NR",
+      "city": "APELDOORN",
+      "street": "Oude Apeldoornseweg 45"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "culture": "nl-NL"
       },
-      "id": "42830637",
+      "id": "51919941",
       "type": "Dealer",
-      "companyName": "Galema & de Boer Auto's B.V.",
-      "contactName": "Arjen Galema",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/51919941-original-7281e480-2a91-4b0c-873c-177704a3aca3.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "JDL Automotive B.V.",
+      "contactName": "Karim El Guerouat",
       "links": {
-        "infoPage": "/lst?atype=C&cid=42830637",
-        "imprint": "https://www.autoscout24.com/dealerinfo/galema-en-de-boer-auto-s-b-v/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/jdl-automotive-b-v?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/jdl-automotive-b-v/imprint"
       },
       "phones": [
         {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 10004971",
-          "callTo": "+31610004971"
+          "formattedNumber": "+31 (0)6 - 44353487",
+          "callTo": "+31644353487"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 10004971",
+          "formattedNumber": "+31 (0)6 - 44353487",
           "callTo": null
         }
       ]
@@ -3447,21 +2276,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "05-2020",
+      "firstRegistration": "12-2012",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.12034523022410681",
+      "imageContent": "no-placeholder|0.16110680152602774",
       "isSmyleEligible": "false",
-      "mileage": "80294",
-      "priceLabel": "top-price",
-      "price": "12999",
+      "mileage": "168096",
+      "priceLabel": "good-price",
+      "price": "5500",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:162, generation_id:176, motortype_id:268, trim_id:217];"
+      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:3919, generation_id:175, motortype_id:273, trim_id:217];"
     },
-    "coverImageAttractiveness": 0.12034523022410681,
+    "coverImageAttractiveness": 0.16110680152602774,
     "vehicleDetails": [
       {
-        "data": "80,294 km",
-        "iconName": "mileage_road",
+        "data": "168,096 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -3470,7 +2299,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "05/2020",
+        "data": "12/2012",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -3480,16 +2309,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "70 kW (95 hp)",
+        "data": "66 kW (90 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "105 g/km (comb.)"
+      "113 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -3510,111 +2338,106 @@
     ]
   },
   {
-    "id": "54afb98a-cbbe-49bc-ac26-4d6287e8e533",
+    "id": "2549b2f2-1f47-428b-ab64-89a1ff45c610",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "325392957"
+      "crossReferenceId": "51122185"
     },
-    "crossReferenceId": "325392957",
+    "crossReferenceId": "51122185",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_bf004052-8c4b-48e1-b000-94f65f8cbbd1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_e464f12c-af5f-4eee-8e72-4c44e1cc1140.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_d9c6995d-00f1-4ec8-a43a-0df4c6d7b742.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_b6bc5048-5b35-4b24-8e95-97e63c71a59f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_731c5e9e-69bd-4472-af2b-4f6c3736caae.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_d8389624-ce6b-4033-bb5c-2e820c634848.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_79c26751-53c8-4cf7-bfc4-ec7973ed3700.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_ef661351-a5cd-467a-acd4-37a1bf2294cd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_a9971724-6ccc-40ac-ae6e-447eda23e3b0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_c1bb1583-ef35-4fdb-b65a-806f6db76a37.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_9dae683d-c4b7-45fe-bb81-b260a294c5ea.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_3524a4ef-8ee1-4050-bc64-a488d279d3c8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_7cdf8de5-15da-4219-b458-9af9c4d37f96.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_ccf58c19-01e8-43d6-9979-74173febbb2f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_a2394dd3-aa1f-4956-a268-98a2ce211925.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_3e05ea18-c459-4028-a1ea-7b838b79baab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_26aac885-dbd1-47b6-ac60-58e2e9c04368.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_764ab810-e6f9-408f-bc25-ac9283d1b65a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_599a7089-f988-4cf9-827d-9310f6565d3e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_34b903b2-5311-45e8-8cb6-ac25c22eaa9e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_c2ab95b7-25e9-4ad4-bdf4-027b9e836a71.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_3b10b87c-2d1c-4740-89ac-ecb11f6db3d5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_dc60990e-0784-4a19-bb65-bf443e388df1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_dbbb7983-949f-4004-8afc-e5200405d39c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_009bbdfb-ca53-4361-8d3a-0720ebdeb12d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_9ce8ce3a-2051-49ca-ad86-0081cc508e38.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_09ef385a-9ac2-483d-bae2-736fd5bfda7c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_78c42572-26dd-40af-942a-c10403d17246.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_7015dd6c-0914-47ae-b491-4e658c20973b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_e77eea69-eb89-46b5-9162-6e6454e109c0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_2aba1334-7e41-401f-b50e-cafeff72911c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_5f358e55-ee96-494f-8a6e-e5703c5f32f7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_3f2b5257-9739-4fa1-bcdd-b1d2e4957481.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_45160f5f-4b44-4b11-b1e8-76ca011b656e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/54afb98a-cbbe-49bc-ac26-4d6287e8e533_d7c51bac-0d80-4136-b6f0-e96215ee912a.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_b1e24e90-cecf-4b3a-8fc7-852b972ffae3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_7ea0616b-f560-4dc7-80ef-359c207b753d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_ad3ed577-2fa0-4b70-803c-e98a78428373.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_b70967d9-c49c-4926-a5d7-091b6bd1de9a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_571a44ad-ddd0-4fa3-b7b4-c0591ce8a955.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_54aa10d5-b4a3-4efa-9524-740be208e96a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_0d049ad4-0b1d-4acf-a0bc-00707534be19.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_e627068f-09ce-4119-af47-1a4483df1090.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_7ba50497-c09e-4447-af07-8d27f6859dc4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_7a6db87e-a28a-407b-8aca-77ab47d6d426.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_d6dc7f53-3c59-42d0-85ac-160af4382cad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_294aab06-e93b-4e14-bd6a-6eb3a52f9953.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_8f682b32-19ac-4104-b5bb-e9e034a8109c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_3f678f91-784a-4fe8-a532-b114071e4ad8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2549b2f2-1f47-428b-ab64-89a1ff45c610_edbeb1a9-b66e-46d4-bdfb-be7037e72faf.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
+    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 8,949"
+      "priceFormatted": "€ 6,950",
+      "suggestedRetailPrice": "€ 12,688",
+      "isVatLabelLegallyRequired": false,
+      "priceSuperscriptString": "1",
+      "priceRaw": 6950,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/volkswagen-golf-1-0-tsi-business-edition-connected-gasoline-grey-54afb98a-cbbe-49bc-ac26-4d6287e8e533",
+    "url": "/offers/volkswagen-up-1-0-bmt-move-up-gasoline-white-cat_ma74mo19750-2549b2f2-1f47-428b-ab64-89a1ff45c610",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
       "make": "Volkswagen",
-      "model": "Golf",
-      "modelGroup": "Golf",
-      "variant": null,
-      "modelId": 2084,
-      "modelVersionInput": "1.0 TSI Business Edition Connected",
+      "model": "up!",
+      "modelGroup": "Up",
+      "variant": "Up",
+      "motorTypeName": "1.0",
+      "modelId": 19750,
+      "modelVersionInput": "1.0 BMT move up!",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
-      "transmission": "Automatic",
+      "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "203,414 km"
+      "mileageInKm": "80,991 km",
+      "engineDisplacementInCCM": "999 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "3771 AG",
-      "city": "BARNEVELD",
-      "street": "Wattstraat 13"
+      "zip": "3861 SN",
+      "city": "NIJKERK",
+      "street": "Sluiswachter 26"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "11076",
+      "id": "9047",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/11076-original-adb93227-4d1f-46b2-9ac6-61375ae6206a.png/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/9047-original-dd9ecf8b-f54e-4feb-bc9c-f81ea9438d31.jpg/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Auto Valk",
+      "companyName": "Autobedrijf van Ramshorst",
       "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=11076",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto-valk-barneveld/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autobedrijf-van-ramshorst?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-van-ramshorst/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)342 - 450306",
-          "callTo": "+31342450306"
+          "formattedNumber": "+31 (0)338 - 081200",
+          "callTo": "+31338081200"
         },
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 15432912",
-          "callTo": "+31615432912"
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)33 - 2453118",
+          "callTo": "+31332453118"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 15432912",
+          "formattedNumber": "+31 (0)6 - 57490293",
           "callTo": null
         }
       ]
@@ -3629,30 +2452,30 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "10-2015",
+      "firstRegistration": "01-2017",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.18231898517936862",
+      "imageContent": "no-placeholder|0.17659209798073594",
       "isSmyleEligible": "false",
-      "mileage": "203414",
-      "priceLabel": "fair-price",
-      "price": "8949",
+      "mileage": "80991",
+      "priceLabel": "top-price",
+      "price": "6950",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100101, variant_id:, generation_id:7, motortype_id:412, trim_id:];"
+      "modelTaxonomy": "[make_id:74, model_group_id:19750, variant_id:3280, generation_id:1316, motortype_id:10342, trim_id:5551];"
     },
-    "coverImageAttractiveness": 0.18231898517936862,
+    "coverImageAttractiveness": 0.17659209798073594,
     "vehicleDetails": [
       {
-        "data": "203,414 km",
-        "iconName": "mileage_road",
+        "data": "80,991 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
-        "data": "Automatic",
+        "data": "Manual",
         "iconName": "gearbox",
         "ariaLabel": "Gear"
       },
       {
-        "data": "10/2015",
+        "data": "01/2017",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -3662,16 +2485,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "85 kW (116 hp)",
+        "data": "44 kW (60 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "99 g/km (comb.)"
+      "96 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -3692,99 +2514,99 @@
     ]
   },
   {
-    "id": "da0fa2dc-9231-464d-8e80-5e1fe21ea873",
+    "id": "e1a9f511-4b4d-437f-85b1-208ca5c758e9",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "319736913"
+      "crossReferenceId": "50310685"
     },
-    "crossReferenceId": "319736913",
+    "crossReferenceId": "50310685",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_abeaaa35-2e08-42aa-8605-d55c4536399d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_7c43a416-0d1c-4ea9-8924-df46fdc834ba.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_d08de99a-7e4b-4d5f-b51c-7563a2eecec6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_0a120c01-5a79-4346-bff2-7ee00b48c07b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_70c3aaf5-342a-45f4-ae11-2a3cbd7ac6b7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_3c9412a2-d2ca-4011-abf2-2eead57065bd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_efff4271-ea9f-4033-9319-a5f2693caf6a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_acd099b5-ca94-4813-98bc-be7afcc6bd08.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_16acf75a-87d4-49e7-9e81-2b875e0fb280.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_4a1ec069-a220-44e5-8d3f-9d5b0eaf7995.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_8d9b58d2-ad56-4c91-b528-3034bf4d52a2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_6ebc4343-1450-41f9-89af-890fa48c25ed.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_93f74486-1268-4963-9c61-ed64a86bd0a6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_0fe0fbf0-db4d-45ae-a676-708547fcd380.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_67010e9b-4a9c-4a7f-bf04-56b4e2a6fc62.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_0558948b-33ae-4c67-9840-981f6611927f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_4c950b35-37c4-49d8-864f-d7a9f349cde9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_b0ff73bf-9d41-402a-8a83-89608b69707d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_176458f1-76b4-4f7c-9e5f-0da5943b5e6e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_8f8ba253-faae-4e73-bf31-47611595421a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_3a503d91-5557-4dba-a898-c3cbaf25db1e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/da0fa2dc-9231-464d-8e80-5e1fe21ea873_26d8b3ca-a8e2-48f6-a9fa-cc7acf7d838b.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_0253477f-6a05-49e4-9ab7-b791fe774dc7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_a8276613-c4ac-4c16-92ee-5200257e9ca2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_97093301-4b97-4981-be9f-de317512fe5a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_ec6a6ca3-6c64-4c3a-ab3d-76e02ef9e1c4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_7fa5d287-06ee-4f99-83d6-0c674b0829dd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_0a715558-79bc-4718-b509-51190e512ddc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_ff9d7b00-6467-4743-b1c7-7f0da4a479a3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_c22e2145-2ac8-4257-95f5-6be4cc45ea13.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_796facd0-ee0b-40c1-9405-d0a6d4aaab1c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_bda49349-cbfb-4133-9b95-abe8d55576c5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_fbc05d96-a65d-4f16-9e95-eda4cfa04fa0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_f020eacf-4e31-49fa-84b8-ae1472056bf4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_66182bab-e280-4045-ab4c-dc518469251f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_7a786842-0234-45f7-aa2c-51bcb9f9e958.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_2b03b0d2-7432-460d-80b4-3a49b04b27a5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_321b8edd-d7c0-4df2-943c-3fd9b9eea51a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_1faffc9b-87f1-4e22-b4ee-8542eae85cd5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_fcaacb8b-a9fb-418a-ac7b-ebc2ad0611cf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_21b87715-2b52-4fbd-89e4-d736b7e97338.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/e1a9f511-4b4d-437f-85b1-208ca5c758e9_41865008-284b-4cca-bff7-f8d13b1488fb.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 20,950"
+      "priceFormatted": "€ 899",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 899,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/seat-leon-2-0-tsi-fr-bom-vol-pano-beats-audio-acc-lichte-bli-gasoline-blue-da0fa2dc-9231-464d-8e80-5e1fe21ea873",
+    "url": "/offers/dacia-sandero-1-2-ambiance-koppeling-versleten-gasoline-white-cat_ma16360mo19129-e1a9f511-4b4d-437f-85b1-208ca5c758e9",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "SEAT",
-      "model": "Leon",
-      "modelGroup": "Leon",
-      "variant": null,
-      "modelId": 15869,
-      "modelVersionInput": "2.0 TSI FR|BOM VOL|PANO|BEATS AUDIO|ACC|LICHTE BLI",
+      "make": "Dacia",
+      "model": "Sandero",
+      "modelGroup": "Sandero",
+      "variant": "Sandero",
+      "motorTypeName": "1.2",
+      "modelId": 19129,
+      "modelVersionInput": "1.2 Ambiance (koppeling versleten)",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
-      "transmission": "Automatic",
+      "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "50,572 km"
+      "mileageInKm": "149,345 km",
+      "engineDisplacementInCCM": "1,149 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "1507 CG",
-      "city": "ZAANDAM",
-      "street": "Grote Tocht 2b"
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "51775566",
+      "id": "17912423",
       "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/51775566-original-2023c333-82f5-4f6a-8915-521469f9106f.jpeg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Snelle Jelle Schadeauto's",
-      "contactName": "Afdeling Verkoop",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
       "links": {
-        "infoPage": "/lst?atype=C&cid=51775566",
-        "imprint": "https://www.autoscout24.com/dealerinfo/snelle-jelle-schadeauto-s/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)75 - 2340750",
-          "callTo": "+31752340750"
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
         },
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 28854110",
-          "callTo": "+31628854110"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 28854110",
-          "callTo": null
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
         }
       ]
     },
@@ -3798,30 +2620,30 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "09-2022",
+      "firstRegistration": "08-2009",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.22871555308724778",
-      "isSmyleEligible": "true",
-      "mileage": "50572",
+      "imageContent": "no-placeholder|0.16293817179978642",
+      "isSmyleEligible": "false",
+      "mileage": "149345",
       "priceLabel": "toolow-price ",
-      "price": "20950",
+      "price": "899",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:64, model_group_id:15869, variant_id:, generation_id:, motortype_id:865, trim_id:436];"
+      "modelTaxonomy": "[make_id:16360, model_group_id:200370, variant_id:4002, generation_id:2108, motortype_id:1740, trim_id:1104];"
     },
-    "coverImageAttractiveness": 0.22871555308724778,
+    "coverImageAttractiveness": 0.16293817179978642,
     "vehicleDetails": [
       {
-        "data": "50,572 km",
-        "iconName": "mileage_road",
+        "data": "149,345 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
-        "data": "Automatic",
+        "data": "Manual",
         "iconName": "gearbox",
         "ariaLabel": "Gear"
       },
       {
-        "data": "09/2022",
+        "data": "08/2009",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -3831,13 +2653,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "140 kW (190 hp)",
+        "data": "55 kW (75 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [],
-    "isListingBoost": false,
+    "wltpValues": [
+      "- (l/100 km)",
+      "139 g/km (comb.)"
+    ],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -3858,90 +2682,99 @@
     ]
   },
   {
-    "id": "18dcdd8d-1434-4434-94af-7d81ef534007",
+    "id": "be6da308-3139-4cb7-9165-93d0041209de",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "444354822"
+      "crossReferenceId": "157562403"
     },
-    "crossReferenceId": "444354822",
+    "crossReferenceId": "157562403",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_833f1b95-a74b-4bdf-ba6a-2284351ed88c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_cad81d4d-3dd8-4737-b8fa-99423eb98c5d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_d0af578c-3544-4c51-9002-09c8b166b0c4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_a394e732-c432-40fd-821b-7c2e6afff8db.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_48866ce5-272c-488e-8ba8-2dac41562437.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_c5fe6f53-1de2-43f2-a3a7-fc1084930c80.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_5700ad47-a8ab-4b0f-88a4-1ccbfc33fe72.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_6cbf5b8b-faf7-4737-81a1-ebda6784890e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_cd811f28-cc13-4a66-9038-17c5aacd5635.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_60dce3d0-d4fd-49e4-be97-f0bac7f4baf1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_30c8c34f-6c46-497e-b921-9051aaa85830.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_42b058ff-7acf-4510-a486-190c362d0074.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/18dcdd8d-1434-4434-94af-7d81ef534007_acd81c25-a54b-4cf5-ad63-a772742ce367.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_4a7dcbe1-c461-44b1-a93d-f502dd169846.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_966019e4-dc31-48ef-bb33-d959218c20c6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_26b704ba-beac-4348-9dc7-7fb738e1e307.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_08fc9816-7f69-4600-9f70-a83b405f62f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_820f12a5-7482-46f2-b161-f986b7e78c82.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_5cb07fa0-c09f-47db-af36-8dba675a4427.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_b796536c-dfa9-44fc-b777-a369f0efda87.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_a92157b8-dfd0-4536-b879-c7875bb81786.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_a2fd8119-9ddb-430a-a4e9-7adea9c0420f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/be6da308-3139-4cb7-9165-93d0041209de_ecd85f48-18eb-478e-ad97-03d64f3adb76.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 1,950"
+      "priceFormatted": "€ 3,290",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3290,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/toyota-yaris-basis-elektr-fensterheber-allwetter-gasoline-red-18dcdd8d-1434-4434-94af-7d81ef534007",
+    "url": "/offers/mini-one-1-4-scheckheft-neuer-tuev-gasoline-white-cat_ma16338mo16602-be6da308-3139-4cb7-9165-93d0041209de",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Toyota",
-      "model": "Yaris",
-      "modelGroup": "Yaris",
-      "variant": null,
-      "modelId": 15663,
-      "modelVersionInput": "Basis/Elektr. Fensterheber/Allwetter",
+      "make": "MINI",
+      "model": "One",
+      "modelGroup": "Mini",
+      "variant": "3 Door",
+      "motorTypeName": "One",
+      "modelId": 16602,
+      "modelVersionInput": "1.4 / Scheckheft/neuer TÜV",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "180,000 km"
+      "mileageInKm": "156,000 km",
+      "engineDisplacementInCCM": "1,397 cc"
     },
     "location": {
       "countryCode": "DE",
-      "zip": "50374",
-      "city": "Erftstadt",
-      "street": "Justus-von-Liebig-Str. 11"
+      "zip": "60386",
+      "city": "Frankfurt",
+      "street": "Adam Opel Str.1"
     },
     "ratings": {
-      "ratingsCount": 25,
-      "ratingsStars": 5,
+      "ratingsCount": 195,
+      "ratingsStars": 4.5,
       "ratingsEnabled": true
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
       },
-      "id": "3935753",
+      "id": "5471978",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/3935753-original-ac41cb5f-588f-4e8b-8c58-4c8ef7717a50.jpg/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/5471978-original-b8a095b3-e668-4762-82a4-74c1eb034ee8.jpg/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "AAC Automobile",
+      "companyName": "R&M Cars GmbH",
+      "contactName": "Rene Miguel del Arbol",
       "links": {
-        "infoPage": "/lst?atype=C&cid=3935753",
-        "imprint": "https://www.autoscout24.com/dealerinfo/aac-automobile/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/r-und-m-cars-gmbh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/r-und-m-cars-gmbh/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+49 (0)2235 - 9555833",
-          "callTo": "+4922359555833"
+          "formattedNumber": "+49 (0)692 - 474969701",
+          "callTo": "+49692474969701"
         },
         {
-          "phoneType": "Fax",
-          "formattedNumber": "+49 (0)2235 - 9556713",
-          "callTo": null
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)69 - 84843356",
+          "callTo": "+496984843356"
         }
       ]
     },
@@ -3950,26 +2783,26 @@
     "isOcs": false,
     "specialConditions": [],
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
       "firstRegistration": "06-2009",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.13565091234905058",
+      "imageContent": "no-placeholder|0.23150381772612327",
       "isSmyleEligible": "false",
-      "mileage": "180000",
-      "priceLabel": "fair-price",
-      "price": "1950",
+      "mileage": "156000",
+      "priceLabel": "top-price",
+      "price": "3290",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:70, model_group_id:201438, variant_id:, generation_id:1279, motortype_id:5372, trim_id:4935];"
+      "modelTaxonomy": "[make_id:16338, model_group_id:100141, variant_id:3865, generation_id:372, motortype_id:12404, trim_id:480450];"
     },
-    "coverImageAttractiveness": 0.13565091234905058,
+    "coverImageAttractiveness": 0.23150381772612327,
     "vehicleDetails": [
       {
-        "data": "180,000 km",
-        "iconName": "mileage_road",
+        "data": "156,000 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -3988,16 +2821,12 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "51 kW (69 hp)",
+        "data": "55 kW (75 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [
-      "5.0 l/100 km (comb.)",
-      "119 g/km (comb.)"
-    ],
-    "isListingBoost": false,
+    "wltpValues": [],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -4018,97 +2847,102 @@
     ]
   },
   {
-    "id": "dff96c38-85f0-42ad-bf46-44a4452d59f9",
+    "id": "ffe081b8-7edf-4d31-a0e3-74f3f837d0f7",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "315733723"
+      "crossReferenceId": "51073488"
     },
-    "crossReferenceId": "315733723",
+    "crossReferenceId": "51073488",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_58ce990d-0e2a-485a-a46c-a976c2d8f64a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_91bc687b-e123-46be-914a-2ff1aa2f86fc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_3d48b96c-607f-44d3-8dc0-de2413d04e4f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_11b9763d-d9b3-4809-80c8-f2777b749503.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_0c35338e-c632-4d90-8f92-765d2e766985.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_ec24dcdb-a8bf-4abe-8c1a-bcb8aadef163.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_74045f51-ea3e-4092-9f33-c38f8b9579b0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_c2770983-6fe4-4f8a-9f58-b7c6976a665e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_ef69101e-2930-4d14-808f-39c4f17d2425.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_847b5bb6-96ab-46c4-92f3-b0261f04fc22.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_fd0d6e93-17bf-4ebe-922c-30d752e6e0d7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_f48659e8-5a8d-4465-aa62-2abf3fd60a10.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_000d4397-7064-4091-b2df-dd5a01b2fd33.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_f8521c7e-ce63-40e6-a1ef-11d3f09be71d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_d7c44878-2c51-4ac4-952c-a902b863ec3f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_b318194d-15b9-492c-8f3d-b03f3c473c93.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_a5a2cfc5-880e-415c-a479-d5154587cbfa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_ac297bc3-3d9b-472c-8747-da1c51bac601.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_dca7dc16-1f89-4bc9-acad-9c51666df26a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_e7eaa92c-6650-45e5-a249-d9504a81c185.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_8e432840-a4c3-411c-ae9b-5db6fa2b7f8b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_326116f3-676f-49dc-ad2a-9f5946c6c74c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_9557eef9-b65f-43c0-8688-50e1b89739d6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_5826c2a0-acc0-4391-8b0c-47005f125a65.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_05768d2c-0931-412a-a533-a26e2d7f1fd9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_68fb3e95-2984-4e33-80ed-12d517f297f6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_0bd527b3-8163-49f3-b35f-3967ee13d12d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_8283a80b-782c-479b-b79d-ee082a6c91e9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_c2770549-1a7c-430e-9123-5751bc8a819d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_1ce4d446-eef0-400d-8ebd-3f3a6ff3f15d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dff96c38-85f0-42ad-bf46-44a4452d59f9_c0273157-4269-444d-8315-402611a69e28.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_fd78ba26-dd6f-43f6-b07c-e4c321380822.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_7b22694a-6454-41f8-b19b-589d2557ab14.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_fb2bf93a-1077-4028-be79-8444897d8371.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_cfb1d51c-0899-481f-9cbb-13c6bf542d81.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_652a1a20-98ec-4bb1-9f8c-7c4e36c0e50c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_73230542-2e19-47b8-a5e5-385bacd8305d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_62e6326c-5144-4570-95fd-5e59426cbb5e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_30e1b916-1f8c-4ee2-b53c-89ab142a4dc9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_d93f6549-99f9-4a11-a987-2f7b2a10d8d8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_6952371a-0208-4c8e-b7c3-6a589a44156a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_c13a9a24-8a2a-4406-9b69-b14eff505ede.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_f7f94d8d-3c7c-40a5-8307-0c7eaf59070b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_2bbf461d-80ec-48a2-8436-7d3037b37f1b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_1009e7fd-e715-4c5e-a760-307b6169d190.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_85b029f1-bd2a-4e0f-b962-ecb6625df213.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_414d1836-54d0-4105-80e3-42122cc50c89.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ffe081b8-7edf-4d31-a0e3-74f3f837d0f7_c1d4f6e2-becb-4b75-825f-b824c847e493.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
+    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 8,950"
+      "priceFormatted": "€ 3,495",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3495,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/audi-a3-sportback-1-2-tfsi-attraction-pro-line-airco-navi-gasoline-brown-dff96c38-85f0-42ad-bf46-44a4452d59f9",
+    "url": "/offers/volkswagen-polo-1-2-12v-comfortline-airco-pdc-bt-carplay-gasoline-black-cat_ma74mo2090-ffe081b8-7edf-4d31-a0e3-74f3f837d0f7",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Audi",
-      "model": "A3",
-      "modelGroup": "A3",
-      "variant": null,
-      "modelId": 1624,
-      "modelVersionInput": "Sportback 1.2 TFSI Attraction Pro Line Airco Navi",
+      "make": "Volkswagen",
+      "model": "Polo",
+      "modelGroup": "Polo",
+      "variant": "Hatchback 5-Door",
+      "motorTypeName": "1.2",
+      "modelId": 2090,
+      "modelVersionInput": "1.2-12V Comfortline |Airco|PDC|BT/CarPlay|",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "189,562 km"
+      "mileageInKm": "249,886 km",
+      "engineDisplacementInCCM": "1,198 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "7418 BX",
-      "city": "DEVENTER",
-      "street": "Groningerstraat 7"
+      "zip": "4879 AV",
+      "city": "ETTEN-LEUR",
+      "street": "Kroonstraat 55"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "45846826",
+      "id": "42685370",
       "type": "Dealer",
-      "companyName": "Pars Bedrijfsauto's",
-      "contactName": "Afdeling verkoop",
+      "companyName": "Marijnissen Occasions",
+      "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=45846826",
-        "imprint": "https://www.autoscout24.com/dealerinfo/pars-bedrijfsauto-s/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/marijnissen-occasions?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/marijnissen-occasions/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)768 - 080683",
+          "callTo": "+31768080683"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 20885055",
-          "callTo": "+31620885055"
+          "formattedNumber": "+31 (0)6 - 18866033",
+          "callTo": "+31618866033"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 20885055",
+          "formattedNumber": "+31 (0)6 - 18866033",
           "callTo": null
         }
       ]
@@ -4123,21 +2957,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "02-2014",
+      "firstRegistration": "04-2010",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.15477040821446475",
+      "imageContent": "no-placeholder|0.1532642615879214",
       "isSmyleEligible": "false",
-      "mileage": "189562",
+      "mileage": "249886",
       "priceLabel": "fair-price",
-      "price": "8950",
+      "price": "3495",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:9, model_group_id:1624, variant_id:, generation_id:153, motortype_id:228, trim_id:];"
+      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:3919, generation_id:175, motortype_id:271, trim_id:217];"
     },
-    "coverImageAttractiveness": 0.15477040821446475,
+    "coverImageAttractiveness": 0.1532642615879214,
     "vehicleDetails": [
       {
-        "data": "189,562 km",
-        "iconName": "mileage_road",
+        "data": "249,886 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -4146,7 +2980,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "02/2014",
+        "data": "04/2010",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -4156,16 +2990,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "77 kW (105 hp)",
+        "data": "51 kW (69 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "114 g/km (comb.)"
+      "128 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -4186,100 +3019,2682 @@
     ]
   },
   {
-    "id": "0a3c1377-9572-4ad5-8838-2d6d2b584300",
+    "id": "7202599c-4efe-4de3-848d-9c80cf61d9bf",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": null
+      "crossReferenceId": "154155718"
     },
+    "crossReferenceId": "154155718",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_55202fb5-43e7-401e-8318-e0299fecfea4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_74b559ea-5802-4a35-a857-5b84594410f0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_2d31e9e5-24f3-4416-aae4-4eec116aaad9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_b1bd2f8b-e80a-40c1-9378-b9612090c72d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_89400dfe-aef6-4efb-b022-32d65635cce8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_d9b6ee3f-376b-48ed-aac9-62c518e29dc3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_abf9f32e-dd07-45ab-adf3-5e488bd5fb52.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_d14bc317-79dd-4920-b816-6ee0e949bca4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_f3430592-3303-41c8-a522-ebeded2ceb81.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_f4025f51-2e39-4e19-8e81-d6c8ce0ee79c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_e737258a-2df3-488c-8b07-efa1be7a0442.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_731fb9c0-2630-415c-9ab9-19e816fabfd1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_58417b03-ad1c-4a5e-8cef-815fae10ab99.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_aeb99207-9dca-4ba1-b77f-2563d2df7d10.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_5a790d70-353f-46dd-8288-01c9ec5e1296.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_bad39b16-aadc-48b2-ab31-fa245158e7e3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_f93242a6-7ff8-4b71-bdf1-af2fcb85cc12.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_5be2fc4a-5422-42ab-b715-b18604f73e92.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_9aa4dbea-4e5d-4c6b-8892-ad8ef629e052.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_f2d87288-4f43-45e5-8125-e41ac11fe935.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_917db29a-a30a-46e7-815d-84a4be5a4e52.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_91655f8d-3adf-4eee-9159-f9c14b7b7a25.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_641475a3-3d94-4590-9874-eae8db13e23c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_b6df1a1d-9713-42d1-9d6d-989e0e3af3a0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/0a3c1377-9572-4ad5-8838-2d6d2b584300_09a870a7-7cf4-439e-9e15-d85197567b28.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_d130166c-1c7d-4abc-9c10-c98a8f063b74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_af0b7abb-e422-42f7-beae-5f06345164be.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_82ef0f65-5805-4c01-9c42-f27ba4ba80e3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_2a7301cd-b59a-499c-914b-127c477c0ca4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_000c087e-9e15-4e95-b595-586ccdab7cb5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_7e669649-b083-48db-ae30-17bd952445c4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_b3bc3818-a279-4754-8018-62862518992f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7202599c-4efe-4de3-848d-9c80cf61d9bf_5f2ef1b9-f88d-4d7a-beb1-6d661ac67d80.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
-    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 11,990"
+      "priceFormatted": "€ 1,990",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1990,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
     },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/opel-corsa-1-2-start-stop-edition-r-kam-180-grad-dab-efh-gasoline-black-0a3c1377-9572-4ad5-8838-2d6d2b584300",
+    "url": "/offers/hyundai-i20-classic-gasoline-cat_ma33mo19188-7202599c-4efe-4de3-848d-9c80cf61d9bf",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Opel",
-      "model": "Corsa",
-      "modelGroup": "Corsa",
-      "variant": null,
-      "modelId": 1918,
-      "modelVersionInput": "1.2 Start/Stop Edition R-KAM 180-Grad DAB+ EFH",
+      "make": "Hyundai",
+      "model": "i20",
+      "modelGroup": "i20",
+      "variant": "i20",
+      "motorTypeName": "1.2",
+      "modelId": 19188,
+      "modelVersionInput": "Classic",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "26,314 km"
+      "mileageInKm": "162,000 km",
+      "engineDisplacementInCCM": "1,248 cc"
     },
     "location": {
       "countryCode": "DE",
-      "zip": "46539",
-      "city": "Dinslaken",
-      "street": "Am Pfauenzehnt 15"
+      "zip": "09114",
+      "city": "Chemnitz",
+      "street": "Blankenburgstr. 62"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "60485690",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/60485690-original-6da7faaf-90e4-4cc8-abcd-dc107dd085a3.jpeg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Handelsagentur Schramm",
+      "contactName": "Roy Schramm",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/handelsagentur-schramm-chemnitz-09114-2?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/handelsagentur-schramm-chemnitz-09114-2/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)371 - 2435212800",
+          "callTo": "+493712435212800"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)174 - 3084669",
+          "callTo": "+491743084669"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)162 - 8578586",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2014",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.1589698682976337",
+      "isSmyleEligible": "false",
+      "mileage": "162000",
+      "priceLabel": "top-price",
+      "price": "1990",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19188, variant_id:3266, generation_id:919, motortype_id:2250, trim_id:1917];"
+    },
+    "coverImageAttractiveness": 0.1589698682976337,
+    "vehicleDetails": [
+      {
+        "data": "162,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2014",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "63 kW (86 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "4.9 l/100 km (comb.)",
+      "114 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "7d1c5cc4-bc38-4317-990b-3e3e55b948a4",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50193414"
+    },
+    "crossReferenceId": "50193414",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_9f4db209-1c0b-4726-9cbe-5acbdd1b51d0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_e7661c2d-e82f-4a0d-a58c-9c3bb7b78323.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_e464f9da-4e46-4117-9057-49d17e772800.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_84cc2b83-25b0-48e4-9e88-621153b48e7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_0dcacceb-45c5-473e-8811-cbf9dd4c90f8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_8bc77d3e-d877-49eb-9413-dac5489f6288.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_a3f9c2df-f7cc-4789-9846-930a38a00b99.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_a9c8155e-010c-47b7-aea8-141e4ba2c86c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_249cb9eb-8ffc-4200-8133-b5a136b179ff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_374daf5e-d02f-458a-a026-cfc997c0fa2e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_8ede95cb-5436-40d4-b058-3268d57f086d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_27e623a4-0a5a-48cc-9338-616fe8e99b9f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_92914290-6263-461d-bb77-e978ab20aaea.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_26a28f1d-82e7-402c-b1d2-666867af822d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_df7c0267-f67a-4a3c-a12f-0cacf23f8c37.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_f07eb4a1-6a7f-4033-9030-30363a7f2363.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_23200956-8ccd-40e0-bfbf-f12b17ba3e24.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_f4bb4ef8-88b5-420f-aa03-f93b01653b54.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_4e78dab3-2a02-45e4-89ac-7a167dfe3df8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_466a0be6-1a72-4ad6-9834-24055302a59e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_121404cd-93f8-4f30-9fbc-99707c13a168.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_86eda0f1-5318-41f6-99bc-d88a563626d2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_e8f80554-36aa-4efb-b45f-954f4dbfbe63.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_7576c03c-308f-42a5-90a0-b9993e53db60.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_a871c4db-9a81-4d36-86a3-a7d02e0fa1fd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_e1aeeadd-80bf-4883-b6e1-732abd037ded.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_616e690f-da25-4ab0-b316-68b78cef0ec3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_cf7cde5d-0217-4489-94a8-42ddbf97a829.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_7f69f9a9-d999-42e3-a830-8d2841d0667c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_dcde301d-832b-4ae7-820e-f0d643c2d60f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_91cfee44-7079-4524-9c94-5aed2d53e13e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_38af0441-2cfc-4654-bfa8-e4ccd3fc1323.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_3c7a067a-84d4-454f-894e-50757cdb6231.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_002f80b7-1764-464f-8831-8fc1c2a94c39.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_f2919810-6398-4c2f-bd88-5afec9fdcea0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_ba1335a0-5d77-4552-90cc-61251cf59fc9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_f14aae0c-9acb-4303-9c9e-8877bf92cf8d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_09662fa4-f8cc-44cc-a885-a590f943857b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7d1c5cc4-bc38-4317-990b-3e3e55b948a4_7328abcd-c438-4984-847a-b5250167b38c.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,995",
+      "suggestedRetailPrice": "€ 17,130",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3995,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/toyota-yaris-1-3-vvt-i-aspiration-gasoline-red-cat_ma70mo15663-7d1c5cc4-bc38-4317-990b-3e3e55b948a4",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Toyota",
+      "model": "Yaris",
+      "modelGroup": "Yaris",
+      "variant": "Yaris",
+      "motorTypeName": "1.33",
+      "modelId": 15663,
+      "modelVersionInput": "1.3 VVT-i Aspiration",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "231,164 km",
+      "engineDisplacementInCCM": "1,329 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "17912423",
+      "type": "Dealer",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "03-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.23475820600780395",
+      "isSmyleEligible": "false",
+      "mileage": "231164",
+      "priceLabel": "good-price",
+      "price": "3995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:70, model_group_id:201438, variant_id:3713, generation_id:1280, motortype_id:5374, trim_id:4935];"
+    },
+    "coverImageAttractiveness": 0.23475820600780395,
+    "vehicleDetails": [
+      {
+        "data": "231,164 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "03/2012",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "74 kW (101 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "120 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "39b08415-5d54-45a5-bfdb-37038e284e03",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "40633089043488"
+    },
+    "crossReferenceId": "40633089043488",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_ff3b68a8-a7a1-4d42-b77a-f6f6912de385.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_36c8414f-0dcd-4020-b2b5-53863c6bbbdf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_74ad2323-83d3-41df-a30c-d36ddd612df4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_b6c8221e-6d69-43ba-8e51-771bacc0593b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_f19034f2-c0e2-4081-bb47-cd645e3ccbaa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_df2a4e03-3075-4d0c-bba7-51ec52218fd6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_e8568b68-4431-425f-92a2-cbb8fdc4e655.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_86467829-f101-4e50-aa90-b68367b601b1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_acbdbd68-7132-4f58-8385-0b62cd006a69.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_90816465-06f2-4456-be93-aab3363558e7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_9d2b9fad-1cd3-4fd8-ad1d-67d2da613d4c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_97003818-004f-4ef3-a850-ba17ca0b15ea.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_8ff95276-c1e3-4636-8356-34e85265401d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_6233e24d-b5df-489c-ad97-1ed50137a729.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_7a7d6973-739a-4674-85f3-a0685a540abc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_33ac7d55-5f0b-4635-9349-8215f15d4326.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_1e22487d-6bfc-4359-9102-d060a0232aa5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_6f6ce5b1-67dc-4317-96ca-0af26e378c20.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_c7f6d12c-bef3-4d6b-a85b-b7b09ebda821.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_1e1ff9e4-d7d0-4b2f-bff5-3a3309fff7aa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_0dcc63f2-aba6-4d95-bc69-f0561469d891.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_73372a27-07f7-4e99-b2ef-cf47ac953c31.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_0ae095c4-f1c2-4a5e-bddf-a2efa12e68d9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_b29af000-c98d-49a5-a039-7fde9c00eaa0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_13e60790-cb9d-48ca-bb1c-bc70551c1449.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_ffc7fae6-b347-461e-9e91-4b1117e64d8a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_91672b16-87dc-44a6-85e5-fa9aa217b7d7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_94ca3736-7d77-4385-b798-bb6574dd6e9b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_f7fb029f-d8f7-4bd6-bb75-a7c502b9782a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_97f9617d-e514-48e6-9cc6-338751158bee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_e6edf270-ff24-451c-b58a-e410e5b3a6ad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_a60fd6d3-d3e7-4022-856d-cbdecdf3483e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_bbe5f39f-e493-4327-a822-0d11d06bbc07.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_cc8959dc-f903-40c3-8d4b-6e2c7e84da54.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_462d098e-97af-4957-88dd-f551618b0537.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_c9339ae8-4400-4c5e-953c-a4cec0382e4b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_bb2c850c-849d-45c9-a044-a5c14480645c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_92b543f7-425b-45d2-b3de-b6d2ff53beb9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_ed9c3568-f67e-484c-b722-7bbee9b448f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/39b08415-5d54-45a5-bfdb-37038e284e03_24cea672-3547-48e2-a4f9-5b9966ec198d.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 14,999",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 14999,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/peugeot-208-1-2-101ps-allure-carplay-acc-led-360-1hand-gasoline-black-cat_ma55mo20057-39b08415-5d54-45a5-bfdb-37038e284e03",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Peugeot",
+      "model": "208",
+      "modelGroup": "208",
+      "variant": "208",
+      "motorTypeName": "100",
+      "modelId": 20057,
+      "modelVersionInput": "1.2 101PS Allure Carplay ACC LED 360° 1Hand",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "7,351 km",
+      "engineDisplacementInCCM": "1,199 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "14513",
+      "city": "Teltow",
+      "street": "Lichterfelder Allee 14"
     },
     "ratings": {
-      "ratingsCount": 40,
+      "ratingsCount": 121,
+      "ratingsStars": 4.5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "13514388",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/13514388-original-08ae5945-0376-41fe-a0c1-c6bd5898f021.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autohaus Klann GmbH",
+      "contactName": "Vertrieb Gebrauchtwagen",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohaus-klann-gmbh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-klann-gmbh/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)332 - 8354013401",
+          "callTo": "+493328354013401"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)3328 - 3599968",
+          "callTo": "+4933283599968"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)1577 - 3527695",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "04-2025",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2472876653450281",
+      "isSmyleEligible": "true",
+      "mileage": "7351",
+      "priceLabel": "top-price",
+      "price": "14999",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:55, model_group_id:201150, variant_id:3624, generation_id:1073, motortype_id:3253, trim_id:1067];"
+    },
+    "coverImageAttractiveness": 0.2472876653450281,
+    "vehicleDetails": [
+      {
+        "data": "7,351 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "04/2025",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "74 kW (101 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "116 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "16188f30-1d5d-4902-b096-d7b0f5690892",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "3173980"
+    },
+    "crossReferenceId": "3173980",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_aeaf56d4-83e4-4bcd-aac8-a68edc10b7fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_bf813452-5610-46de-8966-6e1242967c8d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_4bbed7b7-fd03-4a91-8038-82cf2e457abe.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_ad18cabd-722e-488e-8c4e-21a9b67a3f47.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_f75f5698-22cc-4755-9f9c-07d60abe78ec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_3191ec97-2daf-4712-896e-78044a766340.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_7a28b1d2-6bc6-415c-a894-7eee6a3fd94c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_baf7eb58-b96d-433b-9eb5-7523826a6fd5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_0a092d81-a778-4aea-89ec-657b2ddf549a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_bc2e7284-179e-4e78-85be-f3e5641c7501.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_cd7faa7f-5d1e-4f04-b8f3-e44b34a46466.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_b45c75ea-5666-489a-b9fa-ea1faa207e22.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_928353cb-a654-46a7-a7f7-5dc0d190751e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_2e4ea8e4-2143-4ed9-9829-b17ca6c59e7a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_2f1b65c9-4e8e-4802-b00a-07e989e11797.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_6e3a3776-efb5-473d-8928-536b35c77fa5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_71029288-644d-434f-8029-30494c98dee4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/16188f30-1d5d-4902-b096-d7b0f5690892_1659528c-4028-4088-b2be-5c9984fe2d79.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,195",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1195,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/mazda-6-1-8i-exclusive-clima-rijdt-goed-export-price-gasoline-blue-cat_ma46mo18266-16188f30-1d5d-4902-b096-d7b0f5690892",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Mazda",
+      "model": "6",
+      "modelGroup": "Mazda6",
+      "variant": "Kombi",
+      "motorTypeName": "1.8",
+      "modelId": 18266,
+      "modelVersionInput": "1.8i Exclusive CLIMA RIJDT GOED EXPORT PRICE",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "259,875 km",
+      "engineDisplacementInCCM": "1,798 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3076 JA",
+      "city": "ROTTERDAM",
+      "street": "Berkenwoudestraat 23"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "20250231",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/20250231-original-ddb5589a-dfb2-4269-8037-be90340104d5.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Ed-Kar Import en Export",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)108 - 084733",
+          "callTo": "+31108084733"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": "+31651191563"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "06-2003",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.1576019466504317",
+      "isSmyleEligible": "false",
+      "mileage": "259875",
+      "priceLabel": "toolow-price ",
+      "price": "1195",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:46, model_group_id:200953, variant_id:1461, generation_id:1753, motortype_id:2615, trim_id:3374];"
+    },
+    "coverImageAttractiveness": 0.1576019466504317,
+    "vehicleDetails": [
+      {
+        "data": "259,875 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "06/2003",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "88 kW (120 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "cda05f94-4f2a-43a1-aa94-22d4768bcd39",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "455916880"
+    },
+    "crossReferenceId": "455916880",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_93dbd60e-58c0-4bf3-939d-dfc5f33e3835.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_672c1e90-1f04-4413-9208-a0d80622e7b4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_f4fb59b8-9c1d-4686-adee-9f986a34cf5f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_5e41b809-1d78-43a0-a943-bb06b11d8b4d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_e59205d9-2db4-4a22-b13f-f58824e931e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_9610c307-21cd-4bbd-8d5b-f748b3d0d867.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_d47d31f1-eeb3-4daa-9b4e-c5b94ddf4f6a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_42cbd9ae-7d13-42f5-9cf5-05ff30953abd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_27946277-f592-4c51-a810-e171eb4edf2e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_52ef4819-adfc-4b1f-8519-3c9b9e7be249.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_e414fd37-26ff-416f-bba0-8563d5a207cf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_c752415e-f750-4a0a-b62a-7dafd1c01638.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_1fa50ca7-816d-417e-800f-044eb6422324.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_caa8340d-4fd0-4100-996a-757803044994.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_4c7b4766-505f-44e5-8e39-e8339584ea45.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_be28c4b6-354c-4267-9f62-aeae5bcd886b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cda05f94-4f2a-43a1-aa94-22d4768bcd39_2ad23b50-28d8-4f52-86f1-c51f0f14197e.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 6,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 6950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/volkswagen-polo-v-life-1-2l-klima-gasoline-white-cat_ma74mo2090-cda05f94-4f2a-43a1-aa94-22d4768bcd39",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Volkswagen",
+      "model": "Polo",
+      "modelGroup": "Polo",
+      "variant": "Hatchback 5-Door",
+      "motorTypeName": "1.2 TSI",
+      "modelId": 2090,
+      "modelVersionInput": "V Life*1,2L*KLIMA*",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "95,000 km",
+      "engineDisplacementInCCM": "1,197 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "21079",
+      "city": "Hamburg",
+      "street": "Traunweg 1"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "culture": "de-DE"
+      },
+      "id": "63180646",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/63180646-original-2017e38f-f8f0-4583-be23-cc0ca2fdc20d.jpeg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Kartaliverschiffung",
+      "contactName": "Mohamed Kartali",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/kartaliverschiffung?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/kartaliverschiffung/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)172 - 4588853",
+          "callTo": "+491724588853"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)172 - 4588853",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2013",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2791043155888878",
+      "isSmyleEligible": "false",
+      "mileage": "95000",
+      "priceLabel": "good-price",
+      "price": "6950",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:3919, generation_id:175, motortype_id:273, trim_id:244];"
+    },
+    "coverImageAttractiveness": 0.2791043155888878,
+    "vehicleDetails": [
+      {
+        "data": "95,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2013",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "66 kW (90 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "5.1 l/100 km (comb.)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "0ae8bade-884c-4e0f-bf38-3291e9e69ff3",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "49874211"
+    },
+    "crossReferenceId": "49874211",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_5fca3d61-7fb5-443e-adbf-1347d2fef2f1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_b225bdee-4ae1-432c-9b8b-ad47b58dff63.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_8d588f37-cd47-490b-b2e9-3f9ab30744e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_b5d08e30-2fa6-4ba4-a25c-d622d390eb81.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_f55e8181-5bae-492c-98ba-f6a40953cb5c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_8a1e3a99-56c7-4b1f-b724-cd041eda9e48.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_5b7e457c-036a-4d9f-b21e-bc88472c3e7c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_ee028740-bce0-4eae-8a78-9707224d91fd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_f6cee89c-8a1a-4a6d-8dda-233e8be4e8ed.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_c1088cb9-3586-425d-b792-88007edf9fad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_4e0bc4d6-eb50-4056-a5b7-be4c6f4b67c9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_dc2c43dd-706e-447c-a823-3dcf453b1c6c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_62691395-0791-4e80-885e-c94b0c166462.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_d97ab8c6-8598-429f-9f12-ca9b8a164421.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_fcdfef53-eec9-49e6-bd8b-84ead08f96c2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_d049fbd8-bf4c-4091-b84b-69abc5fff045.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_dfbb03d1-f31d-4516-bfb2-a8077bcde76f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_aa2805a4-c930-45e5-bf50-8305309bcf0b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_25678004-85a9-470e-b5b7-7a17b7020f5e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_7713e6d0-19c4-4950-a6a4-111b4d926fbc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_dff838d2-cab9-4120-85b2-6747b5c8218a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_cd351c13-1c82-4b7a-9ff3-1ffb71192350.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_e497bb36-fbca-45a2-8ef8-14236c92097c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_08a44be2-366d-48bb-880c-eed87399305c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_8e46502d-571b-441c-afae-626f2ca18975.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_43b12217-18bc-4f9a-803a-104313a88b50.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_63694b15-705f-46ec-8604-6d1f8a70df44.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_eb0edad1-9354-4d4e-b1a3-6cafb4dbe787.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_fe73b007-f2c9-48c5-bbc2-c32b94c765ba.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_97a593db-f9a0-4540-8959-6599956d574d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_5bff42cd-6ca8-4632-b3ee-f36eb8a54bc4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0ae8bade-884c-4e0f-bf38-3291e9e69ff3_e196289e-228b-44f4-a564-654c50a4e8b4.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,995",
+      "suggestedRetailPrice": "€ 29,995",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1995,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/alfa-romeo-giulietta-1-4-t-distinctive-gasoline-black-cat_ma6mo1611-0ae8bade-884c-4e0f-bf38-3291e9e69ff3",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Alfa Romeo",
+      "model": "Giulietta",
+      "modelGroup": "Giulietta",
+      "variant": null,
+      "motorTypeName": "1.4 TB MultiAir",
+      "modelId": 1611,
+      "modelVersionInput": "1.4 T Distinctive",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "293,834 km",
+      "engineDisplacementInCCM": "1,368 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "17912423",
+      "type": "Dealer",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "04-2011",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.21744584030674874",
+      "isSmyleEligible": "false",
+      "mileage": "293834",
+      "priceLabel": "toolow-price ",
+      "price": "1995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:6, model_group_id:200051, variant_id:, generation_id:2279, motortype_id:12663, trim_id:8137];"
+    },
+    "coverImageAttractiveness": 0.21744584030674874,
+    "vehicleDetails": [
+      {
+        "data": "293,834 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "04/2011",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "125 kW (170 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "134 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "732cd05d-a0a8-4a38-ad91-3bc175687f31",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50195154"
+    },
+    "crossReferenceId": "50195154",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_25f5b29a-694d-4a8e-a78c-446eb6e0c3c0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_ef165c83-51ea-4264-bb71-d9a10c2bbc54.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_a862bde3-78d8-46c2-b704-cd2275678b1a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_b299d266-9a19-4340-b720-5026e21f2555.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_1305eee6-2a94-4dd4-9ae0-41a941ebfcb7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_4278a78f-0962-4fd4-b608-ddc411b16a90.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_4870af8c-5f7e-41dc-93a8-10b90450f5bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_0129e922-cdaf-4745-bd91-f557c0a4a8d0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_6b8bcd57-ec7a-4c54-a3c1-1295d7ec553d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_1bad34cd-36eb-4922-b3a4-e32f5b5e1785.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_1ea20a6e-e581-4cd0-941d-1a3031cc2e86.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_b51d7643-31d2-4bfa-8fef-ddf0f08a8906.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_f2f98a52-1375-42d5-ab3e-674ab70c45dd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_5ab3ef58-0d17-44f4-856e-bf2a04cffb35.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_cbf47fe9-afc5-4c11-b616-2a771e5ae6b1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_68ab036f-87ee-436c-96e9-ce20681f5466.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_83b74939-6f4f-4bbe-953a-ee8d162d8acd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_0adea5f5-48b5-4b4e-bcf0-590f371ff93c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_0473bd42-7a18-41a5-8d92-669d408161a7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_89c001d4-2776-4a98-a7fc-5431c199db44.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_0b05648b-c57f-4dcf-a587-dff390b778f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_1621753e-d60a-4f65-a4b3-883bbf86e440.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_b3e2b507-62b5-49c2-b527-6d5df6b30bab.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_01015552-99dc-4a42-9dec-93efe9126701.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_27b48c69-f940-48e3-93bb-91a36122eba2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_69081470-7a1b-4bac-aec8-6be31fd40c37.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_eb293647-e979-416e-8110-d73df0c8b175.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_f6c8719f-0ffa-420b-bd83-15196811056e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_7e3ccc4f-2ce7-48f5-8c87-8c290b51b273.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_3e6f2bec-849b-4d3c-8771-56ef976a2963.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_081fa46f-ba21-402d-bef5-c7833f18bc23.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_e7874a7b-347d-4a52-a311-a4ba98261c93.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_90ec63d6-acdc-4662-93b6-ff7582d602ac.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_64f7f9aa-7052-4acc-a1b6-35e361c8b6bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_656a47a9-7bdb-45df-a182-02779b76e2e2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_5ef0a88e-d1c4-4627-bdac-c3590864bc59.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_bc13c79e-e762-41cc-91a9-a41400d9b8f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_2ade52f6-e6e1-4b8a-874c-c472cda49cb6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_d129ceef-4f1c-4413-9a7d-d2799c6a6ab1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_7a668300-a33f-4b65-bfff-6308909521e2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/732cd05d-a0a8-4a38-ad91-3bc175687f31_f4ea5f94-9de0-447b-b561-92ac32ae79d7.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,500",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3500,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/volvo-v40-2-0-d2-kinetic-trekhaak-nav-cruise-clima-db-riem-v-diesel-cat_ma73mo2082-732cd05d-a0a8-4a38-ad91-3bc175687f31",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Volvo",
+      "model": "V40",
+      "modelGroup": "V40",
+      "variant": "V40",
+      "motorTypeName": "D2",
+      "modelId": 2082,
+      "modelVersionInput": "2.0 D2 Kinetic Trekhaak Nav/Cruise Clima DB-Riem v",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Diesel",
+      "mileageInKm": "316,144 km",
+      "engineDisplacementInCCM": "1,969 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "9231 HS",
+      "city": "SURHUISTERVEEN",
+      "street": "Molenweg 4"
+    },
+    "ratings": {
+      "ratingsCount": 449,
       "ratingsStars": 5,
       "ratingsEnabled": true
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "23066",
+      "id": "2227420",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/23066-original-43586002-836f-4653-8898-4d51103fa603/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/2227420-original-c3e29df5-c41e-4630-82ae-927c1cdaa518.png/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Autohaus Bernds GmbH",
+      "companyName": "Garage Ploegh",
+      "contactName": "A. Ploegh",
       "links": {
-        "infoPage": "/lst?atype=C&cid=23066",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-bernds-gmbh-dinslaken/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/garage-ploegh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/garage-ploegh/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+49 (0)2064 - 44660",
-          "callTo": "+49206444660"
+          "formattedNumber": "+31 (0)512 - 788338",
+          "callTo": "+31512788338"
         },
         {
-          "phoneType": "Fax",
-          "formattedNumber": "+49 (0)203 - 544727400",
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)512 - 361251",
+          "callTo": "+31512361251"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 43530009",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "11-2015",
+      "fuelType": "d",
+      "imageContent": "no-placeholder|0.16300397079396123",
+      "isSmyleEligible": "false",
+      "mileage": "316144",
+      "priceLabel": "top-price",
+      "price": "3500",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:73, model_group_id:202647, variant_id:2664, generation_id:10922, motortype_id:11808, trim_id:478553];"
+    },
+    "coverImageAttractiveness": 0.16300397079396123,
+    "vehicleDetails": [
+      {
+        "data": "316,144 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "11/2015",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Diesel",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "88 kW (120 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "0 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "35949081-b2ce-4501-91b6-f4f5dd00a8d9",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50508668"
+    },
+    "crossReferenceId": "50508668",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_35a479d1-4308-4742-8a34-8ea2216272c7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_ced80442-b0ad-40b6-81ef-447e79087ccc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_79309f88-55ff-4450-9f37-08d936364760.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_b241a1f9-d4c9-43a4-9ccd-7d79490f7fe4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_9ed2fa3f-f40b-45ac-8498-1f046cd64226.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_a7e81362-3ca8-4f0c-af0e-3797ed8bbac4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_702bb789-efc2-41d8-ba5f-fdd04ff9df6c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_77e965e0-dc55-4701-b749-9a256b681a44.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_afe7c407-8b0c-4bb3-a032-cb863ad88769.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_fa019222-0f67-4798-8800-f9ccc9e9e197.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_40962aa4-f7f4-4893-b66d-49e86edc4d4c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_180b83a0-7117-485b-a968-fc9a19f386e5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_151baa23-a5ea-4ddb-ad52-fd7c4bf089a1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_412d79d1-a40e-4b75-a543-788aa28602ab.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35949081-b2ce-4501-91b6-f4f5dd00a8d9_2667d991-7254-4850-a3df-403e3e3e68de.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 4,499",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 4499,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/fiat-500-1-2-pop-gasoline-white-cat_ma28mo15160-35949081-b2ce-4501-91b6-f4f5dd00a8d9",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Fiat",
+      "model": "500",
+      "modelGroup": "500",
+      "variant": "Hatchback",
+      "motorTypeName": "1.2",
+      "modelId": 15160,
+      "modelVersionInput": "1.2 Pop",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "100,746 km",
+      "engineDisplacementInCCM": "1,242 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "6414 ES",
+      "city": "HEERLEN",
+      "street": "Anjelierstraat 123a"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "38330070",
+      "type": "Dealer",
+      "companyName": "RBMK Automotive",
+      "contactName": "Ruud Beckers",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/rbmk-automotive?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/rbmk-automotive/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)458 - 080583",
+          "callTo": "+31458080583"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 36171327",
+          "callTo": "+31636171327"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 36171327",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2311556460922547",
+      "isSmyleEligible": "false",
+      "mileage": "100746",
+      "priceLabel": "top-price",
+      "price": "4499",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:4199, generation_id:789, motortype_id:1763, trim_id:5960];"
+    },
+    "coverImageAttractiveness": 0.2311556460922547,
+    "vehicleDetails": [
+      {
+        "data": "100,746 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2012",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "51 kW (69 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "3ff17f20-41d9-4d89-98dd-0de10b7c6448",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": null
+    },
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_d02d9c97-d888-4c0b-bc45-89f04f42a85e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_1d63ede1-4139-4813-874c-d94ebea8b1be.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_02184f33-e63e-4931-91fa-e0d1c36f52e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_08c1d3c1-a248-43c1-bb66-aa28bd2a217c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_6d6c0740-5f8d-4f0d-abb3-a8106fc065f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_8a601e58-263b-4ac0-a6b7-6c024e85b509.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_ac1f8af8-b131-48c3-a278-fe0508b5de2b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_ea74e6c7-2c59-4d47-ab45-e71a2bb583dc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_b5b64ea8-f590-4fea-a3bd-a052dbb21e9b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_a7c88b63-252d-4660-bbb6-47f97bde9e68.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_7fabaab0-f1e2-45f0-b758-41d6fe07c694.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_ac6471be-981e-4980-b8ec-d661c32f14a5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_0d9fe822-a622-48f4-ba76-81dd50decbfc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_32a091c0-ddaa-4257-9593-b34f387a1c6d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3ff17f20-41d9-4d89-98dd-0de10b7c6448_80573189-b356-4912-826b-7f33bd93fa06.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 7,999",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 7999,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/hyundai-i10-select-gasoline-white-cat_ma33mo19123-3ff17f20-41d9-4d89-98dd-0de10b7c6448",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Hyundai",
+      "model": "i10",
+      "modelGroup": "i10",
+      "variant": null,
+      "motorTypeName": "1.0",
+      "modelId": 19123,
+      "modelVersionInput": "Select",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "58,062 km",
+      "engineDisplacementInCCM": "998 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "99867",
+      "city": "Gotha",
+      "street": "Burbachstraße 1"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "62947761",
+      "type": "Dealer",
+      "companyName": "A. E. G.",
+      "contactName": "Rudik Arutunjan",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/a-e-g-gotha?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/a-e-g-gotha/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)1733 - 659903",
+          "callTo": "+491733659903"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2021",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18629797610520404",
+      "isSmyleEligible": "false",
+      "mileage": "58062",
+      "priceLabel": "toolow-price ",
+      "price": "7999",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19123, variant_id:, generation_id:1362, motortype_id:2243, trim_id:6816];"
+    },
+    "coverImageAttractiveness": 0.18629797610520404,
+    "vehicleDetails": [
+      {
+        "data": "58,062 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2021",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "49 kW (67 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "3029abc2-72eb-48dd-928b-fccf835a12d9",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "39237117869280"
+    },
+    "crossReferenceId": "39237117869280",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_8b690c63-38fc-4a1d-80b3-c77e12fd49fd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_a8f95bbb-0c6b-48e4-ae9b-d4b222d34da3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_f362c7bc-30aa-4d0e-ba4e-fd63da397fcc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_02a9acd6-fcb3-4606-9900-1f491faf4f76.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_5c53abf7-7a20-4747-8e5f-b00545f440e6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_0c300c3d-4da2-482c-800d-bc324d9ef6c6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_6c16c542-ab2d-4456-bde3-cbf4e61212bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_6fc80a89-592d-4dda-84f8-8ed1c208a76f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_a9c83f97-c12f-441a-9deb-541f85d3eae5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_b55c82a8-8701-46cf-9f9a-45ac7b5dc0e3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_b7c4690e-21ad-4ac3-b6bb-72b9162265e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_928ea338-82b9-4dea-970d-d6d1898710c7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_a1b49f8b-6532-4a21-8516-11c2e04790fb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_656cfa6e-3cf7-42da-89f0-1e1c492b0134.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_f798e3fd-8377-4cae-a893-45844007c384.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_300c8edb-be58-488a-8afc-f9502b37ff2a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_b2b9c929-765b-4a55-8da4-1fe6257a9d4b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_e099ed0f-4c13-4280-b7c6-2ddff611a1bc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_9ea93f57-edf5-485d-8ce2-6d5b5d5cba77.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_fb987c79-e359-4fae-930c-eec431fab7f5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_37169d4d-7fa7-4930-8624-32047f535ff4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_16987cde-ac13-4a3a-9637-c2e427880ddc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_d0ec3956-ba10-47a1-8add-d3aaaffb95d0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_bb52f3a0-02ec-45cc-ae51-fc9273e7e051.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_42d5da0e-e414-464d-8148-e07a9b76865e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_a5fb4ea4-5d2a-4dca-b505-9b0b8d10aea0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_16225554-7486-4d7c-ba3f-92ec849b8f8c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_d532c2bb-b738-41b1-ba7e-c5b69802a1ee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_af014c36-40a8-4d5e-985c-5f95f1b2758c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_99582a72-7e8c-4833-a507-732abb668d99.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_2513610c-3a3f-4225-a1fa-a7a2d149ec44.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_51da8978-3b2f-49a9-98f9-81493a79543d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_e0e2f3da-85da-424a-abd0-e0b7bd263240.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_b9330441-075a-4aa1-a70e-ff00d76124c1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_eff72586-60d5-4131-97cd-5bdb34cb92d2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/3029abc2-72eb-48dd-928b-fccf835a12d9_85eb835e-a87d-47b0-b7c1-9c7ece4b0071.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 4,999",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 4999,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/fiat-500-rock-star-gasoline-black-cat_ma28mo15160-3029abc2-72eb-48dd-928b-fccf835a12d9",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Fiat",
+      "model": "500",
+      "modelGroup": "500",
+      "variant": "Hatchback",
+      "motorTypeName": "1.4",
+      "modelId": 15160,
+      "modelVersionInput": "Rock Star",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "100,000 km",
+      "engineDisplacementInCCM": "1,368 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "73779",
+      "city": "Deizisau",
+      "street": "Plochinger Str.31"
+    },
+    "ratings": {
+      "ratingsCount": 20,
+      "ratingsStars": 4.5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "20035308",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/20035308-original-1727fee5-8113-4ebe-8b60-1c90478b89d3.PNG/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "A.K. Automobile GmbH",
+      "contactName": "Ali Kassem",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/a-k-automobile-gmbh-deizisau?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/a-k-automobile-gmbh-deizisau/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)715 - 3703027300",
+          "callTo": "+497153703027300"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)173 - 7258321",
+          "callTo": "+491737258321"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)173 - 7258321",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "06-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2286016701296395",
+      "isSmyleEligible": "false",
+      "mileage": "100000",
+      "priceLabel": "good-price",
+      "price": "4999",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:4199, generation_id:789, motortype_id:1765, trim_id:480175];"
+    },
+    "coverImageAttractiveness": 0.2286016701296395,
+    "vehicleDetails": [
+      {
+        "data": "100,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "06/2012",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "74 kW (101 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "6.3 l/100 km (comb.)",
+      "140 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "ad3d6a1c-2e3d-44a9-97ab-84ced24383e7",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "2696176"
+    },
+    "crossReferenceId": "2696176",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_6d0514af-6582-4c0c-a729-3684a6b2c51b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_44893790-f87c-41e8-8ea0-a42dc2a98eb3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_8bd393f6-a707-42ae-aa21-e8d1965c0490.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_e2392d50-d60b-4293-950c-485cb24475d6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_12f3eadb-efa4-4b91-ae0f-dc524901215a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_f2df3b86-9cc0-477d-966c-a9239696a98f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_60164393-ed29-41d7-90c7-42ccb24de6e8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_e2dc6d88-5ea7-40a9-91ff-fee2267317e5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_dfec8e65-d141-4cfa-b165-a82e75712498.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_12ba022c-4988-4f2d-b622-5574dee77a5f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_7438d40a-e6b8-4c01-af17-412667bbf9ac.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_48d820bf-0003-4be8-a9f0-aad7de965bb7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_4d05e0da-17d6-4e11-86aa-6d42fb7d000f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_4f4f2704-f889-4999-9ee2-6c0a17ce030b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_1f931558-22ef-4bdf-a0f5-c2594eecc5ce.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_d712ec9b-17b4-4b2c-9eaa-eb557302fa28.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_de1d23be-4a8c-4c1e-b532-24cd266ddd51.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_63cf1a2b-b643-440e-9804-2cddbb54d7f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_1105fae2-7b56-4a6a-8c9c-ebbd4b41ac66.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_6600889e-3fe3-4be3-b514-5e7996303c10.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/ad3d6a1c-2e3d-44a9-97ab-84ced24383e7_24cee82d-f2b6-4bd5-9383-3697996aecbe.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,795",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1795,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/mazda-2-1-3-bifuel-gt-m-line-airco-meeneem-prijs-export-gasoline-black-cat_ma46mo18342-ad3d6a1c-2e3d-44a9-97ab-84ced24383e7",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Mazda",
+      "model": "2",
+      "modelGroup": "Mazda2",
+      "variant": "5 Door",
+      "motorTypeName": "1.3",
+      "modelId": 18342,
+      "modelVersionInput": "1.3 BIFUEL GT-M Line AIRCO MEENEEM PRIJS EXPORT",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "226,789 km",
+      "engineDisplacementInCCM": "1,349 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3076 JA",
+      "city": "ROTTERDAM",
+      "street": "Berkenwoudestraat 23"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "20250231",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/20250231-original-ddb5589a-dfb2-4269-8037-be90340104d5.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Ed-Kar Import en Export",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/ed-kar-import-en-export/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)108 - 084733",
+          "callTo": "+31108084733"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": "+31651191563"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 51191563",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "10-2011",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.17644282790115207",
+      "isSmyleEligible": "false",
+      "mileage": "226789",
+      "priceLabel": "top-price",
+      "price": "1795",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:46, model_group_id:200956, variant_id:3902, generation_id:1737, motortype_id:2594, trim_id:1795];"
+    },
+    "coverImageAttractiveness": 0.17644282790115207,
+    "vehicleDetails": [
+      {
+        "data": "226,789 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "10/2011",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "62 kW (84 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "fbef23da-98fd-44ac-a971-ddc6704d2f19",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": null
+    },
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_f2773388-3ec2-4a00-9c57-63b1eebcc548.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_84948a94-854b-4675-bb2b-fdd60d1c5e59.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_34bf3feb-486d-4112-aea0-bf95b2dd3a99.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_91ecb430-9da5-4bd1-a1e4-c9477f414aae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_d4e6329e-6566-4c9e-be46-3479e2803e07.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_3b067775-0995-4ae3-914e-a1a1642ee6dc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_e8a84d0d-23a9-4ae7-81c5-e2b29291198b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_30cc6321-c7f3-43df-806e-88d758633257.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_a729673d-fd7a-4708-a427-9f983c177c36.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_660f070c-ab0c-4ffc-bb0c-55c391129d3e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_77688c5e-49c1-4a9b-94e9-b1b237eaae32.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_75d54346-3231-4c92-9808-7b779235c295.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_37db6d23-4bdb-48e7-ac56-8c1ecc5bd8fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_0f5400a8-dfbc-4827-9cf2-99716299c83d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_7b48b913-c5d9-47c2-ad12-f1732e741ad6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_4535ee5e-fdcc-4de2-aace-3ddf4b48231b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_31e27c67-8421-47e7-a71e-3fe79e11cc75.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_995e3f46-01d4-4ac4-96af-f9c6586e5a8d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_98cf716e-df2e-4e64-b666-4543a8e8640c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_b9199eea-79be-4827-a21c-a491a4e76cb0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_9ef743e1-53f8-4355-8711-8843ea823eea.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_452ddd67-b927-42ec-a979-76a3134a9d18.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_a6402d33-e835-49c3-b507-da32d9992611.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_13c66d52-61ba-4349-9340-94d9b68aeaee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_320743f1-2281-405d-916a-cbf83a4ef602.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_f8d86bee-3fe9-4078-80fc-818ac20bbad8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fbef23da-98fd-44ac-a971-ddc6704d2f19_e81252c1-a237-4e30-9edf-c6a45356229f.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 5,599",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 5599,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/hyundai-i20-classic-gasoline-grey-cat_ma33mo19188-fbef23da-98fd-44ac-a971-ddc6704d2f19",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Hyundai",
+      "model": "i20",
+      "modelGroup": "i20",
+      "variant": "i20",
+      "motorTypeName": "1.2",
+      "modelId": 19188,
+      "modelVersionInput": "Classic",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "123,000 km",
+      "engineDisplacementInCCM": "1,248 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "46238",
+      "city": "Bottrop",
+      "street": "An der Knippenburg 108"
+    },
+    "ratings": {
+      "ratingsCount": 6,
+      "ratingsStars": 5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "61701398",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/61701398-original-6d3e4e37-a1b8-4d03-9d81-528ee0699e79.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "DriveX",
+      "contactName": "Hassan Haidar",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/drivex?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/drivex/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)204 - 17230739",
+          "callTo": "+4920417230739"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)155 - 67439668",
+          "callTo": "+4915567439668"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)155 - 67439668",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T10",
+    "adTier": "T10",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2015",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.11332907472417708",
+      "isSmyleEligible": "false",
+      "mileage": "123000",
+      "priceLabel": "top-price",
+      "price": "5599",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19188, variant_id:3266, generation_id:919, motortype_id:2250, trim_id:1917];"
+    },
+    "coverImageAttractiveness": 0.11332907472417708,
+    "vehicleDetails": [
+      {
+        "data": "123,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2015",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "63 kW (86 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "isListingBoost": true,
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "se1"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "se1"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "listing_boost"
+      }
+    ]
+  },
+  {
+    "id": "0adbbee3-09a9-467a-b1e8-2d8f07918824",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50522252"
+    },
+    "crossReferenceId": "50522252",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_172e7316-d056-4a02-aa64-aa70b823956c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_e1df845e-91c6-4eed-a4e1-2293420a489a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_54b173a2-810c-4ef0-a390-14c9d7fc6a61.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_0e539c52-c9d9-4d2c-8601-4fe1c3ee7396.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_1425d416-b299-4a60-8ddc-695d010c97b2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_e3db2be8-1cba-48b3-8af7-717f6cd3e977.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_f6429b81-43fb-4b88-a3f5-05a87d8a3bc4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_387493bd-9f20-4fbd-878d-6cd4893057ef.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_0ad208a4-0b26-420a-85f6-e6e53f2a3c0e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_3afb0b6c-a997-42cb-a75c-6e9010ba052f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_c7d09911-e8c8-4f83-a416-5e47f0c12b47.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_7fd75055-021f-450d-b917-02a352b45816.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_b4f0c0d5-a7fe-4d43-83be-d2d921882760.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_e2b9d002-db89-44e2-a051-7d55db078db1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_791a8182-ac7a-4fd8-8182-6371c1d442e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_66af9f5c-7889-409a-85e3-2e5fad2eb65e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_037e5b81-87de-4efe-a0ee-041c432cd682.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_aa842b39-43af-4267-9eb5-f294703023b1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_419203c1-4be5-4e18-a1d3-d1bd98a897ea.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_38ab0b98-0d26-4726-a75d-f4505a40f695.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_d00957e1-3dad-44c5-ac42-aaea37782437.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_f292e8b6-c367-4f6b-8bb6-e42aa440db2f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_5c6c8eb7-ce48-4587-8eb2-87d60a33970e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_31bfc993-ce40-430b-94de-309dfc7acc68.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_a0d87639-1792-4b26-8740-134a507eac8e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_51492d4b-ed70-4742-9fb2-6d37a73e6ca5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_225a7560-8864-4f61-9b68-3c246a88c00f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_16c82b5c-0f4a-4f6b-85ae-f1d2f59bab13.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_67406374-c321-4a75-831a-913c3e34f07e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_ccf55f70-b3e4-4a70-b51a-ee27f4916c7f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_d4837fdb-a1a0-422b-b2b4-244f3348f171.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_0bf1bbc4-7d9c-44eb-8ff2-d712ea689892.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_cef72ba3-ae92-47b8-aded-daf01a628e22.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_62081f5e-60f8-4f81-a4c7-44ee946b8cfa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_682a0f4a-443d-4931-a24e-dfd6d9c1aaaf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_c6773bd4-cfde-4368-bf2f-701b29d04e3a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_7fd9421a-dbcd-4eb4-b67c-1661f549faf1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_eb6e8f97-0074-4fee-b657-53709bac8a2c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/0adbbee3-09a9-467a-b1e8-2d8f07918824_9c46a370-55b2-41f8-b59a-8d5260d5265a.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,844",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3844,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/toyota-aygo-1-0i-vvt-i-x-play-camera-lm-velgen-5drs-lm-velgen-gasoline-grey-cat_ma70mo18655-0adbbee3-09a9-467a-b1e8-2d8f07918824",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Toyota",
+      "model": "Aygo",
+      "modelGroup": "Aygo",
+      "variant": "5 Door",
+      "motorTypeName": null,
+      "modelId": 18655,
+      "modelVersionInput": "1.0i VVT-i x-play Camera LM velgen 5drs LM Velgen",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "272,590 km",
+      "engineDisplacementInCCM": "998 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "2803 PA",
+      "city": "GOUDA",
+      "street": "Burgemeester van Reenensingel 117"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "33917270",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/33917270-original-106c10fc-9c23-4f4c-b672-df012cf434ca.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Van Den Boog Automotive",
+      "contactName": "Lajos van den Boog",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/van-den-boog-automotive?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/van-den-boog-automotive/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)182 - 788293",
+          "callTo": "+31182788293"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)348 - 724347",
+          "callTo": "+31348724347"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)348 - 724347",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2014",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.38262790048297124",
+      "isSmyleEligible": "false",
+      "mileage": "272590",
+      "priceLabel": "somewhat-expensive",
+      "price": "3844",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:70, model_group_id:201443, variant_id:3888, generation_id:1214, motortype_id:, trim_id:480841];"
+    },
+    "coverImageAttractiveness": 0.38262790048297124,
+    "vehicleDetails": [
+      {
+        "data": "272,590 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2014",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "51 kW (69 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "88 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "7a84b851-8505-4f92-8fdb-1a284ac2ab88",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51059040"
+    },
+    "crossReferenceId": "51059040",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_5afae55e-7418-477b-9bc2-7a86203459fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_da5fac33-b0d7-4334-8996-93acb4526659.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_277176bf-4a11-4296-9f72-351c71340f86.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_a43bf078-81a2-4e5c-a507-0eb75d6d7206.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_2a015ca9-d23d-4fa4-b55d-2917b748a75d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_c0763262-37a7-44c6-b754-ac2b9d650faa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_0f244748-1384-48b3-9fb6-f3e3faf1068a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_af314621-fe43-4b50-93b7-9bf2a5674972.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_7c5a3a51-306e-4a46-94c5-749db3c5d4c2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_0a7101af-92f5-4fe5-a824-bbbb0d68ff45.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_a4303669-befc-40ca-842b-ea2de5702a38.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_c778821e-5100-4b43-a1fb-668a75bcd4f0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_1aa4afd2-85bb-4417-8322-c7db9e95c80f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_de7d8627-9864-4582-a567-e7efc86a4ebb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_d90cf4f5-3338-4ee5-ab07-6acbde69cc4d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_86a27949-e2b3-4e5c-b3c1-db742363c317.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_9f134303-a4a1-4335-8478-86bd80f5d1ec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_c3cad54e-24c4-491c-b6d8-25d7fa89cee8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_b8738230-e03d-4293-acec-1ef7b5988ad4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_a13b25d8-05a5-473c-85f1-7ff6f86c6ee5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/7a84b851-8505-4f92-8fdb-1a284ac2ab88_d3e434e8-8c19-45f6-a8a4-6246a3293698.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,745",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3745,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/fiat-500-1-2-lounge-parelmoer-panoramadak-carplay-elekt-gasoline-cat_ma28mo15160-7a84b851-8505-4f92-8fdb-1a284ac2ab88",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Fiat",
+      "model": "500",
+      "modelGroup": "500",
+      "variant": "Hatchback",
+      "motorTypeName": "1.2",
+      "modelId": 15160,
+      "modelVersionInput": "1.2 Lounge PARELMOER! (PANORAMADAK, CARPLAY, ELEKT",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "142,442 km",
+      "engineDisplacementInCCM": "1,242 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "4879 AH",
+      "city": "ETTEN-LEUR",
+      "street": "Florijnstraat 8d"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "culture": "nl-NL"
+      },
+      "id": "51070909",
+      "type": "Dealer",
+      "companyName": "SNBT",
+      "contactName": "Stijn Bult",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/snbt?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/snbt/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 12808374",
+          "callTo": "+31612808374"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 12808374",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Zero"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2008",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18196891988130848",
+      "isSmyleEligible": "false",
+      "mileage": "142442",
+      "priceLabel": "fair-price",
+      "price": "3745",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:4199, generation_id:789, motortype_id:1763, trim_id:5101];"
+    },
+    "coverImageAttractiveness": 0.18196891988130848,
+    "vehicleDetails": [
+      {
+        "data": "142,442 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2008",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "51 kW (69 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "4d6f00d9-3c42-4161-afcb-3e681d1111b3",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "39888737258432"
+    },
+    "crossReferenceId": "39888737258432",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_2fac3850-2fda-463e-9538-acac9c4f74be.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_47c24472-a94f-44de-b138-3a9e5a0cbd66.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_c4b56dbb-4a7a-42f3-a346-8c97cac9c3de.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_31f225d5-5a46-45ed-b5df-8f79528f2d1d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_43d86d12-7d97-4c10-b04c-32c512c2ddee.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_38f2dc82-6c06-466e-b0f1-ef358f7a0a16.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_4c97bc39-ccf1-4e79-a4e8-f55bbc162b9a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_3b4a7438-5210-4162-a373-d05dae98cf8e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_38aa50d5-52da-4259-bf34-98e1e2f46ea1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_49e2243d-a513-4ea5-bd04-e978185dd2b4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_bea45745-b44f-4ca2-92ff-fbf8705069bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_f50ed352-6ac4-47ee-817a-edc1c0e7a868.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_1501fbf9-2ed9-4279-9712-ed7d71f6ed82.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_b676bbd3-7ec4-4dcb-9a99-465b30ab8be0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_d1635bea-d243-4f7d-a95d-928e35e4c6df.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_aa091f03-746d-45ff-b002-464a6a8a7aab.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_2e46a534-752c-4545-b7f7-caad12452d2e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_8a970a14-ebe2-4b97-aa04-01a073e046e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_c50e2419-a9cd-4d92-afed-ff8af40054ca.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_9473ac47-9e75-40ad-89dc-512bc77452f9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_4eb28634-d8d6-4e98-8de2-34ac9c232133.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_53d5e2da-cc5d-45bb-9a2b-26a74f5a3c86.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_88224c64-f4fa-4d22-a864-9d9e08b13b36.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_42715f71-dae5-48a7-b117-258e492e28bf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_5244b080-09f7-406c-9560-0eca6b3f51a8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_1212656d-a460-4dd1-a8f2-9e5b3cdba30a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_fdd3e191-7255-4a93-af5b-8186aea72d0a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_c991a150-d9b0-4afe-8b88-1aad7427fa98.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_3d9cdfe0-48ef-497c-9590-742653715b8f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_f6916c36-a7f8-47d9-ac1e-50b8676c7e44.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_3a41c605-498e-4a4e-af61-b98284b58c3a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_4c5adc4d-1750-469a-829d-690abe1cc1b0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_f32604f7-c278-4823-a1b4-843641c48299.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_192174e7-e6c8-4a88-8d41-4bfe7ddacd07.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_a1c6100f-b9ac-48e4-bb91-1220c91ee6bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_090578df-1d3a-43ea-a662-9fb1d554260f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_04294085-ff11-4e45-aa3c-9ea6201823f2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_5eb69b3b-4f12-4024-93e0-5f53fb1b676c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_f5d261d6-442a-4f49-8811-c516cd06fa01.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_1826c022-2bd5-4d94-8955-2d5bc2341221.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4d6f00d9-3c42-4161-afcb-3e681d1111b3_5b94f982-eb67-4405-b3dd-01005aa2b4ca.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 10,820",
+      "isVatLabelLegallyRequired": false,
+      "priceSuperscriptString": "1",
+      "priceRaw": 10820,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/opel-corsa-f-1-2-elegance-navi-led-kamera-sport-dab+-gasoline-silver-cat_ma54mo1918-4d6f00d9-3c42-4161-afcb-3e681d1111b3",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Opel",
+      "model": "Corsa",
+      "modelGroup": "Corsa",
+      "variant": "Corsa",
+      "motorTypeName": "1.2",
+      "modelId": 1918,
+      "modelVersionInput": "F 1.2 ELEGANCE NAVI/LED/KAMERA/SPORT/DAB+",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "24,690 km",
+      "engineDisplacementInCCM": "1,199 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "38364",
+      "city": "Schöningen",
+      "street": "Büddenstedter Str. 6-12"
+    },
+    "ratings": {
+      "ratingsCount": 271,
+      "ratingsStars": 4.5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "5313355",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/5313355-original-a9b61257-cdec-456d-907a-4450ee8f519d.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autohaus Thiede GmbH",
+      "contactName": "Stefanie Thiede",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohaus-thiede-gmbh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-thiede-gmbh/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)535 - 2570986304",
+          "callTo": "+495352570986304"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)5352 - 1853",
+          "callTo": "+4953521853"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)1525 - 6025296",
           "callTo": null
         }
       ]
@@ -4296,19 +5711,19 @@
     "tracking": {
       "firstRegistration": "03-2023",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.21920064902073055",
+      "imageContent": "no-placeholder|0.21729582904744493",
       "isSmyleEligible": "true",
-      "mileage": "26314",
+      "mileage": "24690",
       "priceLabel": "top-price",
-      "price": "11990",
+      "price": "10820",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:, generation_id:266, motortype_id:625, trim_id:2757];"
+      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:3184, generation_id:266, motortype_id:625, trim_id:3042];"
     },
-    "coverImageAttractiveness": 0.21920064902073055,
+    "coverImageAttractiveness": 0.21729582904744493,
     "vehicleDetails": [
       {
-        "data": "26,314 km",
-        "iconName": "mileage_road",
+        "data": "24,690 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -4332,11 +5747,7 @@
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [
-      "5.9 l/100 km (comb.)",
-      "125 g/km (comb.)"
-    ],
-    "isListingBoost": false,
+    "wltpValues": [],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -4357,96 +5768,457 @@
     ]
   },
   {
-    "id": "cf544f2b-a55e-4755-80dc-b7e2df1b7250",
+    "id": "fa859ccd-29f7-4398-b794-7146c668a020",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "325264413"
+      "crossReferenceId": "50976195"
     },
-    "crossReferenceId": "325264413",
+    "crossReferenceId": "50976195",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_5a1a0d04-134c-413f-b99a-c1a28ca09665.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_ab7592a7-ea36-4612-b2e0-0e1eec1f4e83.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_85db396f-b84e-468e-a3fb-62e631b6184c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_44b75113-c4a4-4f68-8829-163725574d1c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_e586ca91-adac-4ed9-9dbe-8275c28b44fb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_c030b97f-357d-4b58-8b46-0a1e6ad9a2d9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_2a0c10c4-9fcb-455e-8752-649f9c4e93ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_f4d99627-524e-4f16-a891-2e6e0e80144c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_e0a6c112-29a5-4202-b583-63323324d397.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_712d77dd-21a6-4d12-a98b-8d882f70e500.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_021bfddf-b5d3-4511-a554-372c286e5c84.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_2ac2e36b-d432-4365-bc40-d19a480b3097.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_b51411e3-de59-4a66-b424-78a06707b207.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_672361ce-01e4-4920-86c7-2df8c9e83bd3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_cc90207f-d0f2-4cb2-9b6c-ef0c45bcdd29.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_d6fda73d-3b2e-478c-b951-2f373229ece5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_714b32b1-8639-4731-ab7e-d35102750869.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_53c90cf4-3568-438e-9264-73fe08e44bc9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_4c738eb8-17e4-4c11-b037-abce92885752.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_1a59e8b1-d138-4359-9569-caffffeda2c2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_6b07c03a-1c81-4b7c-8e89-cc528b8dff32.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_07fb94e2-9106-4d28-85d7-d46e07d21f21.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_22979c8e-21be-44c4-a8a4-45cb2045c547.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_3c269148-5055-45b7-b7db-aa87ee35ce3d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/cf544f2b-a55e-4755-80dc-b7e2df1b7250_855b651a-62a0-4139-a7fb-a090b409cabd.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_740e39a6-656b-4e55-be1a-3f0fda84b59d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_c5dea4f7-2711-4ec8-b8d8-09f18ae0a0d6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_53bde0da-c73d-409d-b453-1b46346b3079.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_eda57190-0b49-4dfe-ab76-582e8b047962.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_1215c80f-f539-4fc7-88e7-b8071e601f75.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_ebac70e6-1d24-4ed0-93fb-1c8d0012a875.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_d8db9b37-e87c-4d06-ba2d-2eeb4249a745.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_75441f85-1305-44b5-a792-ff500216940c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_0cd2df5d-e424-4745-9609-1f3013071f04.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_882c32e4-4c00-45be-b493-d1ceedad7eb1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_2a845cbe-64c2-46b1-b0f8-19a9054e8bd5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_d4398026-11a8-4fc8-bfa6-cb63a00b035b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_fcac60b4-7b1e-4ae2-b6d6-605ab23335fb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_04ddde36-07f6-4d38-811f-2476e39cfc21.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_bab67548-431b-4241-9aab-fe7ef182961f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_43ac0d68-fe83-444d-ba68-3cb1c5d18580.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_c80579c5-55ed-4be4-aa87-43d80b59766e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_dbda67be-a51a-4cde-8762-4618802e14f2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_1ded5881-89f1-4ace-bcf2-a98b671c822f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_f42f296e-1710-4e82-b615-cbb208ece032.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_ee875e95-214f-4458-9d28-be52849700af.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_97aa3095-1eb8-421b-9235-086fa0709768.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_dfd999b6-72c2-46e0-9ff7-f09a25be9fce.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_66e079a9-af09-43b6-a0ff-94cf1e7d3ad2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_79cc0e01-1768-4be4-a296-202830e01976.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_fca3ba8f-76c7-4c9c-8eec-6ab1aefe3b94.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_459e7dc3-0d61-4970-a670-ddc3a269cdf2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/fa859ccd-29f7-4398-b794-7146c668a020_f21875cf-72cd-4077-a033-3c2090fa0424.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 2,499"
+      "priceFormatted": "€ 1,445",
+      "suggestedRetailPrice": "€ 16,790",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1445,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/volkswagen-fox-1-4-airco-nap-2e-eigenaar-gasoline-black-cf544f2b-a55e-4755-80dc-b7e2df1b7250",
+    "url": "/offers/kia-rio-1-2-cvvt-super-pack-versnellingsbak-defect-gasoline-black-cat_ma39mo16476-fa859ccd-29f7-4398-b794-7146c668a020",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Volkswagen",
-      "model": "Fox",
-      "modelGroup": "Fox",
-      "variant": null,
-      "modelId": 18599,
-      "modelVersionInput": "1.4 Airco | NAP | 2e eigenaar",
+      "make": "Kia",
+      "model": "Rio",
+      "modelGroup": "Rio",
+      "variant": "Rio",
+      "motorTypeName": "1.2",
+      "modelId": 16476,
+      "modelVersionInput": "1.2 CVVT Super Pack (versnellingsbak defect)",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "154,757 km"
+      "mileageInKm": "333,218 km",
+      "engineDisplacementInCCM": "1,248 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "5038 GP",
-      "city": "TILBURG",
-      "street": "Boomstraat 117a"
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "51036003",
+      "id": "17912423",
       "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/51036003-original-4eb7d248-ab67-481e-b3d3-41f247eb2482.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Euromax Auto's",
-      "contactName": "Euromax Autos",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
       "links": {
-        "infoPage": "/lst?atype=C&cid=51036003",
-        "imprint": "https://www.autoscout24.com/dealerinfo/euromax-auto-s/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "10-2011",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.1851857074540333",
+      "isSmyleEligible": "false",
+      "mileage": "333218",
+      "priceLabel": "good-price",
+      "price": "1445",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:39, model_group_id:200742, variant_id:3513, generation_id:985, motortype_id:2463, trim_id:2899];"
+    },
+    "coverImageAttractiveness": 0.1851857074540333,
+    "vehicleDetails": [
+      {
+        "data": "333,218 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "10/2011",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "63 kW (86 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "109 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "4c498c40-a4ce-44fc-b705-c01fa60918f0",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "39404491567072"
+    },
+    "crossReferenceId": "39404491567072",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_79dbfd19-4b10-43b8-a3fa-68b2219fdb81.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_c7f2cd3a-108f-4bf5-abfe-2df68a884192.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_b5fc7c85-5d8e-49d0-a1f6-863fc6673d37.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_33155515-bd38-48b6-a4bb-a10f17e2ed49.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_ffae0d7d-8c1a-4431-8274-97101c0db4fc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_b80a271f-8950-4c87-ac3f-c479c0d84c5e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_a69dd03e-9f25-48d3-af71-882735b6978c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_f21e9b41-13af-4ff1-a067-150d55a7794d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_19fe3bb8-6d15-4f4b-885a-0bdafab1082d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/4c498c40-a4ce-44fc-b705-c01fa60918f0_1abc7da8-d3a1-48bd-840a-3487a7d82595.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 6,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 6950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/peugeot-208-puretech-zahnriemen-neu-gasoline-orange-cat_ma55mo20057-4c498c40-a4ce-44fc-b705-c01fa60918f0",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Peugeot",
+      "model": "208",
+      "modelGroup": "208",
+      "variant": "208",
+      "motorTypeName": "82",
+      "modelId": 20057,
+      "modelVersionInput": "PureTech / Zahnriemen neu",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "73,500 km",
+      "engineDisplacementInCCM": "1,199 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "53489",
+      "city": "Sinzig",
+      "street": "Auf der Albach 1"
+    },
+    "ratings": {
+      "ratingsCount": 2,
+      "ratingsStars": 1.5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "23042108",
+      "type": "Dealer",
+      "companyName": "GR Automobile",
+      "contactName": "Guido Ritz",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/gr-automobile-sinzig?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/gr-automobile-sinzig/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)264 - 2959034300",
+          "callTo": "+492642959034300"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 25370431",
-          "callTo": "+31625370431"
+          "formattedNumber": "+49 (0)171 - 4787400",
+          "callTo": "+491714787400"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "08-2019",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.24234016673223624",
+      "isSmyleEligible": "false",
+      "mileage": "73500",
+      "priceLabel": "top-price",
+      "price": "6950",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:55, model_group_id:201150, variant_id:3624, generation_id:1074, motortype_id:3264, trim_id:902];"
+    },
+    "coverImageAttractiveness": 0.24234016673223624,
+    "vehicleDetails": [
+      {
+        "data": "73,500 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "08/2019",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "61 kW (83 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "4.8 l/100 km (comb.)",
+      "- (g/km)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "9225bc8e-8bd7-4335-8f8a-a90ebbb02525",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50365073"
+    },
+    "crossReferenceId": "50365073",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_3143d0b6-ff1f-4f42-bb7d-6d279bee3d55.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_d276120d-7d1e-47b0-821d-d4706828ee65.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_01399b64-6c88-43f2-af1e-ce1ea1da3d11.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_eda7dfa3-3a25-4839-a832-3bcb8bb21144.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_97844d19-f7aa-4b38-8a71-4278869391bb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_11fc6407-7d0c-4c57-b377-d0a49223bd7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_feb29e8e-eb77-44ac-a899-3a850998b8cc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_00a46647-f449-4e8a-91c5-4eabf4823304.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_9fcdc65e-5cb6-4d4e-9b6e-e8c3a9361543.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_8df08542-4508-4b19-8bf5-a4ba8fc98e58.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_b0e24af2-49cf-4a01-98c7-bc7ee203865f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_924faa00-46e8-4ef4-ac3a-3e4cf588ee05.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_74209f13-43c2-4309-a17d-699303d171f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_6c680ae6-a219-4cab-aac9-0dfa59032c82.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_fea6b19b-04df-4a15-b25a-d14bfd249f2b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_24f58898-f98f-4c86-a8aa-274d48ec604b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_89d94b5c-c172-4bd3-aaa1-0c503fd9c4b8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_6876f676-d8bb-43d3-9979-a443dfb12037.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_14992017-9559-4287-9c5d-4d6b94994a63.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_cbb7f053-fc10-43eb-8b9c-ab8176bc08c7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_b92af780-0f09-42cd-8ca5-cfd38cc6c537.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_3690a438-7f6e-491d-ad39-2f89eab1414b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_f925ff0d-dd31-4b59-a010-a01a1aa6d1f5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_7f8ef38c-f4d1-4ed6-bd94-73f3c598d435.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_11c8449e-564c-4148-97b8-2007a1da7369.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_f087452a-2879-4be1-9f18-b74bb653a15b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/9225bc8e-8bd7-4335-8f8a-a90ebbb02525_97a6be36-44a1-4a21-8a9c-4be3d66a1d34.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 22,499",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 22499,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/bmw-140-1-serie-m140i-xdrive-high-executive-lci-2-leder-gasoline-grey-cat_ma13mo74386-9225bc8e-8bd7-4335-8f8a-a90ebbb02525",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "BMW",
+      "model": "140",
+      "modelGroup": "1 Series",
+      "variant": "Hatchback 5-Door",
+      "motorTypeName": "M140i",
+      "modelId": 74386,
+      "modelVersionInput": "1-serie M140i xDrive High Executive LCI 2 | Leder",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Automatic",
+      "fuel": "Gasoline",
+      "mileageInKm": "225,516 km",
+      "engineDisplacementInCCM": "2,998 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "5705 DK",
+      "city": "HELMOND",
+      "street": "Varenschut 17"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "40817686",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/40817686-original-6d074bac-15b8-48ac-aa9e-7610bbcf6a2d.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "AP Car Store B.V.",
+      "contactName": "Albert Jayachi",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/ap-car-store-b-v-helmond?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/ap-car-store-b-v-helmond/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)317 - 728191",
+          "callTo": "+31317728191"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 82177058",
+          "callTo": "+31682177058"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 25370431",
+          "formattedNumber": "+31 (0)6 - 82177058",
           "callTo": null
         }
       ]
@@ -4461,30 +6233,30 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "09-2007",
+      "firstRegistration": "07-2018",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.22764797934271974",
+      "imageContent": "no-placeholder|0.4709606019244058",
       "isSmyleEligible": "false",
-      "mileage": "154757",
-      "priceLabel": "unknown",
-      "price": "2499",
+      "mileage": "225516",
+      "priceLabel": "good-price",
+      "price": "22499",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:18599, variant_id:, generation_id:1294, motortype_id:4076, trim_id:3783];"
+      "modelTaxonomy": "[make_id:13, model_group_id:100037, variant_id:4087, generation_id:192, motortype_id:531, trim_id:7052];"
     },
-    "coverImageAttractiveness": 0.22764797934271974,
+    "coverImageAttractiveness": 0.4709606019244058,
     "vehicleDetails": [
       {
-        "data": "154,757 km",
-        "iconName": "mileage_road",
+        "data": "225,516 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
-        "data": "Manual",
+        "data": "Automatic",
         "iconName": "gearbox",
         "ariaLabel": "Gear"
       },
       {
-        "data": "09/2007",
+        "data": "07/2018",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -4494,14 +6266,14 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "55 kW (75 hp)",
+        "data": "250 kW (340 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "159 g/km (comb.)"
+      "169 g/km (comb.)"
     ],
     "trackingParameters": [
       {
@@ -4523,82 +6295,120 @@
     ]
   },
   {
-    "id": "d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d",
+    "id": "5f1f3b73-a1fe-4167-b127-d3f29fa70924",
+    "evBanner": {
+      "type": "hybrid",
+      "label": "Hybrid"
+    },
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": null
+      "crossReferenceId": "50098252"
     },
+    "crossReferenceId": "50098252",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_ed1834b4-0604-4df3-b9d2-409c9dd5157b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_8fa3ea2d-65f7-4bba-b58f-4f11fa05b0b0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_c060e719-731f-4d5c-9528-d01fe3775a70.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_2ceee46e-653a-44b2-8f27-18f8f6e207fc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_751f116b-0c64-4634-b746-d294a89167e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_fc8381f7-fbfb-42ff-97a2-d6481155dec5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_933f4c0b-4c77-4d50-b971-03437a564760.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_154af1ea-5174-46fb-88fb-0f670152b0f7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d_7659ebe9-96df-4ae1-9a07-c3b81b5a35df.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_8a9f6952-420f-41eb-bc6a-e947164ee098.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_8571639f-1e6b-4946-ab34-a35e8142f82b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_6c8b0496-db01-4bd8-ae88-d09c8a58aaef.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_152c5846-b42b-456f-8b53-3d0da17f28ad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_f1189d45-b466-41e9-8a34-61a86568f66b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_91c4845e-79e7-4b21-ad2f-b23c136742bf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_e8f8975a-878e-4296-a078-d1b5977c89e0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_02d2f8ef-e809-43b1-b3fa-2bdf577d5fb1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_5512bce7-8cab-4e0a-bcb2-f449cd1261de.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_d8025e5e-6cc8-47a4-b893-191b6b66cf43.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_2a18cae5-de48-42ed-aa28-375b1adfc384.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_be8df190-568e-41f9-b8d3-ef2ba5f1dd77.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_dfa5e010-a0d5-4805-8d67-1249e9c041d8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_3429d97f-334a-48f9-91ff-8625b3ea57eb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_50a2dcef-c310-49c8-b481-41b8cbcd790a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_d68ee4ea-670f-4bf7-af70-cc551cf2e120.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_5abf181e-1db0-47fc-a218-43de6b829222.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_060dcef7-7e38-4420-91a5-4a17c6302ddd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_a237c9be-5590-4750-9db8-0ba6a1cf6df4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_7003a253-462b-4e54-938e-672e7d66f8f3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_e18d5d9a-6b0c-41b9-b09a-0a5c504eb6f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_2760296a-6548-4350-9657-2198f20d4a22.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_778ef7e3-7c47-4376-ac02-a51715031e74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_e4c9a407-0c0c-4e04-ba09-8da26afad091.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5f1f3b73-a1fe-4167-b127-d3f29fa70924_1eb2af48-8fbd-4903-8987-b7830d78f6c3.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 3,890"
+      "priceFormatted": "€ 7,999",
+      "suggestedRetailPrice": "€ 52,420",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 7999,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/suzuki-alto-hu-neu-service-neu-gewaehrleistung-1-jahr-gasoline-violet-d18cf5f3-1ce5-4252-b0d6-a9bc5f2ae94d",
+    "url": "/offers/audi-a3-sportback-1-4-e-tron-phev-s-line-lees-tekst-electric-gasoline-grey-cat_ma9mo1624-5f1f3b73-a1fe-4167-b127-d3f29fa70924",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Suzuki",
-      "model": "Alto",
-      "modelGroup": "Alto",
-      "variant": null,
-      "modelId": 2029,
-      "modelVersionInput": "HU NEU * Service NEU * GEWÄHRLEISTUNG 1 JAHR",
+      "make": "Audi",
+      "model": "A3",
+      "modelGroup": "A3",
+      "variant": "Sportback",
+      "motorTypeName": "1.4 TFSI e-tron",
+      "modelId": 1624,
+      "modelVersionInput": "Sportback 1.4 e-tron PHEV S-Line | LEES TEKST ! |",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "100,000 km"
+      "transmission": "Automatic",
+      "fuel": "Electric/Gasoline",
+      "mileageInKm": "256,812 km",
+      "engineDisplacementInCCM": "1,395 cc"
     },
     "location": {
-      "countryCode": "DE",
-      "zip": "41334",
-      "city": "Nettetal",
-      "street": "Niedickstr.65"
-    },
-    "ratings": {
-      "ratingsCount": 14,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
+      "countryCode": "NL",
+      "zip": "7602 PW",
+      "city": "ALMELO",
+      "street": "Parmentierweg 1a"
     },
     "seller": {
       "dealer": {
         "maxImages": 50,
         "hasDealerInformationOnResultList": true,
-        "isFreespeeCallTrackingEnabled": true
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "51254260",
+      "id": "52291027",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/51254260-original-4a64894b-8005-4c4f-b876-eaec3f099d5b.png/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/52291027-original-ab74b293-6531-4223-ba68-19e87f180fef.png/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Akar Performance GmbH",
-      "contactName": "Abbas Akar",
+      "companyName": "Regge Autogroep",
+      "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=51254260",
-        "imprint": "https://www.autoscout24.com/dealerinfo/akar-performance-gmbh/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/regge-autogroep?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/regge-autogroep/imprint"
       },
       "phones": [
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)176 - 62348729",
-          "callTo": "+4917662348729"
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)546 - 788865",
+          "callTo": "+31546788865"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)546 - 799548",
+          "callTo": "+31546799548"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)546 - 799548",
+          "callTo": null
         }
       ]
     },
@@ -4612,21 +6422,197 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "08-2011",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2179368959979514",
+      "firstRegistration": "10-2015",
+      "fuelType": "2",
+      "imageContent": "no-placeholder|0.1455608868068038",
       "isSmyleEligible": "false",
-      "mileage": "100000",
-      "priceLabel": "unknown",
-      "price": "3890",
+      "mileage": "256812",
+      "priceLabel": "good-price",
+      "price": "7999",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:68, model_group_id:201406, variant_id:, generation_id:1428, motortype_id:9986, trim_id:];"
+      "modelTaxonomy": "[make_id:9, model_group_id:1624, variant_id:152, generation_id:153, motortype_id:12392, trim_id:136];"
     },
-    "coverImageAttractiveness": 0.2179368959979514,
+    "coverImageAttractiveness": 0.1455608868068038,
     "vehicleDetails": [
       {
-        "data": "100,000 km",
-        "iconName": "mileage_road",
+        "data": "256,812 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Automatic",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "10/2015",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Electric/Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "150 kW (204 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "28e6f527-22db-444d-b6f5-c48d92973304",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51127898"
+    },
+    "crossReferenceId": "51127898",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_5c33a263-0c41-46b9-b578-54ead455df64.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_bdb251f0-e401-42a8-928c-0ca5e2fc273c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_911aa862-6e89-4ccc-b56f-69ca70b84442.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_4665a274-98fe-4cea-b81b-a487d02f2a49.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_df6ce7a8-0b72-4e02-8b3a-6f1036e19742.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_1d005f2b-88f2-4888-9d55-db62e41140d0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_84bbf3ab-c1b3-4c20-821c-8e1f20116f07.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_a97dd9b6-61ba-4245-9c4f-a2560205b943.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_781343d0-8623-410e-9191-653131bc0f80.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_43e03d06-e2ad-40f8-9909-0a6b0fcd0ac7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_806c340c-4c1b-4504-9355-fc0c303b4085.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_c9cd8d67-610c-4d57-a767-5833b94783c8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_0a2d42a8-c184-4f2f-8b0b-a35e08b50563.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_8e11d466-4184-461c-9aed-31aeacdee508.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_cd48b519-c864-4f89-97b5-f922e1cb5c4c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_ae9aa825-7f84-4e8d-854f-37dc80e10e7e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_76119dd2-5861-4640-b412-cfeee888194d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_8bc860ed-b26d-4c95-a17e-d54f0c05b30a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_7ba32d0e-0acc-4bd2-8da0-01ad1383a958.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/28e6f527-22db-444d-b6f5-c48d92973304_bbd845cb-4abb-46ef-8c67-71408dbc5cd8.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 2,250",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2250,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/ford-focus-1-6-ti-vct-titanium-gasoline-black-cat_ma29mo15537-28e6f527-22db-444d-b6f5-c48d92973304",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Ford",
+      "model": "Focus",
+      "modelGroup": "Focus",
+      "variant": "Focus Sedan",
+      "motorTypeName": "1.6",
+      "modelId": 15537,
+      "modelVersionInput": "1.6 TI-VCT Titanium",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "166,713 km",
+      "engineDisplacementInCCM": "1,596 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "2141 AN",
+      "city": "VIJFHUIZEN",
+      "street": "Kromme Spieringweg 450"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "10405",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/10405-original-04869ead-8a55-4aa3-835e-439d99cfdfd2.jpg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autobedrijf Blankert",
+      "contactName": "Viktor Blankert",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autobedrijf-blankert?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-blankert/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)238 - 080816",
+          "callTo": "+31238080816"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)23 - 5581804",
+          "callTo": "+31235581804"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 52606960",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T30",
+    "adTier": "T30",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "06-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.16795741547028675",
+      "isSmyleEligible": "false",
+      "mileage": "166713",
+      "priceLabel": "toolow-price ",
+      "price": "2250",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:29, model_group_id:15537, variant_id:262, generation_id:273, motortype_id:635, trim_id:7872];"
+    },
+    "coverImageAttractiveness": 0.16795741547028675,
+    "vehicleDetails": [
+      {
+        "data": "166,713 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -4635,7 +6621,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "08/2011",
+        "data": "06/2012",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -4645,21 +6631,23 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "50 kW (68 hp)",
+        "data": "92 kW (125 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [],
-    "isListingBoost": false,
+    "wltpValues": [
+      "- (l/100 km)",
+      "136 g/km (comb.)"
+    ],
     "trackingParameters": [
       {
         "key": "boost_level",
-        "value": "t50"
+        "value": "t30"
       },
       {
         "key": "applied_boost_level",
-        "value": "t50"
+        "value": "t30"
       },
       {
         "key": "relevance_adjustment",
@@ -4672,97 +6660,121 @@
     ]
   },
   {
-    "id": "d5626229-9309-44c5-8f87-4a1d2e4eca8f",
+    "id": "73400289-c3fa-44f8-a418-240b4f9614e7",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "442492390"
+      "crossReferenceId": "461455614"
     },
-    "crossReferenceId": "442492390",
+    "crossReferenceId": "461455614",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_c1ccee62-9a22-404b-a486-bd832698f1fa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_a9f25636-90ac-452c-a368-b93b2789039c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_31347f45-928b-48fa-b7bc-cbb59c2c28c6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_baa8813e-af42-4e6e-8265-da1cbbb18f75.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_f2ae4ee5-0041-4df6-a061-99d5d73f07b3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_d5d84aaa-90da-49cc-9f18-f0fb3d49ee4d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_90b5e28f-c134-401a-870d-9c69f5319746.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_f62e5c46-21e7-43de-ad6c-36751b7dad0e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_6748c250-7d39-4f9b-8a70-4a992494b9ae.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_4aaa32a3-5717-483c-be60-8977c06a9180.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_e2700266-b3bf-4d42-a631-9d1f000b563b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_7661d53c-ef4d-454b-b0a1-a618ab7cdf8f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_8d004ff4-41b3-4445-9580-3c034f1359b6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_69580e96-d98b-4ff2-9ffe-2919bcbcd793.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_cfc7c996-be88-44f2-b7c2-c502b97eaf15.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_84feef7d-4485-49d1-93b2-93dfb275a5a6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_fd9c8f44-1073-44b6-91b0-4df8049c0739.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_390786c2-a8a1-41bc-bd5a-0dc1d12caae9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d5626229-9309-44c5-8f87-4a1d2e4eca8f_c7e7385b-1ee1-4a71-881c-eec12bff97fd.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_b4e38c6f-57a1-4734-bfb8-08391fffe056.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_d64a35d3-8bd6-4527-b62c-67963928b17b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_256f0f72-539d-461c-8e41-4e1166be49f7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_75cd1cf5-d71b-4a89-935f-bfec66f01a87.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_6ec1369a-00b7-48d5-8375-0768ba181ea0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_775ae0e1-a2bd-46c2-99f6-af96e59f96b5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_ec3050b7-ba66-4761-908b-622ad04dea6e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_5806524a-9579-4292-90bb-5e91187be5e7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_e1cd6e5f-f7c6-4ca3-a91a-0e86d2c80e48.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_9b239579-51ea-4752-83e9-291b72ee064b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_a16c6384-91d7-42bd-972e-8828cffdcf6c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_adf609c6-b29b-4491-9679-5a5b5c1d7825.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_95ab6cea-7b97-4bb1-94b4-b9f9b4d8d1bd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_d2b74b4a-b0bc-4801-9c2c-6273f40b3908.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_f8297629-6e0e-4c63-b718-0eea10c21868.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_ea6a85ae-d2c4-40c4-8227-e9d9679d4a83.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_babbc863-5a8a-4b32-a106-4be6f1e0086f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_3d60310c-df9e-4793-b44b-19e6de477e05.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_45297d63-8b8b-45f7-8bcf-afcaf96cbd8e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_cf0e3a5e-383b-466e-add2-3a8e1bc6a238.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_4bf01a85-3a1e-4971-b67b-73236256dc29.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_2e2173b5-7959-411f-8e8a-42d7cff093da.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_b5c6c27c-ef5f-460e-b924-fdaf530df13a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_710df134-c040-4555-a835-eb99642e64d6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_0d354e64-f321-4942-b531-dd83f9a6fdf5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_a9b7846f-4261-44c8-971e-87d8f2d04783.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/73400289-c3fa-44f8-a418-240b4f9614e7_8b0e553d-1e61-450d-b996-fdb10fa38627.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 2,500"
+      "priceFormatted": "€ 6,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 6950,
+      "isConditionalPrice": true
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/mini-one-mini-one-seven-klima-hu-11-26-gasoline-black-d5626229-9309-44c5-8f87-4a1d2e4eca8f",
+    "url": "/offers/opel-adam-adam-jam-ecotec-klima-gjreifen-tuev+service-neu-gasoline-yellow-cat_ma54mo20191-73400289-c3fa-44f8-a418-240b4f9614e7",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "MINI",
-      "model": "One",
-      "modelGroup": "Mini",
-      "variant": "One 3-Türer",
-      "modelId": 16602,
-      "modelVersionInput": "Mini One SEVEN/ Klima/ HU 11.26",
+      "make": "Opel",
+      "model": "Adam",
+      "modelGroup": "Adam",
+      "variant": null,
+      "motorTypeName": "1.0",
+      "modelId": 20191,
+      "modelVersionInput": "ADAM JAM ECOTEC KLIMA GJREIFEN TÜV+SERVICE NEU",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "182,087 km"
+      "mileageInKm": "70,000 km",
+      "engineDisplacementInCCM": "999 cc",
+      "isCurrentlyDamaged": false
     },
     "location": {
       "countryCode": "DE",
-      "zip": "48599",
-      "city": "Gronau",
-      "street": "Opelstr. 14"
+      "zip": "21502",
+      "city": "Geesthacht",
+      "street": "Mercatorstraße  20"
     },
     "ratings": {
-      "ratingsCount": 29,
-      "ratingsStars": 4.5,
+      "ratingsCount": 102,
+      "ratingsStars": 5,
       "ratingsEnabled": true
     },
     "seller": {
       "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
       },
-      "id": "16778285",
+      "id": "14899458",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/16778285-original-3e1900e2-f84e-4ad9-b2fa-4d8cd9570910.JPG/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/14899458-original-ceb40ef3-ef07-4877-8fdd-938449611ceb.jpg/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Autohaus Smit GmbH",
-      "contactName": "Ton Smit",
+      "companyName": "ATG Auto & Technik Goldmann",
+      "contactName": "Francois Graff",
       "links": {
-        "infoPage": "/lst?atype=C&cid=16778285",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autohaus-smit-gmbh/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/atg-auto-und-technik-goldmann?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/atg-auto-und-technik-goldmann/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+49 (0)2562 - 965330",
-          "callTo": "+492562965330"
+          "formattedNumber": "+49 (0)415 - 2136993400",
+          "callTo": "+494152136993400"
         },
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)172 - 5305490",
-          "callTo": "+491725305490"
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)40 - 52476376",
+          "callTo": "+494052476376"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)157 - 38809550",
+          "callTo": null
         }
       ]
     },
@@ -4776,21 +6788,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "11-2006",
+      "firstRegistration": "12-2015",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.140418292616714",
+      "imageContent": "no-placeholder|0.25499658967469907",
       "isSmyleEligible": "false",
-      "mileage": "182087",
-      "priceLabel": "fair-price",
-      "price": "2500",
+      "mileage": "70000",
+      "priceLabel": "top-price",
+      "price": "6950",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:16338, model_group_id:100141, variant_id:2688, generation_id:371, motortype_id:, trim_id:6885];"
+      "modelTaxonomy": "[make_id:54, model_group_id:20191, variant_id:, generation_id:1012, motortype_id:3501, trim_id:5711];"
     },
-    "coverImageAttractiveness": 0.140418292616714,
+    "coverImageAttractiveness": 0.25499658967469907,
     "vehicleDetails": [
       {
-        "data": "182,087 km",
-        "iconName": "mileage_road",
+        "data": "70,000 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -4799,7 +6811,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "11/2006",
+        "data": "12/2015",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -4814,11 +6826,7 @@
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [
-      "6.8 l/100 km (comb.)",
-      "164 g/km (comb.)"
-    ],
-    "isListingBoost": false,
+    "wltpValues": [],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -4839,573 +6847,98 @@
     ]
   },
   {
-    "id": "5989f75b-4e44-446e-b8f8-1ae226c2aaf0",
+    "id": "5d845a3b-af8d-436b-a0e0-8a0870d6bdd1",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "314016507"
+      "crossReferenceId": "50986054"
     },
-    "crossReferenceId": "314016507",
+    "crossReferenceId": "50986054",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_0898095a-06a5-470a-a04f-2dc8fe1e791c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_6bb4c8c5-a6d0-4283-8b56-7d2717338948.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_ca36abb6-da75-4592-8759-79547359d424.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_e6b5e991-92c3-4321-86a1-9a6654f2141a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_1912aafa-61ca-4e3a-8e8f-f4a666b6677f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_c574ec5a-f36c-4cc9-b69b-2a7bca262adc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_a405cd5c-7d31-4c59-9697-146f85a0494f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_763dc93c-0513-47a9-bacf-acb56243696d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_e6fb1a75-0df2-4448-9b29-fa076a7adcc9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_2c9de377-b661-4865-a546-5ee9c93ae95a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_ee269246-0ae3-4531-af03-b345dfaf7407.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_b649eb5f-f5f8-442a-ac95-cbe14a625d63.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_75b0e673-6320-4185-8ad9-91907a30a130.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_ff22570c-38a0-4823-a6a7-db2124442631.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5989f75b-4e44-446e-b8f8-1ae226c2aaf0_86e4d2f8-aded-4a23-84f7-abb89a34320c.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_60bbaa6d-aa87-4973-bae6-74d320e4614f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_dcd1ce33-1344-419a-a7e3-7401922a5128.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_5df7f4f4-c32d-472d-b4b0-d0c1fdbff62c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_9466c6df-43ae-4b94-a729-6c86e85d1380.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_c8d786dd-cde5-4a0b-9d87-18614a8a12d6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_2f80fa3c-ce40-4998-bee9-1ed43962c3d4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_917b3a74-5fae-4d60-a11e-209d1ca370bd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_7d276ec2-0b77-4c47-97d2-7e64bbfaadd6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_f9146337-f8fa-4dab-9739-1f7bb4a5a7e7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_d54d376c-c636-4ced-a101-324033fee099.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_a0bc0bac-966d-4ca9-a019-b216206319ff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_167b68f2-ca63-4886-b88d-cbb4c53781f8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_85c3d84e-04af-4958-bff3-a2f50b5fbaa8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_a396e6c4-10c4-4e61-bb57-388c3144f146.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_299e57f1-c84b-498b-a3b7-2f37148d00c9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_d48b2b8e-1aeb-4132-890b-c842cbd6fcde.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_93931df5-65cb-4f08-b271-d59a71d87097.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_7a278b54-4f2a-42f7-b706-38466b6d5588.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/5d845a3b-af8d-436b-a0e0-8a0870d6bdd1_9c7378fc-72cf-4536-89de-5a7b9ed477a6.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 3,850"
+      "priceFormatted": "€ 1,645",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1645,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/alfa-romeo-giulietta-1-4-t-progression-gasoline-black-5989f75b-4e44-446e-b8f8-1ae226c2aaf0",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Alfa Romeo",
-      "model": "Giulietta",
-      "modelGroup": "Giulietta",
-      "variant": null,
-      "modelId": 1611,
-      "modelVersionInput": "1.4 T Progression",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "237,277 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "6827 AT",
-      "city": "ARNHEM",
-      "street": "Westervoortsedijk 65"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "45489236",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/45489236-original-561e263a-860b-4e32-95bb-e90a8afcfab3.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Beekman Auto's",
-      "contactName": "Afdeling verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=45489236",
-        "imprint": "https://www.autoscout24.com/dealerinfo/beekman-auto-s/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 21250919",
-          "callTo": "+31621250919"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 21250919",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Zero"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "01-2012",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2215046051823335",
-      "isSmyleEligible": "false",
-      "mileage": "237277",
-      "priceLabel": "top-price",
-      "price": "3850",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:6, model_group_id:200051, variant_id:, generation_id:2279, motortype_id:5545, trim_id:4544];"
-    },
-    "coverImageAttractiveness": 0.2215046051823335,
-    "vehicleDetails": [
-      {
-        "data": "237,277 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "01/2012",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "125 kW (170 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "134 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "dc0648e7-8856-4bd7-90b3-4387af9d86f1",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "317968582"
-    },
-    "crossReferenceId": "317968582",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_0f0b3e62-99ec-4d6e-9244-059b421b93c1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_183f823a-8487-424a-a660-5b718ae29ed7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_9d1fe564-a455-4b2f-9d5b-051eb46feb00.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_7748d9fe-ae5d-4127-a4cd-32cadb468eec.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_47a14438-ae4a-4fd6-a2d3-44de352641e1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_37e5f92d-39f3-4835-8fb6-48f12564712f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_d6058842-34df-4f45-a8b4-82ad53c42a3a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_e2efd06e-e548-4ce7-b474-143fce833f1d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_b90cb4b6-01c5-4eec-9306-5eaa9cc7ef4b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_01706a29-d7e3-4a80-86df-e5c0218adf25.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_3b0b9113-a199-4515-beef-bb25f7c7056c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_498b5244-76e1-413b-9b2b-f1d041f9ca8d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_6a2b298a-f4aa-4967-acf8-eddf3c3b5922.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_1eb13245-3312-4ee7-9304-c433914803dd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_ee94de74-2935-45c9-8ad4-b8f8113cd797.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_74147a5f-059a-4c22-9eea-1ae5cbb41143.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_0be6f9c1-2f12-447d-852a-f4bd2f673b48.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_b1e6cea5-3f5a-4ca7-a90a-aa54ff26c64c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_7e1d04b2-331d-4144-809d-791da71f56a6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_2eeb4d2f-3b75-4a63-a793-88cef97ff4b7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/dc0648e7-8856-4bd7-90b3-4387af9d86f1_45740447-dfd2-44cc-950d-fb70bdc1a8a4.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/mini-cooper-mini-pepper-1-6-116-pk-cruise-lichtmetaal-co-gasoline-red-dc0648e7-8856-4bd7-90b3-4387af9d86f1",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "MINI",
-      "model": "Cooper",
-      "modelGroup": "3 Door",
-      "variant": "Cooper",
-      "modelId": 16603,
-      "modelVersionInput": "Mini Pepper 1.6 116 pk - cruise - lichtmetaal - co",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "157,451 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "8152 DN",
-      "city": "LEMELERVELD",
-      "street": "Weerdhuisweg 11"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "36889725",
-      "type": "Dealer",
-      "companyName": "Kragt Auto's",
-      "contactName": "William Kragt",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=36889725",
-        "imprint": "https://www.autoscout24.com/dealerinfo/kragt-auto-s/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)572 - 745234",
-          "callTo": "+31572745234"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "03-2004",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2881850322664259",
-      "isSmyleEligible": "false",
-      "mileage": "157451",
-      "priceLabel": "top-price",
-      "price": "1950",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:16338, model_group_id:202311, variant_id:2987, generation_id:11036, motortype_id:, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.2881850322664259,
-    "vehicleDetails": [
-      {
-        "data": "157,451 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "03/2004",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "85 kW (116 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "165 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "26ba1303-825d-485b-89ed-f003d20f853a",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "324049119"
-    },
-    "crossReferenceId": "324049119",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_e692a6fe-2346-40fd-a92c-54f13e05d124.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_d81246ad-3716-43e4-abae-e50bde5110c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_72a9ad27-fd99-4761-8425-a2a80c1eff27.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_c4564645-dc47-4261-8b11-89d1faa32a68.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_f7d26699-f52f-476f-81f5-640d4a058c77.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_a6d3ea89-805d-49a0-944b-cdc474bd1f80.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_8bf29a46-1df5-4d2c-82df-619e05da0476.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_f089170d-61b2-4a0d-b166-86bf7b2e5aca.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_7254ab4e-84b9-4321-943b-fa02e55bfd77.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_5ddeba95-42da-41d4-8969-7833b7d48b97.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_756e6c16-8175-498c-b3d1-28d4fcc531c4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_e474d9fe-8095-4537-a424-ec464bc2e0d7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_6ed4a843-4004-4b0f-9b7e-14354847e28a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_18ede6e9-3636-4b2e-8e9b-2e94de987586.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_c0a1e1a6-aa1d-4b3c-bf59-44cdb171e9e8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_09072da7-5fc6-49ef-9a9a-3d495542c8c3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_33cb161a-a049-4185-ab9b-afa1cb979539.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_60cf5ba1-2501-41ba-a9ea-bf257c9810e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_5c232684-d85d-40b3-850d-4a4fe1e72cc5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_17821118-42d6-443d-a94b-14a0a5af6f1a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_d7235902-ad47-41f2-a142-bdde3aee9a62.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_0e8f97a7-6552-4df3-85f8-05262dbbc417.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_b188f166-cc20-48e9-9a57-7a089cc8c043.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/26ba1303-825d-485b-89ed-f003d20f853a_c2068ab4-b90b-4e9b-a3c9-305ee9d6bdec.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/audi-a3-1-6-ambition-pro-line-carplay-facelift-airco-gasoline-grey-26ba1303-825d-485b-89ed-f003d20f853a",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Audi",
-      "model": "A3",
-      "modelGroup": "A3",
-      "variant": "Sedan",
-      "modelId": 1624,
-      "modelVersionInput": "1.6 Ambition Pro Line | Carplay | Facelift | Airco",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "238,673 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "7944 HT",
-      "city": "MEPPEL",
-      "street": "Industrieweg 3"
-    },
-    "seller": {
-      "dealer": {
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "15258689",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/15258689-original-ac8d440f-f17b-4f58-b5a7-5e1b08834499.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autobedrijf Meijer",
-      "contactName": "Rudolf Meijer",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=15258689",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-meijer/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)522 - 785249",
-          "callTo": "+31522785249"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 54227129",
-          "callTo": "+31654227129"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 54227129",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "04-2009",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.13425215932041767",
-      "isSmyleEligible": "false",
-      "mileage": "238673",
-      "priceLabel": "somewhat-expensive",
-      "price": "3950",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:9, model_group_id:1624, variant_id:151, generation_id:152, motortype_id:233, trim_id:131];"
-    },
-    "coverImageAttractiveness": 0.13425215932041767,
-    "vehicleDetails": [
-      {
-        "data": "238,673 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "04/2009",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "75 kW (102 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "162 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "b8ec173a-c031-4385-a06c-defb272417a3",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "324205634"
-    },
-    "crossReferenceId": "324205634",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_4e3ff8e3-551a-42e7-b276-d801f4f7a1aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_4df2438a-22b9-4f56-a02c-c07950ac7a3b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_a6ed890d-1703-4621-b955-6d204a288081.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_86f94f26-f9f7-415b-97cb-42e96cf47925.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_4689b6b7-535c-422c-801f-b19d6e6c90ac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_d63de343-0a5c-41d7-bc2c-9c80c50cbcb9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_d349b90f-909b-4eb4-9993-3bc0455effe4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_cf601ae3-affa-489b-95bc-a0a3a3a6c922.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_5952d3e1-bcbf-4dda-a13b-61c5951d8cba.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_8121596e-67a9-4b3a-becd-5f9abc59a8a2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_96db3146-80c3-40a2-9c09-581bd04b0271.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_679bf031-860d-46b9-911a-743770da1689.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_4f2e46ed-0758-47ea-9e6d-0d4acc02916b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_c71dd12e-3d3f-4a6d-98b5-0caca5a88277.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_2fb7943b-7add-443c-848d-9740f4ee9c9a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_0797f73b-f969-4bb8-9886-4ed061c7d803.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_50196fef-896c-4e3e-ba72-88314725ef59.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_ae8e349c-6552-41d8-bc58-66c9bd288f08.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_2cd2bd9f-36f9-4e63-bf5e-a10790c6347c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b8ec173a-c031-4385-a06c-defb272417a3_5f4eb31a-5f24-4df5-a2de-8f7fbc4c8f5e.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,450"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/citroen-c1-1-0-12v-ambiance-airco-apk-gasoline-red-b8ec173a-c031-4385-a06c-defb272417a3",
+    "url": "/offers/citroen-c1-1-0-12v-seduction-gasoline-black-cat_ma21mo18651-5d845a3b-af8d-436b-a0e0-8a0870d6bdd1",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
       "make": "Citroen",
       "model": "C1",
       "modelGroup": "C1",
-      "variant": null,
+      "variant": "C1",
+      "motorTypeName": "1.0",
       "modelId": 18651,
-      "modelVersionInput": "1.0-12V Ambiance Airco/APK",
+      "modelVersionInput": "1.0-12V Séduction",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "238,723 km"
+      "mileageInKm": "146,289 km",
+      "engineDisplacementInCCM": "998 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "7091 EP",
-      "city": "DINXPERLO",
-      "street": "Aaltenseweg 89"
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "46122556",
+      "id": "17912423",
       "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/46122556-original-7cded674-6c6e-46d6-b3b1-1c0f33d6f349.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Taeke Automotive",
-      "contactName": "Taeke Lammers",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
       "links": {
-        "infoPage": "/lst?atype=C&cid=46122556",
-        "imprint": "https://www.autoscout24.com/dealerinfo/taeke-automotive/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
       },
       "phones": [
         {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 17478496",
-          "callTo": "+31617478496"
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
         },
         {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 17478496",
-          "callTo": null
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
         }
       ]
     },
@@ -5419,21 +6952,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "10-2009",
+      "firstRegistration": "06-2009",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.2169090917493841",
+      "imageContent": "no-placeholder|0.30884751320526305",
       "isSmyleEligible": "false",
-      "mileage": "238723",
+      "mileage": "146289",
       "priceLabel": "top-price",
-      "price": "1450",
+      "price": "1645",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:21, model_group_id:200305, variant_id:, generation_id:2122, motortype_id:1430, trim_id:988];"
+      "modelTaxonomy": "[make_id:21, model_group_id:200305, variant_id:3411, generation_id:2122, motortype_id:1430, trim_id:988];"
     },
-    "coverImageAttractiveness": 0.2169090917493841,
+    "coverImageAttractiveness": 0.30884751320526305,
     "vehicleDetails": [
       {
-        "data": "238,723 km",
-        "iconName": "mileage_road",
+        "data": "146,289 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -5442,7 +6975,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "10/2009",
+        "data": "06/2009",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -5461,7 +6994,6 @@
       "- (l/100 km)",
       "106 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -5482,111 +7014,103 @@
     ]
   },
   {
-    "id": "eacc5e2e-8734-4a6e-9f42-c38da8c3bf61",
+    "id": "b3626a2c-0540-49ee-99f8-17ffd811622e",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "316877950"
+      "crossReferenceId": "50912107"
     },
-    "crossReferenceId": "316877950",
+    "crossReferenceId": "50912107",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_812ce606-d486-49f2-ad58-441e8dedb440.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_eef2a587-e650-4f72-bec3-199396967530.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_b20b6980-626f-4a10-a142-9de097e806cb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_e72f6575-c05a-4407-903f-e0b40a1673a1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_4a7c775e-1909-4db3-a66d-a761fc929476.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_20a0ad7a-caef-4cd2-a965-88b48ba21367.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_3ef5da04-33ad-4931-9ee4-bb68109577ba.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_32ad4d3f-b7fa-4680-a26d-fbae88bb03e4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_8b357150-9b95-4b0c-886b-4a0797605864.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_95b6b435-5f89-44cb-a37d-0b0b477baad1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_11b20b0e-8627-43f7-bda4-513cb5080cde.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_919c67e9-0bbd-46b5-b668-5af93bd2147c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_91d076e6-bfb5-431d-8c24-3eaed0524ead.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_9665284e-363e-4b6b-a406-8a3ff0a44d47.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_f686d485-3e7f-4c02-992a-55bae69294f0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_2f7afb38-d1dd-41fc-b291-ea886c55e9e9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_e384ac51-76eb-4e10-b8f2-92ed6507156b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_3547a860-a0cd-4224-a6f1-d0f454916fdc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_531be2a7-af42-40b5-b62d-b0d51e9b5a81.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_e15f25e5-7a95-4112-bad3-bc446591c22a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_549023fc-f668-4082-9471-1fa6fe876d1a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_32def75d-abae-4d71-b7f0-dfd5f1be68e4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_a209205f-c059-486e-b667-16cf5fed8f6b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_0c756ed3-871b-4eb0-a5dd-85803905d8d2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_ef0c194d-1757-4a9d-ab69-fa143dce39c5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_c2003870-b768-41db-b10c-f38fe3bdd664.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_f8a166ea-d07d-4115-86c5-286f5e2b63bd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_994c0f32-f4ec-4eaf-be5a-1a0cb018e9d1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_e080ac44-6efc-4c92-9e8f-ddc1b2143dc8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_a454158e-094f-456c-85b1-a393f571c8bd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_c84692a4-4a4c-4d90-8fbd-484910c4be58.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_e8e9e549-1239-4fc0-ae31-d5b53eb72265.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_48dd26f7-58b1-491f-ab33-b7a5a9f62447.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_2feebb20-cfa0-48ec-a378-46c9e504ada0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_5ee243ec-e835-42ee-b373-3480e9e2e080.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_f43ea1ec-6fcf-48fc-9bfc-46ce4a3bb61e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_3afe8aff-5381-41f4-b1bb-f128fc0c9d72.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_16912443-4213-41fa-a7d4-1d1fa4a60e2b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_31cda59a-8823-4c92-b1f0-f3a39bfc64c6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/eacc5e2e-8734-4a6e-9f42-c38da8c3bf61_93de6df6-6b5b-4f2d-b3f5-5ec871718ce7.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_4c9dc891-0ac3-43dd-80c3-df2f7ec1610c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_04ceb2c4-8ca4-4673-be05-f7df56258ab4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_7f6d5fff-c961-4e3d-a456-62ce1c1a50b2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_50cabddd-23dd-4656-806f-2806c52e4c1e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_60b05ee7-8783-44b3-a54d-27d414ffea27.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_df89e7c5-54be-41b6-ad52-5dede469ea39.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_800705a6-8262-40da-b8da-1e8e9fca9fb0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_dd1e3917-1f5c-4661-a3e9-b0f47193c720.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_9867ab20-0cc1-46ed-8a18-e09ad3bf07be.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_31e986d3-b566-4b1d-84a5-bf029aec4ab7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_8fcbcc6c-f433-4d80-b9f1-3eac65ff2a9d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_52699f9a-771d-422d-ba95-0279f479e81e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_e6ed203d-87d0-4cf6-85a9-8e64e12c54b2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/b3626a2c-0540-49ee-99f8-17ffd811622e_acd5be7d-6988-4b5c-95c1-cb4fc94c5311.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 2,699"
+      "priceFormatted": "€ 2,295",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2295,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/seat-leon-1-4-tsi-reference-apk-12-2026-gasoline-black-eacc5e2e-8734-4a6e-9f42-c38da8c3bf61",
+    "url": "/offers/seat-ibiza-sc-1-2-club-gasoline-white-cat_ma64mo2006-b3626a2c-0540-49ee-99f8-17ffd811622e",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
       "make": "SEAT",
-      "model": "Leon",
-      "modelGroup": "Leon",
-      "variant": null,
-      "modelId": 15869,
-      "modelVersionInput": "1.4 TSI Reference *apk:12-2026*",
+      "model": "Ibiza",
+      "modelGroup": "Ibiza",
+      "variant": "Ibiza",
+      "motorTypeName": "1.2",
+      "modelId": 2006,
+      "modelVersionInput": "SC 1.2 Club",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "209,000 km"
+      "mileageInKm": "236,813 km",
+      "engineDisplacementInCCM": "1,198 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "8191 JH",
-      "city": "WAPENVELD",
-      "street": "Ir. R.R. van der Zeelaan 1"
+      "zip": "3812 RJ",
+      "city": "AMERSFOORT",
+      "street": "Uraniumweg 19"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "id": "48479913",
+      "id": "28190408",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/48479913-original-38ed75af-e6fa-4b4d-8c61-fe9124ce999d.jpg/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/28190408-original-bf3d1617-4b7c-4a0b-b0f8-5374df04b5c9.png/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Andreas Auto's",
-      "contactName": "Andreas Ilbrink",
+      "companyName": "Autohandel Honing",
+      "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=48479913",
-        "imprint": "https://www.autoscout24.com/dealerinfo/andreas-auto-s-wapenveld-8191-jh-1/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohandel-honing?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohandel-honing/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)338 - 081192",
+          "callTo": "+31338081192"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 49396366",
-          "callTo": "+31649396366"
+          "formattedNumber": "+31 (0)6 - 42724196",
+          "callTo": "+31642724196"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 49396366",
+          "formattedNumber": "+31 (0)6 - 42724196",
           "callTo": null
         }
       ]
@@ -5601,21 +7125,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "05-2009",
+      "firstRegistration": "05-2010",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.1729149269871625",
+      "imageContent": "no-placeholder|0.21908731687777605",
       "isSmyleEligible": "false",
-      "mileage": "209000",
-      "priceLabel": "good-price",
-      "price": "2699",
+      "mileage": "236813",
+      "priceLabel": "expensive",
+      "price": "2295",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:64, model_group_id:15869, variant_id:, generation_id:, motortype_id:850, trim_id:447];"
+      "modelTaxonomy": "[make_id:64, model_group_id:2006, variant_id:3199, generation_id:1195, motortype_id:4127, trim_id:480755];"
     },
-    "coverImageAttractiveness": 0.1729149269871625,
+    "coverImageAttractiveness": 0.21908731687777605,
     "vehicleDetails": [
       {
-        "data": "209,000 km",
-        "iconName": "mileage_road",
+        "data": "236,813 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -5624,7 +7148,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "05/2009",
+        "data": "05/2010",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -5634,16 +7158,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "92 kW (125 hp)",
+        "data": "44 kW (60 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "148 g/km (comb.)"
+      "128 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -5664,71 +7187,783 @@
     ]
   },
   {
-    "id": "88f765f6-493c-480d-9261-45e6058ef53b",
+    "id": "1df771d5-f974-4866-92c6-ab6d6260afc7",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "323731404"
+      "crossReferenceId": "50925508"
     },
-    "crossReferenceId": "323731404",
+    "crossReferenceId": "50925508",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_3a6ac62f-2a8f-451d-a09d-e435eda1ab8d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_ce6af7ae-5378-4b8f-b0e7-c65e2d005797.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_dfc3ee92-9090-4187-9bcb-24d49aff2e59.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_e6682fca-8aaf-4882-b1b9-23d90364161a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_f4c3a42c-e9e1-4b0f-bdc4-0eb632a42d85.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_ccc7b981-5ad6-42a4-8a1f-e8b96e4a7471.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_42836882-6822-418c-94fd-3b3f43be74b9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_0cebfdd8-53aa-47e9-b3f7-1e4ebab37bfe.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_ffdc5b24-7c07-4243-89e8-1f1b3286f9f2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_a393270c-f6a7-4ce3-999d-c8872184bfab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_9e35455a-b442-4d66-b910-781b9408926e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_5ab660a5-b4a5-4ca8-a3d2-f7b4debdf18c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_c70a83a0-46f9-43a2-aa68-cca739441680.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_39d0a358-e6cb-4bc2-b8e2-2ac60832d51d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_2ae14aa0-c05a-44d2-a0da-3c2ecf2b11dc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_89172981-07bd-4b22-9583-cef69aeacebb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_1d72b2e3-719e-4c47-b51a-e4d8f58dcee8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_bcdd668d-1401-4a21-939b-0a713e27da9c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_0731bec1-a98e-444b-9ac7-2a3b5b58ffa6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_fd008b73-29a5-412c-be7d-3b9663199dfa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_486f98ed-6089-4205-abac-6c1f88ff3f7a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_40be459b-d244-4464-a749-a76ce21001a3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/88f765f6-493c-480d-9261-45e6058ef53b_62a2094c-96b2-4df0-bff6-64f8bfdd0fbc.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_5d3e19ff-754b-4797-8c21-9c129eb6cf09.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_d91213d4-d516-426b-9f34-7d6a070e696d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_24cdb940-2e54-4de1-aa70-93cd18e2cab4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_cfe90fcc-59fe-4c39-af6d-ff848ab090bc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_680cf06a-c133-4719-ac16-7a6378277e8a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_80c2159f-44a4-40ae-b8c7-d0784416a855.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_c94b7110-71d2-4433-be94-4725ed51873d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_87a3d388-f7b7-4a2b-85d9-07aeb553e218.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_ba743bc9-e1ac-4d16-9776-88947c5950c4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_28406d14-f13c-4b45-a369-8401a265c812.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_c6f68d00-8fa6-4852-9b84-4e6466ddc3c0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_fc43a78b-ef6f-4a62-8f99-f39b6125d11a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_af5fe0fd-d475-4350-bf54-d6e92b79ca89.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_dd90a9c6-ab28-40a4-9272-795f99a24ce9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_47b325d7-525c-463c-85ea-4a45744ec0da.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_92a6989d-caaf-4a9b-89dd-de2bbc439720.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_49dfc062-bf73-4ac3-83c5-929d52289c88.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_f7dd37d0-a7fc-490f-bd36-0798d0e53bc6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_5bd5261a-cb17-431f-862d-321aedb5053a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/1df771d5-f974-4866-92c6-ab6d6260afc7_59f84646-fd8b-4cdd-9906-d9d5e9d75c1b.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 2,999"
+      "priceFormatted": "€ 2,995",
+      "suggestedRetailPrice": "€ 14,955",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2995,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/seat-ibiza-1-4-16v-25-edition-i-airco-cruise-nap-apk-1eeig-gasoline-red-88f765f6-493c-480d-9261-45e6058ef53b",
+    "url": "/offers/citroen-c3-1-0-vti-attraction-airco-th-gasoline-grey-cat_ma21mo18264-1df771d5-f974-4866-92c6-ab6d6260afc7",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "SEAT",
-      "model": "Ibiza",
-      "modelGroup": "Ibiza",
-      "variant": null,
-      "modelId": 2006,
-      "modelVersionInput": "1.4-16V 25 Edition I Airco/Cruise/Nap/Apk/1eEIG",
+      "make": "Citroen",
+      "model": "C3",
+      "modelGroup": "C3",
+      "variant": "C3",
+      "motorTypeName": "68",
+      "modelId": 18264,
+      "modelVersionInput": "1.0 VTi Attraction AIRCO TH",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "133,748 km"
+      "mileageInKm": "135,352 km",
+      "engineDisplacementInCCM": "999 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "7091 EP",
-      "city": "DINXPERLO",
-      "street": "Aaltenseweg 89"
+      "zip": "7821 AC",
+      "city": "EMMEN",
+      "street": "Kapitein Nemostraat 34"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "4514313",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/4514313-original-c3645a64-9d27-49dd-9139-57580c5003c3.JPG/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Dealerauto's Emmen",
+      "contactName": "Erwin Wind",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/dealerauto-s-emmen?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/dealerauto-s-emmen/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)524 - 788230",
+          "callTo": "+31524788230"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)591 - 633111",
+          "callTo": "+31591633111"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)591 - 633111",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "01-2014",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.17321967789579185",
+      "isSmyleEligible": "false",
+      "mileage": "135352",
+      "priceLabel": "good-price",
+      "price": "2995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:21, model_group_id:200303, variant_id:3409, generation_id:2126, motortype_id:1448, trim_id:480099];"
+    },
+    "coverImageAttractiveness": 0.17321967789579185,
+    "vehicleDetails": [
+      {
+        "data": "135,352 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "01/2014",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "50 kW (68 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "95 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "cb27c0bc-c670-4302-bac3-6ce13ed5b665",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "457634476"
+    },
+    "crossReferenceId": "457634476",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_9ba2f1a3-4c7c-4190-a5ee-d3a007f2d1eb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_85d427ea-425d-42e8-b56d-8f99adadcc7f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_ecf898d8-1682-4159-94db-c6ab7c84cd91.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_eed6b049-df3e-441a-a6d8-4efa8c9561d1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_877dff10-7bb7-4220-a0db-ba3db31b6cbf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_50745e4e-1b04-4de5-81f3-e6693e1ab602.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_56ba10dc-ac80-4b1b-b09a-47b000e026fc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_44789d49-6122-4670-887a-ffae97e355fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_e8452f53-bda9-4d51-9a89-09ca13ef5ac1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_aa0f5170-ac12-4ac5-a66e-c92419f87103.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_bc5d3e2c-a4d2-4f49-891c-fde2a3413c27.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cb27c0bc-c670-4302-bac3-6ce13ed5b665_ec75d984-11ca-4225-ab2e-cfe9ddc4f411.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 4,985",
+      "isVatLabelLegallyRequired": false,
+      "priceSuperscriptString": "1",
+      "priceRaw": 4985,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/hyundai-i10-select-5-tuerig-tuev-service-neu-gasoline-black-cat_ma33mo19123-cb27c0bc-c670-4302-bac3-6ce13ed5b665",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Hyundai",
+      "model": "i10",
+      "modelGroup": "i10",
+      "variant": null,
+      "motorTypeName": "1.0",
+      "modelId": 19123,
+      "modelVersionInput": "Select*5-türig*TÜV & SERVICE NEU*",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "119,000 km",
+      "engineDisplacementInCCM": "998 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "14480",
+      "city": "Potsdam",
+      "street": "Großbeerenstr.  215"
+    },
+    "ratings": {
+      "ratingsCount": 48,
+      "ratingsStars": 4.5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "22413943",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/22413943-original-67c22337-b735-482a-9c71-378b5e6f844f.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Zeitgeist Automobile GmbH",
+      "contactName": "Ulf Dannenmann",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/zeitgeist-automobile-gmbh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/zeitgeist-automobile-gmbh/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)331 - 23189247",
+          "callTo": "+4933123189247"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)163 - 7528788",
+          "callTo": "+491637528788"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+49 (0)163 - 7528788",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "01-2019",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.19510714389596306",
+      "isSmyleEligible": "false",
+      "mileage": "119000",
+      "priceLabel": "top-price",
+      "price": "4985",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19123, variant_id:, generation_id:1362, motortype_id:2243, trim_id:8068];"
+    },
+    "coverImageAttractiveness": 0.19510714389596306,
+    "vehicleDetails": [
+      {
+        "data": "119,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "01/2019",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "49 kW (67 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "5.1 l/100 km (comb.)",
+      "117 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "cdd19c4b-2baf-4823-bd32-fe2863f77a2d",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50364903"
+    },
+    "crossReferenceId": "50364903",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_e0812b96-4b86-4d12-9776-75a6c8c01f95.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_1e8e2aeb-e675-4d49-afce-1f92fe2a707c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_13b7a4be-b77b-4fc3-9e48-c44bfc7c3c4a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_6cbc0d2d-58cf-465e-aaaa-0a6af4ef0c09.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_74aaff90-bfdc-4d55-b6c9-30117309090a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_5108a8e9-20eb-456d-b8e9-c532dd2af2f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_8dfa9078-aac4-43f7-b9f6-7e066a24f65c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_0924fbb3-c421-4cbe-afe6-58c6640ea22a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_3155a1bd-73d5-47c7-844b-eeb04fcb4ea3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_f604872d-1826-43e8-be10-daa9ec67a8f8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_51f4d095-b7ad-46ba-a7df-b93ff27caa67.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_72197725-a7d0-4fa2-a7cd-ff258df3c9b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/cdd19c4b-2baf-4823-bd32-fe2863f77a2d_5f6cfcb5-63a8-43af-8723-3d28bfe26027.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,750",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1750,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/fiat-500-1-2-pop-airco-elekramen-inruilkoopie-gasoline-black-cat_ma28mo15160-cdd19c4b-2baf-4823-bd32-fe2863f77a2d",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Fiat",
+      "model": "500",
+      "modelGroup": "500",
+      "variant": "Hatchback",
+      "motorTypeName": "1.2",
+      "modelId": 15160,
+      "modelVersionInput": "1.2 Pop|AIRCO|ELEKRAMEN|INRUILKOOPIE",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "254,278 km",
+      "engineDisplacementInCCM": "1,242 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3812 RJ",
+      "city": "AMERSFOORT",
+      "street": "Uraniumweg 19"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "28190408",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/28190408-original-bf3d1617-4b7c-4a0b-b0f8-5374df04b5c9.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autohandel Honing",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autohandel-honing?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autohandel-honing/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)338 - 081192",
+          "callTo": "+31338081192"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 42724196",
+          "callTo": "+31642724196"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 42724196",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "10-2008",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.1437701850023657",
+      "isSmyleEligible": "false",
+      "mileage": "254278",
+      "priceLabel": "good-price",
+      "price": "1750",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:4199, generation_id:789, motortype_id:1763, trim_id:5960];"
+    },
+    "coverImageAttractiveness": 0.1437701850023657,
+    "vehicleDetails": [
+      {
+        "data": "254,278 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "10/2008",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "51 kW (69 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "722e6abd-76c1-4540-85db-936475caee1d",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "3209292"
+    },
+    "crossReferenceId": "3209292",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_dac23f51-1bf0-4c5e-aeb5-c49ee40e3f73.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_1eba82cf-8f14-4876-920e-b961cde85f53.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_70699b2b-f81c-4e6d-a8ae-9232f369b8c5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_88e0284e-1ca0-43b0-a295-cc8ac2a8ebb5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_5ecea28a-5495-4439-86ea-ef042426b3c5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_797d456b-2ae8-4452-b54b-4e0cbe21d800.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_d0210277-1074-44c4-9bcf-37a695ed6829.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_f35b2247-28d5-4a2e-8952-f551ecf8eb74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_f2ab5995-7f30-4f5e-9a8b-b07747da5e4d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_24810ad6-20bd-4cbb-8d0f-a0aada0087a4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_415c27c9-404d-43d3-9200-d930c3a6a3d3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_8156422d-68f4-4124-8b2f-55379f08f9a3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_d5d04b50-9f1f-4574-8b26-df18e3a42fd5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_e5af1aed-af22-4f33-9846-f79732a5c814.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_6c913bfa-e99d-4181-a236-9dd3c3ce2827.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_3abd662b-c757-4c4c-9811-64db20cc2a38.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_af726f42-6e3f-4289-a549-e85a00c7af0e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_9603669c-e900-4ea7-bcd2-4d0e13b7e82c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_3f90dccf-9a16-4051-9167-cc0d4aa2c770.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_9222ef04-ec42-4989-9f96-28cd7028f56f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_5b0140c0-8d50-4595-9c0c-359d000e804f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_0a0b487a-0cec-48d7-bf93-24b2ab8b9c2c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_9007b294-a63e-470a-bf6e-fe6967741c73.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/722e6abd-76c1-4540-85db-936475caee1d_85a5372a-4f73-424e-af9b-9a03ca3d72a2.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/hyundai-i10-i10-1-1-active-uitv-5-deurs-gasoline-grey-cat_ma33mo19123-722e6abd-76c1-4540-85db-936475caee1d",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Hyundai",
+      "model": "i10",
+      "modelGroup": "i10",
+      "variant": null,
+      "motorTypeName": "1.1",
+      "modelId": 19123,
+      "modelVersionInput": "i10 1.1 Active Uitv. 5-Deurs",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "116,377 km",
+      "engineDisplacementInCCM": "1,086 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "7482 DB",
+      "city": "HAAKSBERGEN",
+      "street": "Tolstraat 8b"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "culture": "nl-NL"
+      },
+      "id": "16338194",
+      "type": "Dealer",
+      "companyName": "Paul Wijlens Automobielen",
+      "contactName": "P. Wijlens",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/paul-wijlens-automobielen?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/paul-wijlens-automobielen/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)53 - 5722615",
+          "callTo": "+31535722615"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 54311322",
+          "callTo": "+31654311322"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "06-2009",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.17564324578718415",
+      "isSmyleEligible": "false",
+      "mileage": "116377",
+      "priceLabel": "top-price",
+      "price": "1950",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19123, variant_id:, generation_id:917, motortype_id:2245, trim_id:480305];"
+    },
+    "coverImageAttractiveness": 0.17564324578718415,
+    "vehicleDetails": [
+      {
+        "data": "116,377 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "06/2009",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "49 kW (67 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "6f2872d9-aa1b-4fbd-8e43-833da46a56c3",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51068048"
+    },
+    "crossReferenceId": "51068048",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_40b2e7d4-006b-4dc4-bdd3-2cefd29bf60d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_c4498b5d-a303-46fc-860a-4592ffdf4315.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_9786bb7d-cd88-41fc-bcad-5d4a2903b957.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_503d5757-f90e-473d-9497-090fac366dc5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_25a0f2a3-9bb2-417c-b5a3-04756939e230.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_f4ddfd44-8daa-4973-93bf-dc6f51f38682.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_71b5b048-e963-417d-b6b7-cc27d64627f8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_18a856c4-61f8-4e31-bbab-60efbc596b45.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_1d1e58c6-da99-4118-a1fb-f66c505fcd7d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_24a58827-01f3-4ff6-8245-fd428f3ecdf3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_ddc5b953-4103-4dfa-abfa-d7af7f904619.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_e2e2e044-59df-48ce-8aa2-7b5276994e9b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_79b64a1b-d0c2-4ed9-a4d2-bfdaeb2651d1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_6b0b66f7-26bc-46ab-9c35-ba5080fe2bc3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_1206fbbd-69a8-4b30-83b5-741e74b8df63.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_b02d9042-5f00-4944-8acb-4d3b1398c9cb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_c559ebbd-b6b9-4f07-9af5-27dc8a80dc7f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_faaf5913-343f-4ed5-95e6-aebdd15e7690.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_b519b54c-0bba-4c82-a16e-f1885599b7b5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_e38beec5-0ef9-447b-876f-531c968114db.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_0136710b-ec25-4232-9bb9-b42112587960.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6f2872d9-aa1b-4fbd-8e43-833da46a56c3_efe21d9e-6afe-48cb-b118-999f616f465b.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,950",
+      "suggestedRetailPrice": "€ 16,741",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/opel-corsa-1-2-16v-cosmo-airco-cruise-camera-nap-apk-gasoline-brown-cat_ma54mo1918-6f2872d9-aa1b-4fbd-8e43-833da46a56c3",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Opel",
+      "model": "Corsa",
+      "modelGroup": "Corsa",
+      "variant": "Corsa",
+      "motorTypeName": "1.2",
+      "modelId": 1918,
+      "modelVersionInput": "1.2-16V Cosmo AIRCO/CRUISE/CAMERA/NAP/APK",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "131,482 km",
+      "engineDisplacementInCCM": "1,229 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "7091 ZZ",
+      "city": "DINXPERLO",
+      "street": "Meniststraat 1a"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
       "id": "46122556",
       "type": "Dealer",
@@ -5740,10 +7975,15 @@
       "companyName": "Taeke Automotive",
       "contactName": "Taeke Lammers",
       "links": {
-        "infoPage": "/lst?atype=C&cid=46122556",
+        "infoPage": "https://www.autoscout24.com/dealerinfo/taeke-automotive?atype=C",
         "imprint": "https://www.autoscout24.com/dealerinfo/taeke-automotive/imprint"
       },
       "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)314 - 788521",
+          "callTo": "+31314788521"
+        },
         {
           "phoneType": "Mobile",
           "formattedNumber": "+31 (0)6 - 17478496",
@@ -5766,21 +8006,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "11-2008",
+      "firstRegistration": "05-2011",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.20756132489077306",
+      "imageContent": "no-placeholder|0.15179868478172542",
       "isSmyleEligible": "false",
-      "mileage": "133748",
-      "priceLabel": "top-price",
-      "price": "2999",
+      "mileage": "131482",
+      "priceLabel": "fair-price",
+      "price": "3950",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:64, model_group_id:2006, variant_id:, generation_id:1195, motortype_id:4131, trim_id:2059];"
+      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:3184, generation_id:264, motortype_id:625, trim_id:4588];"
     },
-    "coverImageAttractiveness": 0.20756132489077306,
+    "coverImageAttractiveness": 0.15179868478172542,
     "vehicleDetails": [
       {
-        "data": "133,748 km",
-        "iconName": "mileage_road",
+        "data": "131,482 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -5789,7 +8029,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "11/2008",
+        "data": "05/2011",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -5806,9 +8046,8 @@
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "149 g/km (comb.)"
+      "124 g/km (comb.)"
     ],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -5829,85 +8068,1560 @@
     ]
   },
   {
-    "id": "e9a8d0c8-8e7e-48e8-8671-9ff14b82879a",
+    "id": "23a01b40-400d-487e-8d1f-e80875c49e38",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "321093258"
+      "crossReferenceId": "461954557"
     },
-    "crossReferenceId": "321093258",
+    "crossReferenceId": "461954557",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_c1206d85-9a4e-465a-b350-71d176b2b147.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_467ad8da-9c00-4ea9-a546-66caa0f06a14.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_843eda0b-909c-44dd-a008-6e6957c51cda.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_d2b2036a-7d9d-40cf-a455-d0b4a9ee1308.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_7fa4d6d8-657a-4d45-81a7-85322dd1c32b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_c4bff592-2a5f-4642-acbe-d9d6859614cb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_41caf2dc-715a-4490-97ab-eb893d999c9a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_b08c363b-de68-476d-bb31-4979d43a8e13.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_5d8b14cd-6a3d-4ff6-a240-7ff63c639659.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_07ccf031-9945-48ff-a3c3-40a6ae85cd55.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_5cc0d5af-3a44-48b3-bb7e-2674371f29d1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_42ef4f13-0778-4058-9a64-e4baac0b661e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/e9a8d0c8-8e7e-48e8-8671-9ff14b82879a_763e749a-ab9d-4036-b964-0109292c29d0.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_e4a43dde-3ba0-4405-92ea-7067eb6c6991.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_94654d30-fc3f-428b-9a00-0cdb9b1fd201.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_bc638c6a-e296-4411-9e71-862611e2fd9f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_f878e671-df00-4d40-b31d-a1ba119e82d7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_04e51da6-7bb2-4a15-b553-38f43799b01a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_ddb561f1-f376-467f-84e9-1e38e7947e93.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_fe18e42f-5a12-418d-8d34-3b370bd33373.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_b36e2853-02de-41d5-8595-c097b0bb2f5d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_4c3689fb-3574-486d-ba79-34f35c69cdc2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_35e2fe98-7539-464e-8352-8ff08673f6fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_863ae0cf-46ad-4363-b610-89054f55c3b3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/23a01b40-400d-487e-8d1f-e80875c49e38_ce738e29-ce6d-4ddb-a5d8-131751330f34.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 1,945"
+      "priceFormatted": "€ 3,299",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3299,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/peugeot-207-1-6-vti-look-cruise-airco-5-drs-gasoline-grey-e9a8d0c8-8e7e-48e8-8671-9ff14b82879a",
+    "url": "/offers/renault-twingo-1-2-lev-16v-liberty-gasoline-white-cat_ma60mo1979-23a01b40-400d-487e-8d1f-e80875c49e38",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Peugeot",
-      "model": "207",
-      "modelGroup": "207",
-      "variant": "SW",
-      "modelId": 18797,
-      "modelVersionInput": "1.6 VTi Look | Cruise | Airco | 5 drs |",
+      "make": "Renault",
+      "model": "Twingo",
+      "modelGroup": "Twingo",
+      "variant": "Twingo",
+      "motorTypeName": "1.2",
+      "modelId": 1979,
+      "modelVersionInput": "1.2 LEV 16V Liberty",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "205,887 km"
+      "mileageInKm": "103,400 km",
+      "engineDisplacementInCCM": "1,149 cc",
+      "isCurrentlyDamaged": false
     },
     "location": {
-      "countryCode": "NL",
-      "zip": "3781 VM",
-      "city": "VOORTHUIZEN",
-      "street": "Rubensstraat 38"
+      "countryCode": "DE",
+      "zip": "65187",
+      "city": "Wiesbaden",
+      "street": "Mainzer Straße 161"
     },
     "seller": {
       "dealer": {
-        "isFreespeeCallTrackingEnabled": true
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
       },
-      "id": "33561881",
+      "id": "62143682",
       "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/33561881-original-cbcfba89-485b-4913-9e58-058f36b04106.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "HVM Nederland",
-      "contactName": "Sil van den Dool",
+      "companyName": "Elhajj Kfz-Handel",
+      "contactName": "Eid El Hajj",
       "links": {
-        "infoPage": "/lst?atype=C&cid=33561881",
-        "imprint": "https://www.autoscout24.com/dealerinfo/hvm-nederland/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/elhajj-kfz-handel-wiesbaden-65187-1?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/elhajj-kfz-handel-wiesbaden-65187-1/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)611 - 9501890600",
+          "callTo": "+496119501890600"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 83250853",
-          "callTo": "+31683250853"
+          "formattedNumber": "+49 (0)171 - 6851794",
+          "callTo": "+491716851794"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 83250853",
+          "formattedNumber": "+49 (0)171 - 6851794",
           "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "08-2013",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.39912024797091195",
+      "isSmyleEligible": "false",
+      "mileage": "103400",
+      "priceLabel": "top-price",
+      "price": "3299",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:60, model_group_id:201268, variant_id:3654, generation_id:1176, motortype_id:5133, trim_id:4903];"
+    },
+    "coverImageAttractiveness": 0.39912024797091195,
+    "vehicleDetails": [
+      {
+        "data": "103,400 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "08/2013",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "55 kW (75 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "5.1 l/100 km (comb.)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "a578aed7-87ab-4ef1-95a1-51adcdeabe96",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "47653761"
+    },
+    "crossReferenceId": "47653761",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_65e0e9b3-7926-4bd1-9d3f-f1c39e7a155a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_9fc6a7c8-b64a-4f6e-b8bb-f276416f012d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_5c61724c-3bda-4f46-8354-9d92d8f658d8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_e777be0f-8949-459b-94a7-121f9c533b54.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_a99ab79e-0287-483e-b498-351e796a616b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_0265e56a-f125-44db-a549-0e121b26f75a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_d87be190-10da-46df-b42a-46b28ed0e4a1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_68fd0f96-c42b-4978-9f70-0298ac73c8cc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_a7025655-90c5-46f8-b5bd-f96ccd1439b8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_fdaccdaa-5618-4891-97ca-f442dc0eee11.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_24851ff0-c103-44a3-a529-a1b4d7b7f84c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_5489e18e-fd0e-4b5b-8754-bd0c62c59a51.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_dec0654d-2d84-40dd-aa41-094649079178.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_f3ed9be6-ea46-449d-8875-d443ddf66864.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_88df0c1a-3387-498b-a286-5956c6327688.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_4bd07a5e-7058-4db9-91fa-b321243308dc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_901306bb-f735-45f9-b27c-0a2b005317d5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_5888d4b1-3dc9-4dee-96a6-12fb2ca543f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_e306d464-bcdc-4153-aa03-df41a9cb4e10.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_92385449-84f8-47aa-82fa-44c311e22a78.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_af48beb2-7dc8-484b-839d-32a14aba7bf5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_ba96d740-727f-4b7e-bdb6-91ea17f39bae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_2b8a5767-9658-4b25-9185-acd28aaadf18.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_7d75d0f6-9439-4fdf-8462-3aa1a2c442b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_24de459b-497e-4bf8-9ac6-b0039c38ba49.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_060e76f4-a8e3-4e14-b263-e4e521e2fb7e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_25ff1f66-d915-462c-89e3-b7450fbb40cd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_bd29c896-ab84-495e-9e67-a6f4afcee573.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_0dcff02d-c14e-447a-9fc4-b9b57015e681.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/a578aed7-87ab-4ef1-95a1-51adcdeabe96_1c09e2bb-3836-4556-abf6-0a0350fd2908.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 5,995",
+      "suggestedRetailPrice": "€ 24,898",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 5995,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/opel-astra-1-0-turbo-120-jaar-edition-motor-probleem-gasoline-blue-cat_ma54mo1916-a578aed7-87ab-4ef1-95a1-51adcdeabe96",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Opel",
+      "model": "Astra",
+      "modelGroup": "Astra",
+      "variant": "Astra Sports Tourer",
+      "motorTypeName": "1.0 ECOTEC DI Turbo",
+      "modelId": 1916,
+      "modelVersionInput": "1.0 Turbo 120 Jaar Edition (motor probleem)",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "140,223 km",
+      "engineDisplacementInCCM": "999 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "8345 HJ",
+      "city": "KALLENKOTE",
+      "street": "Kallenkote 82"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "17912423",
+      "type": "Dealer",
+      "companyName": "Automobielbedrijf Veld",
+      "contactName": "D. Veld",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/automobielbedrijf-veld/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728240",
+          "callTo": "+31527728240"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)521 - 513309",
+          "callTo": "+31521513309"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2019",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18984994208782457",
+      "isSmyleEligible": "false",
+      "mileage": "140223",
+      "priceLabel": "top-price",
+      "price": "5995",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:54, model_group_id:1916, variant_id:223, generation_id:225, motortype_id:569, trim_id:2755];"
+    },
+    "coverImageAttractiveness": 0.18984994208782457,
+    "vehicleDetails": [
+      {
+        "data": "140,223 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2019",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "77 kW (105 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "133 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "90fc97be-7d5e-4db9-aefd-066af680ae7c",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "40049833994368"
+    },
+    "crossReferenceId": "40049833994368",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_23cc7e1a-1afe-4499-83e5-2278b57b9203.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_edb98abf-2496-48c5-8950-360e29914623.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_0626569e-a424-4180-9c0d-acea5c9848f0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_26984484-0426-4211-8d8f-1d35f86e44f7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_700ee22e-4f5c-4739-a977-e194710a6b4d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_826a00eb-0354-40b9-99e0-237da2758e53.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_8ca64b4f-0963-4b9f-abc3-e5f198029232.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_6ba7cbbb-8b9a-4940-992a-d5fb497191df.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_3b672a32-7ae6-4ecd-a41a-df1f4f172c6d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_13357eae-00c7-43e2-bd84-4779032cea5c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_8d2b00a3-f639-4e33-85b1-a6e53bfe97e9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_90b2a09d-db59-40b7-a157-863c88e873de.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_58d7f0e1-ed50-4dc0-9613-0c3197232eb2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_00b746da-2fae-400c-aa6a-144d0bdd4833.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_3d9686ad-0007-43e6-8124-2bee51617e1f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_85711548-fb24-4b11-abd3-e66d5261f75f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_9fa390a2-fb29-4fa5-b2d8-84a117d5c7a1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_9bb378b5-b7b9-4cbb-a1e6-2c4b816f7292.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_ac3adf8b-eb7c-47ad-a904-eed20c16ec42.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_f3eca934-1416-4caa-be79-5d01190fc7ba.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_6ef15a22-abb1-4955-a380-6de92ba236f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_ec4edd07-12df-4ed9-9b7d-b4dcfb7d5140.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_6802a33d-8e50-447c-8424-69b73e25a1ae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_fd6c6b14-25fa-4924-a14e-091321bc3467.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_4a91a4f4-8676-49eb-bfd3-9de2b06305e6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_fad469ed-a450-46ba-8367-324797ee51e5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_a31cb6ab-3339-46e4-abf6-46d56a716a09.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_289869ff-848e-4e6b-9b31-4460982fa45f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_8f3ea6f7-2076-4fd3-9b9c-1e3443971146.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/90fc97be-7d5e-4db9-aefd-066af680ae7c_5f4850f7-6530-4d6c-ad55-fb598ce63b21.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 6,770",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 6770,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/peugeot-208-gti-garantie-gasoline-black-cat_ma55mo20057-90fc97be-7d5e-4db9-aefd-066af680ae7c",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Peugeot",
+      "model": "208",
+      "modelGroup": "208",
+      "variant": "208",
+      "motorTypeName": "GTI 200",
+      "modelId": 20057,
+      "modelVersionInput": "GTi  Garantie",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "120,000 km",
+      "engineDisplacementInCCM": "1,598 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "48653",
+      "city": "Coesfeld",
+      "street": "Borkener Str. 83"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "61169465",
+      "type": "Dealer",
+      "companyName": "Auto-Service Coesfeld GmbH",
+      "contactName": "Norbert Merschmöller",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/auto-service-coesfeld-gmbh-coesfeld-48653-3?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/auto-service-coesfeld-gmbh-coesfeld-48653-3/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)254 - 1740305600",
+          "callTo": "+492541740305600"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)2541 - 82770",
+          "callTo": "+49254182770"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Zero"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "01-2014",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.12985364456813786",
+      "isSmyleEligible": "false",
+      "mileage": "120000",
+      "priceLabel": "top-price",
+      "price": "6770",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:55, model_group_id:201150, variant_id:3624, generation_id:1074, motortype_id:3269, trim_id:480648];"
+    },
+    "coverImageAttractiveness": 0.12985364456813786,
+    "vehicleDetails": [
+      {
+        "data": "120,000 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "01/2014",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "147 kW (200 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "5.9 l/100 km (comb.)",
+      "140 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "588d5fba-99b7-4ace-ab33-158e04978d5e",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "51127570"
+    },
+    "crossReferenceId": "51127570",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_86db1c34-59ee-476b-8b69-e8a1580d7acc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_3b6d0f90-ff33-4f41-83a0-88ed572d626d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_c63914cd-2e9c-4473-a716-04f8715ea823.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_1686feb7-3e18-4d50-8937-26cc2c81ed98.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_13ba7510-260e-420b-9ff3-be5996b44e5b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_89d07641-109a-4862-bd20-8ada62fd2ac1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_4e048b1e-c4cf-4ef9-91a9-174490610e5f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_57f19749-0a04-4929-8380-a323f591de41.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_f31f7a33-41aa-4662-8397-de16b027f717.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_74fa5826-60c2-4aa7-aad1-01d25b485ac4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_d4a446ca-03fa-4715-b18a-3d788fcd02e1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_c913c339-a1b7-4cd1-9390-004e74f861dd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_7b9938ee-2da1-4e13-8c97-ef76811a6fa5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_0d406c33-7a6a-4049-b2a7-05e656b26e58.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/588d5fba-99b7-4ace-ab33-158e04978d5e_e9ab1447-7356-42cf-9805-df6df29878ae.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 1,244",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1244,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/hyundai-i10-1-1-active-cool-airco-nieuwe-apk-gasoline-red-cat_ma33mo19123-588d5fba-99b7-4ace-ab33-158e04978d5e",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Hyundai",
+      "model": "i10",
+      "modelGroup": "i10",
+      "variant": null,
+      "motorTypeName": "1.1",
+      "modelId": 19123,
+      "modelVersionInput": "1.1 Active Cool! Airco! Nieuwe APK!",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "183,434 km",
+      "engineDisplacementInCCM": "1,086 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "2461 LZ",
+      "city": "TER AAR",
+      "street": "Goudsmid 39"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "29358785",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/29358785-original-566ae1ee-6271-4ab1-a8ca-157b86b40982.PNG/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "AutoPlanner NL",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autoplanner-nl?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autoplanner-nl/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)172 - 788165",
+          "callTo": "+31172788165"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 81787861",
+          "callTo": "+31681787861"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 81787861",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Zero"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "05-2008",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2328105853379031",
+      "isSmyleEligible": "false",
+      "mileage": "183434",
+      "priceLabel": "toolow-price ",
+      "price": "1244",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:33, model_group_id:19123, variant_id:, generation_id:917, motortype_id:2245, trim_id:480305];"
+    },
+    "coverImageAttractiveness": 0.2328105853379031,
+    "vehicleDetails": [
+      {
+        "data": "183,434 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "05/2008",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "49 kW (67 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "6a72760e-558f-493e-9488-8c9d2ce9d274",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "47811843"
+    },
+    "crossReferenceId": "47811843",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_437647d0-e1f4-4d0e-97f2-4aa979456252.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_0149f841-a08a-4813-9864-9eae845777e5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_011625bc-a1ab-4bcc-84ea-31ede0ef74fe.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_638dbd27-759f-485b-b27b-6c9e8508df7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_9f3211cd-59e7-4758-bd40-f562c9012745.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_0808a321-ec31-483d-8f3e-9fedc05923a6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_b5ea73ad-0ef3-49b9-a58a-dc1c1f5acecf.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_74a59c54-02ad-462a-98f8-d2584d683a94.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_59261f76-0a32-48cf-8476-3661caaf0446.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_4d10e5d5-e623-4923-97e0-fc17ba6007d1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_ebf51f70-5214-46d4-8d25-51b2821f6f01.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_c14cf163-3250-47ed-bde6-953bdff01cad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_faea0c1b-ada7-4321-aa91-c80d59dfe145.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_1e87591a-665f-4072-9b8c-9514bbeb35e8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_93118b5d-d572-46d5-b211-b7e79ddb904d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_d048f509-6767-4107-a365-d431b8f1d8c7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_0824b142-7986-4047-a564-cebbdb1accf0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_059e8ad5-1833-475f-9172-204629b45c7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_2ece098d-8ad4-4762-9c79-e7b66835c46a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_9e55a44f-73b4-418c-9f46-5a0d84bbf830.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_9e013f36-641f-4a07-88e7-c22286d4788d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_022e0230-170b-4a70-bd03-8b2c306ace69.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_8809c845-9784-4a7d-a6e6-8ec746b2cf96.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_3c8e54d2-98ea-43ef-9d4d-8826ae15b29c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6a72760e-558f-493e-9488-8c9d2ce9d274_77a31694-2e4a-4bce-b512-64b702dbaaab.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,449",
+      "suggestedRetailPrice": "€ 16,979",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3449,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/volkswagen-polo-1-4-16v-comfortline-clima-cruise-gasoline-black-cat_ma74mo2090-6a72760e-558f-493e-9488-8c9d2ce9d274",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Volkswagen",
+      "model": "Polo",
+      "modelGroup": "Polo",
+      "variant": "Hatchback 5-Door",
+      "motorTypeName": "1.4",
+      "modelId": 2090,
+      "modelVersionInput": "1.4-16V Comfortline. Clima. Cruise!",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "228,535 km",
+      "engineDisplacementInCCM": "1,390 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "3771 AG",
+      "city": "BARNEVELD",
+      "street": "Wattstraat 13"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "11076",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/11076-original-adb93227-4d1f-46b2-9ac6-61375ae6206a.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Auto Valk",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/auto-valk-barneveld?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/auto-valk-barneveld/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)308 - 083806",
+          "callTo": "+31308083806"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)342 - 450306",
+          "callTo": "+31342450306"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 15432912",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "02-2012",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.16408128457619875",
+      "isSmyleEligible": "false",
+      "mileage": "228535",
+      "priceLabel": "top-price",
+      "price": "3449",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:3919, generation_id:175, motortype_id:275, trim_id:217];"
+    },
+    "coverImageAttractiveness": 0.16408128457619875,
+    "vehicleDetails": [
+      {
+        "data": "228,535 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "02/2012",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "63 kW (86 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "139 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "2eb671ba-15eb-48a2-a38c-7d6d31703083",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50921501"
+    },
+    "crossReferenceId": "50921501",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_0c3bcea2-b26a-4e3c-a3b3-0392af2edc73.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_294430bc-ecd4-4d9d-bb6d-fdb1623ae76e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_2427a2fa-eb0b-48f5-aba3-d2a35ef5b2c2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_6d8f268d-f694-4626-95df-14aeb6322fcd.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_1ac1e56b-ae5e-45cd-8204-ea2f2a22de35.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_afd9bfcc-1c70-4c01-90db-a599c3f6ccef.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_c5145594-2449-48ec-ab27-81987ea9068a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_c81c3c9e-4627-4e11-9394-57c85847eb50.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_900f74ae-1268-487b-a420-995ff26c4c5f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_3ed5722e-a93f-418d-8cb6-abf25765cbeb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_b636eecf-6af6-4845-a01f-352ea776cee1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_9fd4186b-1673-4ff4-9b49-ae90bcbcd5f1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_d4b121be-238f-4710-ba30-c171ef3b563b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_2f11d66d-48bd-4634-9584-a8c63463b7d9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_fc85c056-d6d2-40cb-974f-f12dd2ebd827.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_5c7f09b0-a474-4bcc-8244-c93fdafd677b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_fcc94e6f-1805-43ce-bfda-b6882e468035.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_7dd95e4c-d60c-44ca-b754-f1a07964a4fc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_b9fe0aed-5e56-44f6-969b-171232ae09e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_48a1a516-37e8-4582-9c85-b83243778ef6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_920f307f-edb8-450a-a926-a106df610d6c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_41fcfcec-d625-426f-9673-2331d8b5f420.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_39bc28f4-34aa-4d0c-b5b3-ea3bec64cb5b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_2a2ea2c6-b502-49d9-b311-423c8dec32ad.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_fd20c145-a081-4af7-b072-a034abc3261f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/2eb671ba-15eb-48a2-a38c-7d6d31703083_71bb0ed1-ae72-442b-956e-6b6ee03185f8.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 3,950",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 3950,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/seat-leon-1-4-tsi-reference-clima-xenon-led-stoelverwarming-gasoline-black-cat_ma64mo15869-2eb671ba-15eb-48a2-a38c-7d6d31703083",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "SEAT",
+      "model": "Leon",
+      "modelGroup": "Leon",
+      "variant": "Leon",
+      "motorTypeName": "1.4 TSI",
+      "modelId": 15869,
+      "modelVersionInput": "1.4 TSI Reference Clima Xenon/Led Stoelverwarming",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "170,111 km",
+      "engineDisplacementInCCM": "1,390 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "2521 RL",
+      "city": "DEN HAAG",
+      "street": "Neherkade 2030"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "15875673",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/15875673-original-a0b87bd3-7dde-484a-9ed6-2675b67848f5.jpeg/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Autostad Den Haag",
+      "contactName": "Afdeling Verkoop",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autostad-den-haag?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autostad-den-haag/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)708 - 080786",
+          "callTo": "+31708080786"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 11114523",
+          "callTo": "+31611114523"
+        },
+        {
+          "phoneType": "Whatsapp",
+          "formattedNumber": "+31 (0)6 - 11114523",
+          "callTo": null
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "07-2009",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.18609883915577974",
+      "isSmyleEligible": "false",
+      "mileage": "170111",
+      "priceLabel": "somewhat-expensive",
+      "price": "3950",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:64, model_group_id:15869, variant_id:3217, generation_id:492, motortype_id:850, trim_id:447];"
+    },
+    "coverImageAttractiveness": 0.18609883915577974,
+    "vehicleDetails": [
+      {
+        "data": "170,111 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "07/2009",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "92 kW (125 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "- (l/100 km)",
+      "148 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "477adf39-3050-4b46-951b-db9b3a74bbcf",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "40789765544704"
+    },
+    "crossReferenceId": "40789765544704",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_bfa02c87-911f-4110-aec1-57a45ff85cb9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_a7a8760c-f94a-4ad9-a953-6e66535345af.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_0b5243d3-5b4e-4def-9e6d-b2810f26f469.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_a47b18e0-fe96-4ed2-90ba-43f7190d0a40.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_aaf668dd-0d20-439d-89f3-509008b70823.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_2b251e3f-fa50-4518-a35b-fb0b735ef1a2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_4da1014d-2059-4f7d-8675-d0be33f717f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_cfae0a0d-cc68-43f6-a737-e41cf6787ba2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_30fa412e-359b-4af8-b79a-4fe13ec26978.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_e969711c-7f2a-4d4f-a267-17cec81a3200.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_dd6e364d-db41-4704-9e79-90997b1b0870.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_f140c427-7506-464c-abff-96e3f1ece3cc.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_482964fd-41ee-43c7-b46d-02b165641384.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_e5bdc8dd-2c56-4aa8-8bc8-01828cebaf6b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_bbbf8213-598d-4c1b-8744-94fd439c78a6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_62b48340-e904-4a85-b671-b34e6e903bd9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_ab250114-e0f7-4b4b-a0f9-8023da88e869.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_aca3a95b-978e-479e-bad0-421f1cbfeb6f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_a7688dbb-565e-44b2-9912-094628f00591.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_b09a0cec-d063-491f-b980-83f7ad21a58a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_a6ef3391-f4b4-4355-a394-8cdfc91a2287.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_b5e7a246-5fb3-4238-a1cb-88ef84d70d74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_fb0cb6bd-6466-43dc-8a6d-16d724b60341.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_175642c1-544e-4a1d-a3a2-f140daf8d827.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_3c43b4de-5af7-412e-8b60-6e2797d6eb95.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_d340f9e7-e939-4224-81c9-a229a88e881e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_9cf7979c-0ebd-4f37-bcf7-602ec1c6bfb0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_b68b913c-28a8-4400-9e00-88078acd28a9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_4e88c799-8cd2-4b6f-b6eb-fec03c4d8d1f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_9900b50e-9dd7-426c-81eb-6071eab3c7a2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/477adf39-3050-4b46-951b-db9b3a74bbcf_120f9795-0b7f-407e-a6d7-b96c86112a78.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "isOfferNew": true,
+    "price": {
+      "priceFormatted": "€ 2,990",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 2990,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/smart-fortwo-coupe-basis-45-kw-klima-radio-leder-gasoline-black-cat_ma15525mo18439-477adf39-3050-4b46-951b-db9b3a74bbcf",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "smart",
+      "model": "forTwo",
+      "modelGroup": "fortwo",
+      "variant": "Coupe",
+      "motorTypeName": null,
+      "modelId": 18439,
+      "modelVersionInput": "coupe Basis 45 Kw Klima Radio Leder",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Automatic",
+      "fuel": "Gasoline",
+      "mileageInKm": "94,700 km",
+      "engineDisplacementInCCM": "698 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "47506",
+      "city": "Neukirchen-Vluyn",
+      "street": "Weserstr. 3"
+    },
+    "ratings": {
+      "ratingsCount": 196,
+      "ratingsStars": 5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "16090210",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/16090210-original-50aa08de-31ed-48b9-8a43-12dfda73959a/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "Carpoint GmbH",
+      "contactName": "Maik Jung",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/carpoint-gmbh?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/carpoint-gmbh/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)284 - 53954859",
+          "callTo": "+4928453954859"
+        },
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)2845 - 9802860",
+          "callTo": "+4928459802860"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)178 - 1394549",
+          "callTo": "+491781394549"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "03-2003",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.22281444197215627",
+      "isSmyleEligible": "false",
+      "mileage": "94700",
+      "priceLabel": "somewhat-expensive",
+      "price": "2990",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:15525, model_group_id:201362, variant_id:1994, generation_id:1521, motortype_id:, trim_id:480953];"
+    },
+    "coverImageAttractiveness": 0.22281444197215627,
+    "vehicleDetails": [
+      {
+        "data": "94,700 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Automatic",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "03/2003",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "45 kW (61 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "5.3 l/100 km (comb.)",
+      "127 g/km (comb.)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "6569937a-4a46-440c-9129-4f3eec27a03e",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "39965540567456"
+    },
+    "crossReferenceId": "39965540567456",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_580fef8f-198b-4af1-8f32-8e799ae3fd42.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_72e2ed56-4b10-47d5-9e9a-a69505477722.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_0251189e-0f57-4e64-b481-4a15abdb5951.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_13dcfcb7-28eb-42be-a4c5-0b26c5c2f68a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_de1ef6fb-174b-4fd3-b482-30bcd7fe54b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_a5dcd324-69fe-45e0-b1c0-e7ff698a4baa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_c521b36c-7c00-489f-ae33-5d6023b978ec.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_cc6056f8-422a-460b-b26f-b4e6a16d4421.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_42575e8c-723a-4e05-9dea-e2fb299262c0.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_34ccce67-c9d5-4cc1-8ae4-2e4d8d28aeda.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_c19def43-a550-466b-963b-3e07a74e381f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_2c75dc3c-bfd1-47a2-8348-930cfc50cbf3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_bc919c97-033c-4619-b1a7-336f6e2c80f2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_4860438e-e09d-4c71-9d95-306fb6e89e7e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_952f98b8-58cb-460f-b14d-4bfe25a33608.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_2259665c-07ab-4571-8c40-de888242863a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_be919061-aae4-455a-b067-3ae945ab274f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_e783051c-7ec7-4a2e-934b-2fc6d15b3196.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_441cdec2-454a-46bd-b8ee-e1eaf3dd3bbe.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_df8dcb49-7409-4617-8f1c-2cd86588cdff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_350c966e-1639-48cd-8367-e15910f2a23b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_2a8aaf2b-f3c2-4999-b96e-6d394508cb2e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_c0bab01a-0771-4752-979f-051966737bb8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_c90e37e7-2cce-494f-984b-5312e95c3888.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_5a8d9cfe-728c-4454-b03c-764b0a81d612.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_99ddadec-e01f-47d0-a854-19e49d36496a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/6569937a-4a46-440c-9129-4f3eec27a03e_4c57779e-7060-4560-8c28-6c3e25de057d.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 8,750",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 8750,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/citroen-ds3-puretech-82-so-chic-carplay-navi-led-kamera-gasoline-blue-cat_ma21mo19523-6569937a-4a46-440c-9129-4f3eec27a03e",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Citroen",
+      "model": "DS3",
+      "modelGroup": "DS 3",
+      "variant": "DS 3",
+      "motorTypeName": "82",
+      "modelId": 19523,
+      "modelVersionInput": "PureTech 82 So Chic CARPLAY NAVI LED KAMERA",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "37,738 km",
+      "engineDisplacementInCCM": "1,199 cc",
+      "isCurrentlyDamaged": false
+    },
+    "location": {
+      "countryCode": "DE",
+      "zip": "42551",
+      "city": "Velbert",
+      "street": "Pfeilstraße 30"
+    },
+    "ratings": {
+      "ratingsCount": 1,
+      "ratingsStars": 5,
+      "ratingsEnabled": true
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "62176047",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/62176047-original-cab184e6-b466-4cf2-9dac-8495f144b96c.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "AutoHeuser",
+      "contactName": "Jan Heuser",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autoheuser?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autoheuser/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+49 (0)205 - 1423568300",
+          "callTo": "+492051423568300"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)1522 - 6393088",
+          "callTo": "+4915226393088"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+49 (0)178 - 9214003",
+          "callTo": "+491789214003"
+        }
+      ]
+    },
+    "appliedAdTier": "T50",
+    "adTier": "T50",
+    "isOcs": false,
+    "specialConditions": [],
+    "statistics": {
+      "leadsRange": "Some"
+    },
+    "searchResultType": "Organic",
+    "searchResultSection": "Main",
+    "tracking": {
+      "firstRegistration": "01-2017",
+      "fuelType": "b",
+      "imageContent": "no-placeholder|0.2626671587238507",
+      "isSmyleEligible": "false",
+      "mileage": "37738",
+      "priceLabel": "top-price",
+      "price": "8750",
+      "orderBucket": "unknown",
+      "modelTaxonomy": "[make_id:21, model_group_id:200313, variant_id:3419, generation_id:2150, motortype_id:1584, trim_id:1846];"
+    },
+    "coverImageAttractiveness": 0.2626671587238507,
+    "vehicleDetails": [
+      {
+        "data": "37,738 km",
+        "iconName": "mileage_odometer",
+        "ariaLabel": "Mileage"
+      },
+      {
+        "data": "Manual",
+        "iconName": "gearbox",
+        "ariaLabel": "Gear"
+      },
+      {
+        "data": "01/2017",
+        "iconName": "calendar",
+        "ariaLabel": "First registration"
+      },
+      {
+        "data": "Gasoline",
+        "iconName": "gas_pump",
+        "ariaLabel": "Fuel type"
+      },
+      {
+        "data": "60 kW (82 hp)",
+        "iconName": "speedometer",
+        "ariaLabel": "Power"
+      }
+    ],
+    "wltpValues": [
+      "4.6 l/100 km (comb.)",
+      "- (g/km)"
+    ],
+    "trackingParameters": [
+      {
+        "key": "boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "applied_boost_level",
+        "value": "t50"
+      },
+      {
+        "key": "relevance_adjustment",
+        "value": "boost"
+      },
+      {
+        "key": "boosting_product",
+        "value": "mia"
+      }
+    ]
+  },
+  {
+    "id": "62cbcf52-0c69-46ba-ae2b-3df6a84b5149",
+    "identifier": {
+      "legacyId": null,
+      "crossReferenceId": "50366182"
+    },
+    "crossReferenceId": "50366182",
+    "images": [
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_f260468e-2101-4963-a6e7-b6ca99cb3818.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_d36c87d2-3054-4aeb-aa4f-d4115806a9c8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_9c5578fd-963d-492b-8db0-eeb30caa4eb8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_316fdf47-4cb8-4155-b8ce-6f9678383b4e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_81382630-9117-4080-aeb5-dacace8736d7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_875e9da9-db23-43ad-a606-3add91ddbabb.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_58b45ef7-f7df-44a7-b528-e1e409091125.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_24f9658f-0a07-45a1-868f-69bbd99fc2f8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_3465d2b2-727d-4ab0-8233-eeab51a4cb15.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_0cbbab15-852d-4e70-b053-a7351a99743b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_dfb6a220-d3f5-4eae-8ecd-13040cbbc993.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_86891d0d-397e-4117-bc82-7544d898a560.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_486bda6b-9656-489c-abd6-7abf424c4948.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_b93a28a3-9b20-40a2-a61f-bf250bfedaa3.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_5afdbabb-aaf3-452d-850d-de52e26157f4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_f99a58b6-64bd-478b-b394-3bb2af6fd579.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_5798ea10-ca72-495e-a502-2ffd9b8a3834.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_d758936a-492b-4543-baef-1129600ca559.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/62cbcf52-0c69-46ba-ae2b-3df6a84b5149_9064f3ac-125b-448d-9238-569636f7daf5.jpg/250x188.webp"
+    ],
+    "ocsImagesA": [],
+    "price": {
+      "priceFormatted": "€ 1,500",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1500,
+      "isConditionalPrice": false
+    },
+    "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
+    "superDeal": {
+      "oldPriceFormatted": "",
+      "isEligible": false
+    },
+    "url": "/offers/ford-ka-ka+-1-2-trend-apk-03-27-nap-kilometerstand-3-deur-gasoline-black-cat_ma29mo1761-62cbcf52-0c69-46ba-ae2b-3df6a84b5149",
+    "vehicle": {
+      "articleType": "Car",
+      "type": "Car",
+      "make": "Ford",
+      "model": "Ka/Ka+",
+      "modelGroup": "Ka/Ka+",
+      "variant": "Ka",
+      "motorTypeName": "1.2",
+      "modelId": 1761,
+      "modelVersionInput": "1.2 Trend | Apk 03-27 | NAP kilometerstand| 3 Deur",
+      "modelVersionCustom": null,
+      "subtitle": null,
+      "offerType": "U",
+      "transmission": "Manual",
+      "fuel": "Gasoline",
+      "mileageInKm": "141,231 km",
+      "engineDisplacementInCCM": "1,242 cc"
+    },
+    "location": {
+      "countryCode": "NL",
+      "zip": "2465 AA",
+      "city": "RIJNSATERWOUDE",
+      "street": "Herenweg 11"
+    },
+    "seller": {
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
+      },
+      "id": "47198218",
+      "type": "Dealer",
+      "logo": {
+        "small": {
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/47198218-original-ade1cf35-45be-40c3-a873-55799e4a0a7f.png/resize/100x50%3E/quality/90"
+        }
+      },
+      "companyName": "EV Car Company",
+      "contactName": "Rick Brasser",
+      "links": {
+        "infoPage": "https://www.autoscout24.com/dealerinfo/ev-car-company?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/ev-car-company/imprint"
+      },
+      "phones": [
+        {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)172 - 788336",
+          "callTo": "+31172788336"
+        },
+        {
+          "phoneType": "Mobile",
+          "formattedNumber": "+31 (0)6 - 20094235",
+          "callTo": "+31620094235"
         }
       ]
     },
@@ -5923,19 +9637,19 @@
     "tracking": {
       "firstRegistration": "03-2009",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.19866658727263975",
+      "imageContent": "no-placeholder|0.20372734525906677",
       "isSmyleEligible": "false",
-      "mileage": "205887",
-      "priceLabel": "unknown",
-      "price": "1945",
+      "mileage": "141231",
+      "priceLabel": "toolow-price ",
+      "price": "1500",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:55, model_group_id:201153, variant_id:1726, generation_id:1072, motortype_id:3242, trim_id:];"
+      "modelTaxonomy": "[make_id:29, model_group_id:1761, variant_id:3885, generation_id:863, motortype_id:2022, trim_id:8057];"
     },
-    "coverImageAttractiveness": 0.19866658727263975,
+    "coverImageAttractiveness": 0.20372734525906677,
     "vehicleDetails": [
       {
-        "data": "205,887 km",
-        "iconName": "mileage_road",
+        "data": "141,231 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -5954,1731 +9668,15 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "88 kW (120 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "145 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "73694"
-    },
-    "crossReferenceId": "73694",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_31536259-2d12-4bdf-bbc5-31e6e114f7c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_a2002ba2-2aad-4979-a95d-303712d201eb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_78f58f10-bc8d-41dc-8471-3551d7af1e6f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_43f78243-4aa1-465c-8833-03b30e6af0fd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_1c55acaf-de72-4b52-a4b2-97fb9fadba1c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_5d21cf97-1c64-4b92-b958-15234c38a3ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_08722815-1fd5-45b2-a53f-b7b15de889de.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_71ca7222-1d24-48dd-aa14-071e09da3cc0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_d6970162-5536-4ed4-a960-d82d2d74ec68.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_b8295bee-7549-4693-8a3b-732933c96c00.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_75668aa0-1471-4576-81fb-0f17cff7e3c3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_f8bd47e6-72ca-4d0a-87b1-8c90d6b0fc1d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_aa612664-608b-4463-87c8-c46607467f85.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_1a069041-b456-47d5-8496-8a69b4bf865f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_cd11bea8-f46b-43ce-9229-e1e11167d166.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_5865bb84-9717-4990-9658-b36bc7e9195a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_e18b459b-a0a7-45a1-b062-b4f8e17d4742.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_592b6c11-44e2-41a9-92b2-b884f556d84d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6_27dc3848-6534-465f-b496-5be2cf03b141.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 6,295"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/citroen-c3-1-0-benzine-attraction-eerste-eigenaar-24-000km-gasoline-fa3aa436-e7a4-4aa4-8ca5-11e66b6f32b6",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Citroen",
-      "model": "C3",
-      "modelGroup": "C3",
-      "variant": null,
-      "modelId": 18264,
-      "modelVersionInput": "1.0 Benzine Attraction *Eerste Eigenaar *24.000Km",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "24,050 km"
-    },
-    "location": {
-      "countryCode": "BE",
-      "zip": "8210",
-      "city": "Zedelgem",
-      "street": "Torhoutsesteenweg 383"
-    },
-    "ratings": {
-      "ratingsCount": 42,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "2195864",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/2195864-original-63b3045b-8929-4770-b036-473c000cf8b2/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Opel - Garage Deketelaere bvba",
-      "contactName": "Nancy Deketelaere",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=2195864",
-        "imprint": "https://www.autoscout24.com/dealerinfo/opel-garage-deketelaere-bvba/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+32 (0)50 - 277494",
-          "callTo": "+3250277494"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+32 (0)50 - 277494",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2014",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.22898633097186916",
-      "isSmyleEligible": "false",
-      "mileage": "24050",
-      "priceLabel": "fair-price",
-      "price": "6295",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:21, model_group_id:200303, variant_id:, generation_id:2126, motortype_id:1448, trim_id:1238];"
-    },
-    "coverImageAttractiveness": 0.22898633097186916,
-    "vehicleDetails": [
-      {
-        "data": "24,050 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "05/2014",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "50 kW (68 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "5faf91d2-67bf-46d9-a374-a218970902d7",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_cdc4f1aa-7d53-42cb-a312-10c0a4d9fc09.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_1d029128-7408-42dc-a6a4-ab6e651f8302.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_dac09ba0-c58a-4b08-9da2-33aa9e3c1851.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_417b4d23-6444-45a0-a630-dfa4f7786705.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_1b59c900-1a0b-443d-97ef-b90d1c16a0e8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_3110793a-fd2c-4f14-a228-9f6556596ecb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_58c4eca5-b0c4-4866-bafc-f704182bc5bc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_74c5c8f1-f45a-4d64-ad8d-451f860c10e9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_3154ae42-5ed4-43d2-867b-eb30d367aa90.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_7cf07295-dc4a-4fb4-a217-064b9b68aa47.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_be53c491-e33e-433e-802c-ffd11b7d63f3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_1caa2e3e-141d-4370-a807-abae45ffa5c1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_e50d0ccc-a02c-4ff4-9365-40f4aa91914d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_267aca29-5a23-445f-8b55-09eb3b6e282a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_b80842a0-a1a6-4fa1-8a9b-917b329e2311.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/5faf91d2-67bf-46d9-a374-a218970902d7_f2d5a1cf-8fb7-4dda-86d7-3ed6e4a2f0e1.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "isOfferNew": true,
-    "price": {
-      "priceFormatted": "€ 1,490"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/fiat-panda-1-1-active-gasoline-white-5faf91d2-67bf-46d9-a374-a218970902d7",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Fiat",
-      "model": "Panda",
-      "modelGroup": "Panda",
-      "variant": null,
-      "modelId": 1746,
-      "modelVersionInput": "1.1 Active",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "173,100 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "72127",
-      "city": "Kusterdingen",
-      "street": "Lange Gasse 40"
-    },
-    "ratings": {
-      "ratingsCount": 15,
-      "ratingsStars": 4,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {
-        "maxImages": 50,
-        "isFreespeeCallTrackingEnabled": true
-      },
-      "id": "39261483",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/39261483-original-5ce35e80-8f76-4162-a38d-4312a53b1fe5.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autowerk Linde",
-      "contactName": "Autowerk Linde",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=39261483",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autowerk-linde/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)7071 - 7076059",
-          "callTo": "+4970717076059"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)162 - 3646671",
-          "callTo": "+491623646671"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)162 - 3646671",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Zero"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "07-2010",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2889679827917956",
-      "isSmyleEligible": "false",
-      "mileage": "173100",
-      "priceLabel": "somewhat-expensive",
-      "price": "1490",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:28, model_group_id:200526, variant_id:, generation_id:819, motortype_id:1877, trim_id:923];"
-    },
-    "coverImageAttractiveness": 0.2889679827917956,
-    "vehicleDetails": [
-      {
-        "data": "173,100 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "07/2010",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "40 kW (54 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "2d3ac094-0d43-482a-98f3-7db4d25cf2d1",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "445002082"
-    },
-    "crossReferenceId": "445002082",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_b56b31d4-cff9-4890-9983-88ccbbd78861.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_296c8663-37c6-42df-8960-5649e9dc5d3a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_1afcbbba-5708-48d6-9cc0-03e396a1f960.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_8a2a22ef-3435-41f6-b7dd-c0846d2e0145.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_9bb5c8be-ca00-4264-bf4c-0d6608c30dac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_89d1bcac-d812-4e2a-a593-5e6493be89c9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6331d7b9-a118-4155-999d-49658c9763f5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_a02a7971-1cb7-468f-9e04-737e1dbb3da2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_bf6b42f5-5f05-48e3-b4ec-66111c12ffc9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_38dda5c5-346f-4d7b-be7f-67439f707bb0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_7b4082f0-ed97-4fee-ba00-7dfd897cbd99.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6a46de77-5727-4110-bef3-0eb0b4e923d6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_ab10091c-75b3-4204-882c-dfa8fa80006e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_acbeca3f-88f9-4de1-a0ae-3c4240f17da5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_41e39932-aed4-4d7e-916c-55f3afd5f7f7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_4f6a2058-56da-42d4-8498-e2149f645260.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2d3ac094-0d43-482a-98f3-7db4d25cf2d1_6f0078af-e7bf-4dba-99ef-70b08e1cbff5.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "isOfferNew": true,
-    "price": {
-      "priceFormatted": "€ 1,900"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/ford-fiesta-trend-gasoline-blue-2d3ac094-0d43-482a-98f3-7db4d25cf2d1",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Ford",
-      "model": "Fiesta",
-      "modelGroup": "Fiesta",
-      "variant": null,
-      "modelId": 1758,
-      "modelVersionInput": "Trend",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "199,890 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "65428",
-      "city": "Rüsselsheim",
-      "street": "Marktstraße 19"
-    },
-    "ratings": {
-      "ratingsCount": 5,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {},
-      "id": "46345061",
-      "type": "Dealer",
-      "companyName": "Autoagentur Rhein Main",
-      "contactName": "Yusein Hakif Yusein",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=46345061",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autoagentur-rhein-main/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1521 - 9417281",
-          "callTo": "+4915219417281"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)1521 - 9417281",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Nfm",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "06-2011",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.24857714954914834",
-      "isSmyleEligible": "false",
-      "mileage": "199890",
-      "priceLabel": "toolow-price ",
-      "price": "1900",
-      "orderBucket": "0",
-      "modelTaxonomy": "[make_id:29, model_group_id:1758, variant_id:, generation_id:447, motortype_id:832, trim_id:371];"
-    },
-    "coverImageAttractiveness": 0.24857714954914834,
-    "vehicleDetails": [
-      {
-        "data": "199,890 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "06/2011",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "60 kW (82 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "5.7 l/100 km (comb.)",
-      "135 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "sponsored"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "a451c5d7-c04b-452e-b26a-a65c87711c7f",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325060521"
-    },
-    "crossReferenceId": "325060521",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_cb933337-cd67-4789-9341-e4e92990944e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_97b623e5-a1ab-4bc7-b980-b3a0fcf26034.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_77d37b0e-c334-4b5d-893b-047811587cd2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_7eded411-6410-47c2-a4fa-0ebdf04732fd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_01595154-4b7e-437d-8a4a-dd1c2adbd5f8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_58f0426d-23b2-4193-89fe-ee9d689537d3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_77824a6b-da43-4ce4-a8d9-2b2ac7f3783c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_d6ee8c97-4f63-461e-9f20-0a21a97b4808.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_b6ee6fe9-27c4-400a-82a0-0b4f0c1b0c3c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_23a5efc0-33fb-421d-9aae-756dca6483a1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_802f3d32-bf00-4c7c-9a18-2e65d49877d9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_2e35f50f-24f6-41a3-a7e2-5518daa8f75c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_0479b1ad-f46b-4bb9-aa9b-548be6023567.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_e6a44287-e388-408f-b9d3-abc73ce0f6ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_c0f11de1-5a2d-448b-ad16-8d8c1b9a726f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_466822a4-114f-4082-acca-fdeda60fb3ff.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_d3993548-a0a8-4729-9454-e6fb89ec05c8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_e9db49e3-870d-4b96-af7b-e50997ff8ed6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a451c5d7-c04b-452e-b26a-a65c87711c7f_4ee5137f-b0a5-4245-a637-6d66fa85e30e.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,550"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/fiat-500-1-4-16v-lounge-gasoline-red-a451c5d7-c04b-452e-b26a-a65c87711c7f",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Fiat",
-      "model": "500",
-      "modelGroup": "500",
-      "variant": null,
-      "modelId": 15160,
-      "modelVersionInput": "1.4-16V Lounge",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "218,076 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "3113 AH",
-      "city": "SCHIEDAM",
-      "street": "Nieuw-Mathenesserstraat 32a"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "20632688",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/20632688-original-9075d4e4-8c14-4340-bf15-1e18e66ffe74/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Autocentrale Schiedam",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=20632688",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autocentrale-schiedam/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)10 - 7859151",
-          "callTo": "+31107859151"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 42415989",
-          "callTo": "+31642415989"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 42415989",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2008",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.17612457211720256",
-      "isSmyleEligible": "false",
-      "mileage": "218076",
-      "priceLabel": "fair-price",
-      "price": "2550",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:28, model_group_id:200524, variant_id:, generation_id:789, motortype_id:1765, trim_id:5101];"
-    },
-    "coverImageAttractiveness": 0.17612457211720256,
-    "vehicleDetails": [
-      {
-        "data": "218,076 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2008",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "74 kW (101 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "149 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "11a3e93f-49c3-42d0-858e-4cc789a2c418",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_4d1b748b-841f-47a4-95a3-e157894d57d1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_8e317844-b5a2-4e9e-99c2-d2583d10f609.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_dc278f39-bfd4-4657-8a8b-3f5f78161080.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_1cbbc455-7410-4ba2-b598-8ff0b2bbe006.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_f9b290ae-3f2e-43f1-bd2c-44750cdd862e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_f39b3949-80ae-43da-adb7-20f400ce27cc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_0be28e74-d1e7-4fdb-85c4-1b9c2005beda.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_fd94d4d0-36a8-4478-8aa7-5031689783e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_64208064-6937-467b-bbac-257d7d7df062.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a3dc28bc-b632-4e7c-9f89-d0aa5f3139fc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a9ff5b74-311d-4644-b3b9-551c39885d69.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_839378dd-e2c2-4797-9a29-4f569854fcf3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_54391242-e4ea-4cc2-a076-a159e7c929ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_a75b55cc-6fce-4e9c-8eea-6e5c5deb136a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_8e1af15f-aa07-467b-9440-02282ee00fb3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_9c6f9e37-5e1f-471c-a5b1-a1e293494c86.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/11a3e93f-49c3-42d0-858e-4cc789a2c418_9ae601b6-6743-477e-8765-d798745d7ee0.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 7,990"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/hyundai-i20-allwetterr-sitz-lenkradhzg-tuev-serviceneu-garant-gasoline-black-11a3e93f-49c3-42d0-858e-4cc789a2c418",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Hyundai",
-      "model": "i20",
-      "modelGroup": "i20",
-      "variant": null,
-      "modelId": 19188,
-      "modelVersionInput": "Allwetterr.*Sitz-lenkradhzg*TÜV&ServiceNeu*Garant",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "65,000 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "28816",
-      "city": "Stuhr",
-      "street": "Am Hufschlag 2"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "49027072",
-      "type": "Dealer",
-      "companyName": "A.K.H. Autopark",
-      "contactName": "Ali Achour",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=49027072",
-        "imprint": "https://www.autoscout24.com/dealerinfo/a-k-h-autopark/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)173 - 6049860",
-          "callTo": "+491736049860"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)173 - 6049860",
-          "callTo": "+491736049860"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2016",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.14465111827198218",
-      "isSmyleEligible": "false",
-      "mileage": "65000",
-      "priceLabel": "top-price",
-      "price": "7990",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:33, model_group_id:19188, variant_id:, generation_id:920, motortype_id:2250, trim_id:1024];"
-    },
-    "coverImageAttractiveness": 0.14465111827198218,
-    "vehicleDetails": [
-      {
-        "data": "65,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2016",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "62 kW (84 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "d927e9c1-5c53-4688-8e7e-c86b9e176375",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_468bdac8-c86a-476f-b9c3-4d659e8bbc1c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_3426162f-9367-47d7-9b98-6521f584aad7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_0f1b5006-22a4-4c09-a3ae-d6ef2e89752f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_f3290650-5e21-45ef-baea-4a2a31087773.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_f6f22f33-f99b-4c69-b06c-f9c909b4afbd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_878489f1-3617-4413-8f6d-5e6325dce978.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_64322f2c-2c42-4e28-9613-bd9dcf0c3d04.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_bd31374a-fc36-46ec-b9f8-f6ec881501ae.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_e7b5a084-32d3-45dd-bd47-68dcf3b6535b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_30b356d8-a9fc-42f0-85c1-35dfa3cd27e3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_3c20f22c-5244-49a7-99f8-9723c261eed1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_d5c58f83-83fd-478a-ab4f-349017b7d15f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_39a6cc59-782b-4ae9-b0b4-4af915f6b24c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_75dbd536-7365-43b7-9dbf-12f3f14ff3c7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_d2ab1dc4-1c68-4c63-a294-bb91392c84c2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/d927e9c1-5c53-4688-8e7e-c86b9e176375_20ee9310-dfb0-44ce-9194-4d5d5ca54079.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 7,300"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/audi-a1-ambition-gasoline-white-d927e9c1-5c53-4688-8e7e-c86b9e176375",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Audi",
-      "model": "A1",
-      "modelGroup": "A1",
-      "variant": null,
-      "modelId": 19083,
-      "modelVersionInput": "ambition",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "148,000 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "53797",
-      "city": "Lohmar",
-      "street": "Hauptstraße 93"
-    },
-    "ratings": {
-      "ratingsCount": 3,
-      "ratingsStars": 5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {},
-      "id": "39959889",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/39959889-original-9b626993-4a20-43fb-a506-c1c34f54d9e1.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Auto-Schau Rhein-Sieg",
-      "contactName": "Raad Mousa",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=39959889",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto-schau-rhein-sieg-lohmar-53797/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)2246 - 9320632",
-          "callTo": "+4922469320632"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)163 - 2076948",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "06-2013",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.12065544531627415",
-      "isSmyleEligible": "false",
-      "mileage": "148000",
-      "priceLabel": "good-price",
-      "price": "7300",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:9, model_group_id:19083, variant_id:, generation_id:501, motortype_id:868, trim_id:465];"
-    },
-    "coverImageAttractiveness": 0.12065544531627415,
-    "vehicleDetails": [
-      {
-        "data": "148,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "06/2013",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "63 kW (86 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "be5b5bb7-b71e-4209-81ef-64f610457e4b",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "3113245"
-    },
-    "crossReferenceId": "3113245",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_8ddeeb98-f5bf-46b9-9039-aa5e49a2a71c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_a6c13288-2023-4260-8884-b8c483888bab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_d47388bc-585e-4e93-ad2d-7438f738afbd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_81bbc1d6-e79d-4e1b-923c-a101c493985a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_d7a51b13-26be-44d8-b905-c970a816975e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_893764ef-9ba8-455b-bbef-d78130fb6a9a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_b105d277-8f66-41e3-8a1b-33bbe368b042.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_7ba020e7-1079-469f-9f00-35469d3a37b5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_5027496a-7c3c-4d49-9532-c578e15606e1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_91ec8550-6231-4f2d-897d-276bbe369bbd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_57021b56-b1d9-4bed-adcd-2add5f6249ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_ff0ec275-be21-44cd-b669-2a607fb6c154.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/be5b5bb7-b71e-4209-81ef-64f610457e4b_71ca6167-6ac1-481d-ab4e-5f95aee550de.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 2,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-up-1-0-take-up-bluemotion-nieuwe-apk-gasoline-red-be5b5bb7-b71e-4209-81ef-64f610457e4b",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "up!",
-      "modelGroup": "Up",
-      "variant": null,
-      "modelId": 19750,
-      "modelVersionInput": "1.0 take up! BlueMotion - *NIEUWE APK*",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "265,110 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "6717 LS",
-      "city": "EDE",
-      "street": "Hoefweg 20"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "49679012",
-      "type": "Dealer",
-      "companyName": "Van de Hee",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=49679012",
-        "imprint": "https://www.autoscout24.com/dealerinfo/van-de-hee/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+31 (0)318 - 416600",
-          "callTo": "+31318416600"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 53133144",
-          "callTo": "+31653133144"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 53133144",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "01-2013",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.21636632681828705",
-      "isSmyleEligible": "false",
-      "mileage": "265110",
-      "priceLabel": "good-price",
-      "price": "2950",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:19750, variant_id:, generation_id:1316, motortype_id:10342, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.21636632681828705,
-    "vehicleDetails": [
-      {
-        "data": "265,110 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "01/2013",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "44 kW (60 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325475419"
-    },
-    "crossReferenceId": "325475419",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_baa89ae7-cd8e-4815-ae46-aade1170eeaa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_d1a59085-ecaa-4d0e-a812-30241ad5314a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_11df0d67-22e0-4395-a69f-580c14c4a6cf.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_021e2c0a-47f7-4325-bd80-f857e8af3cf3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_42820b83-69e1-4ed3-b811-9408badf4f5a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_354281fd-cd02-4109-b20d-be8a86d7c0d8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_980bc029-7bc6-48d4-87ce-8bd7d7e3803c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_0486df6a-726b-49de-87cc-395baea66d99.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_986fed80-839f-4fee-808d-d1bdcf3bc7ea.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_be657be8-cefa-4661-9db8-7ab5beedd030.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_891b8db2-9ddd-4bba-b619-8426fde96d1f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f_0a62965d-97fb-4c01-a0c8-d14bbed0001f.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 5,890"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/toyota-yaris-1-8-vvti-ts-sport-trekhaak-gasoline-grey-c7a4bdc5-4d56-4c29-b1c7-c6e7e356157f",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Toyota",
-      "model": "Yaris",
-      "modelGroup": "Yaris",
-      "variant": null,
-      "modelId": 15663,
-      "modelVersionInput": "1.8 VVTi TS Sport Trekhaak",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "151,186 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "5811 AL",
-      "city": "CASTENRAY",
-      "street": "Lollebeekweg 54b"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "39564244",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/39564244-original-678bf934-4d57-4b0c-a5b2-9752108019e2.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "F.M.S. Automobielhandel",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=39564244",
-        "imprint": "https://www.autoscout24.com/dealerinfo/f-m-s-automobielhandel-castenray/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 21964985",
-          "callTo": "+31621964985"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 21964985",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Zero"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "01-2008",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2263719807821699",
-      "isSmyleEligible": "false",
-      "mileage": "151186",
-      "priceLabel": "good-price",
-      "price": "5890",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:70, model_group_id:201438, variant_id:, generation_id:1279, motortype_id:5380, trim_id:8123];"
-    },
-    "coverImageAttractiveness": 0.2263719807821699,
-    "vehicleDetails": [
-      {
-        "data": "151,186 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "01/2008",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "98 kW (133 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "170 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "6bb22642-3393-4b0c-9283-0146830ac662",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "318140740"
-    },
-    "crossReferenceId": "318140740",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_edbdf96a-76c6-45c9-8aef-e90122f34004.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_ed16452b-de48-42b8-92c0-ff454645ee2e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_32e2f1be-f664-4a62-bf42-6d42ac7700bd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_ee0b2466-9f3f-4f46-bfc1-8fbcd1c53f8b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_9770bc99-47a1-4e3d-a235-ee2f0765a06b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_652cde9c-ef23-47d0-8c8d-ebd310f4b770.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_3318cbb1-4c04-44aa-a5da-4dd6e235396f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_1c2fbfc4-2a9d-4af0-8d79-ebc2b98e3c13.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_03890798-9ad2-458f-ad15-d153a3a65173.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_7f7359ee-56b2-4dc0-8195-c929e99a59ab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_bcb85eae-41d5-45c0-9049-f25bc6501469.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_9c9dccb2-47b2-4538-8587-a578bb74d789.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_d6b32710-ee20-40a3-aacd-029d18d3918e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_542884bf-652e-4e2b-b794-038a4e34c4b4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_eadf06c1-db98-43e2-86f0-9ca68e15859f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_84323bd9-cbbc-4b4c-952a-87da050aed69.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_51f7db94-96df-4683-a2d1-da4b6924c2aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_0b624182-0c35-4ca1-accf-02a13fde036e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_5c42770f-ec5d-4594-b077-b37021877365.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_c2fbba7b-5287-425d-b2dd-0246482a8283.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6bb22642-3393-4b0c-9283-0146830ac662_f58f86d3-4c82-4d9d-88b0-18f13287f1b0.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,945"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/hyundai-i20-1-2i-first-edition-airco-elek-ramen-nwe-apk-gasoline-blue-6bb22642-3393-4b0c-9283-0146830ac662",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Hyundai",
-      "model": "i20",
-      "modelGroup": "i20",
-      "variant": null,
-      "modelId": 19188,
-      "modelVersionInput": "1.2i First Edition AIRCO | ELEK RAMEN | NWE APK",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "143,472 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "4825 AS",
-      "city": "BREDA",
-      "street": "Regenbeemd 9"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "45152005",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/45152005-original-252bb94a-532c-4848-a7cc-07a303a9d269.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "My Cars Breda",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=45152005",
-        "imprint": "https://www.autoscout24.com/dealerinfo/my-cars-breda-breda-4825-as/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 19037455",
-          "callTo": "+31619037455"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 19037455",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "08-2012",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.15874631622753332",
-      "isSmyleEligible": "false",
-      "mileage": "143472",
-      "priceLabel": "good-price",
-      "price": "3945",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:33, model_group_id:19188, variant_id:, generation_id:919, motortype_id:2250, trim_id:778];"
-    },
-    "coverImageAttractiveness": 0.15874631622753332,
-    "vehicleDetails": [
-      {
-        "data": "143,472 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "08/2012",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "63 kW (86 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "114 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "efe0e068-5abc-476c-8a14-402114effb6f",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/efe0e068-5abc-476c-8a14-402114effb6f_7c58fb81-2fc5-41e3-a2b7-9bdf71825772.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/efe0e068-5abc-476c-8a14-402114effb6f_0ce7d0df-e2c9-4f8d-b230-8e841176ffcc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/efe0e068-5abc-476c-8a14-402114effb6f_366a793a-a9c6-42fd-a8bb-97c4438e9bf3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/efe0e068-5abc-476c-8a14-402114effb6f_2efc24a8-9b3c-453d-a5e5-281f19045ad4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/efe0e068-5abc-476c-8a14-402114effb6f_4071f94f-145f-4f06-a03d-fc91fca381bc.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,950"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/ford-focus-1-6-tdci-110cv-3p-tit-dpf-diesel-grey-efe0e068-5abc-476c-8a14-402114effb6f",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Ford",
-      "model": "Focus",
-      "modelGroup": "Focus",
-      "variant": null,
-      "modelId": 15537,
-      "modelVersionInput": "1.6 TDCi (110CV) 3p. Tit. DPF",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "149,000 km"
-    },
-    "location": {
-      "countryCode": "IT",
-      "zip": "10126",
-      "city": "Torino - TO",
-      "street": "Via Cellini, 15/A"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "3768864",
-      "type": "Dealer",
-      "companyName": "Autobengasi Srl",
-      "contactName": "Paolo .",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=3768864",
-        "imprint": "https://www.autoscout24.com/dealerinfo/autobengasi-srl/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+39 011 - 0200368",
-          "callTo": "+390110200368"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 393 - 3313836",
-          "callTo": "+393933313836"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "05-2008",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.232516708565914",
-      "isSmyleEligible": "false",
-      "mileage": "149000",
-      "priceLabel": "good-price",
-      "price": "1950",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:29, model_group_id:15537, variant_id:, generation_id:272, motortype_id:10976, trim_id:7872];"
-    },
-    "coverImageAttractiveness": 0.232516708565914,
-    "vehicleDetails": [
-      {
-        "data": "149,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "05/2008",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "80 kW (109 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "6fadf6e0-3c7c-4c09-af42-9a28044e6ab8",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_2b3c7e99-ec83-4ed6-96be-270f5546dbff.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_331deb26-0518-43fe-8672-82f980cc8702.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_f337c459-e17c-45e3-a61a-116e78c346d1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_732d400e-3459-4631-8039-ac551c8b3b96.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_e4674808-7e2d-4ec9-869d-70f6d4b5776a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_ebdcf273-bdb9-4836-8d8f-e20dc755b9ab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_f60fb423-8db5-468f-b67d-529fec14d0f0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_a3cf86e1-941e-4098-a82d-ff55d47e268f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_13356c08-e08b-43a8-ad65-55d917114072.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_7ef82150-cf6a-4d1f-9cea-4f784d58c81a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_52872a0b-c1cc-4ed4-b66b-776af29da8e0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_ec7f26a3-2baf-4109-bcde-2d154d8882e0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_f1e483dd-6d18-4dbb-bc31-5154decd0671.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_83c4abda-6ef9-41e7-8a47-fdec26ce79ce.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_7ae41e1c-57e9-4864-859e-a6a9f10b6739.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_70343d8b-d960-4ef5-a457-67148857954f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/6fadf6e0-3c7c-4c09-af42-9a28044e6ab8_836ceb87-4a8c-468e-b282-5b7a94cd8e7f.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "isOfferNew": true,
-    "price": {
-      "priceFormatted": "€ 4,400"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/fiat-panda-1-2-dynamic-69cv-e5-gasoline-silver-6fadf6e0-3c7c-4c09-af42-9a28044e6ab8",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Fiat",
-      "model": "Panda",
-      "modelGroup": "Panda",
-      "variant": null,
-      "modelId": 1746,
-      "modelVersionInput": "1.2 Dynamic 69cv E5",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "73,162 km"
-    },
-    "location": {
-      "countryCode": "IT",
-      "zip": "14040",
-      "city": "Castelnuovo Calcea - AT",
-      "street": "Località Opessina,"
-    },
-    "ratings": {
-      "ratingsCount": 8,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {},
-      "id": "44187601",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/44187601-original-ef36e273-2b4c-41f2-aece-2af027221596.jpeg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Cld auto srl - Asti",
-      "contactName": "Venditore Maurizio",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=44187601",
-        "imprint": "https://www.autoscout24.com/dealerinfo/cld-auto-srl-asti/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 327 - 0782517",
-          "callTo": "+393270782517"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+39 327 - 0782517",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "06-2010",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.17649654094682643",
-      "isSmyleEligible": "false",
-      "mileage": "73162",
-      "priceLabel": "good-price",
-      "price": "4400",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:28, model_group_id:200526, variant_id:, generation_id:819, motortype_id:1878, trim_id:2655];"
-    },
-    "coverImageAttractiveness": 0.17649654094682643,
-    "vehicleDetails": [
-      {
-        "data": "73,162 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "06/2010",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
         "data": "51 kW (69 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
-    "wltpValues": [],
-    "isListingBoost": false,
+    "wltpValues": [
+      "- (l/100 km)",
+      "119 g/km (comb.)"
+    ],
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -7699,104 +9697,113 @@
     ]
   },
   {
-    "id": "edbbcd14-ecd0-4f29-aded-db080f838744",
+    "id": "09fba873-de56-49ae-a24f-6be535b4265f",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "324721881"
+      "crossReferenceId": "48515067"
     },
-    "crossReferenceId": "324721881",
+    "crossReferenceId": "48515067",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_c1af6cc4-e8b4-462d-a957-f5f48cba78a2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_7124a1d2-1d60-447b-9923-6ff7d76c3569.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_c69ac8fb-c997-4891-93ad-129e86a2892a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_e981ae7d-8005-4f87-a531-6f6587880361.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_f1b0777f-b9b8-47c3-a1ad-f1f733dbd801.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_3aa97871-c35d-427a-8bc8-8bcfd2cc5ef2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_30dd2873-d2a5-4864-95bb-778a9398a41e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_e43530c0-3514-493e-9261-934131be0143.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_060220da-2332-4bb4-bd76-92c65913463b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_18210366-d1c2-4d37-b0fd-72a5512abd4a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_c25a0b77-386f-4d7a-b341-a33a0ffcf39f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_18448f56-242e-415d-8215-bf898678836b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_02d961ca-f408-4df9-a4f1-2e744fde4ebe.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_22ce86b9-9b25-49c6-860b-02916b51874f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_3c33106f-b051-43d5-b0b3-751e4a59703f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_31185967-66dc-4857-9927-57fe971113b2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_2131ee4f-188e-4933-9a93-94c396373621.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_7a66b05a-a20e-4eb1-9571-24b5329d1fca.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_4b5d2ebd-56a6-4ae4-9785-b0f5c9ef16e4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_6c4fbb40-255f-4478-9a8c-27cde73a3757.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_d3bc05b8-dd31-4843-83f6-fb2329b560e8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_0f82425d-1526-4ac4-b466-95bd66d0eb43.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_e8845345-3ad9-41e1-8a0e-9834cfd9ce3b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_531269eb-aeb3-47bf-9ff8-4e998226d2a7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_1ba258a8-53a8-4d84-936f-c199ae951b98.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_3dd5ce50-6fb6-4fc2-975f-57f807e67abb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_228cafa4-f0b3-410b-bf80-6e89de71b1a8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_8b5a6a04-0f8e-4dae-a651-ad3fb2ab12e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_4caaca81-b00a-41c3-9593-e30fb03b66ee.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_783ed5dc-3f03-4f98-93ff-c42f7d614f19.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_1b1c4612-b4d7-4b29-9e41-5634252f5598.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_c2496158-6e44-4ce0-914b-bc97ca7be591.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_94995651-c735-4358-8f0a-523c31a2b59f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_bb03c721-b6c5-49e1-aba3-ded03f750ad3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/edbbcd14-ecd0-4f29-aded-db080f838744_6dcd33ca-5324-4f18-93a0-9f7237c474c2.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_f7c54369-c3d7-4ac2-8d19-1f88dd95522f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_c8b5a459-7380-4713-85c4-0d7734073501.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_752dbffd-a684-41ab-9b4f-cacc17cf824d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_8de935d3-c371-463e-860b-bb4a4a02280c.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_b59b0a2b-31a0-4ef3-b5de-3c9a4e017ab9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_e98dd11d-5c82-487c-ac9b-dd73e4ee6995.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_bff8ce65-425e-4d68-93cb-aa971debbad6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_52f48362-4016-4095-a384-2f222de3e5ae.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_b2aca6cb-715d-4d0f-b301-d11b617b0a7b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_bfdb639e-e984-4e68-8d53-94170b9d2ff9.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_2767ff47-c444-4899-b543-76cadb5c4914.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_7171a8e4-121d-44a7-9d24-2c9d14ca1ca8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_79922318-91a0-4f7b-83fe-923967c45e35.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_8bb47de0-f5e8-4ed6-a325-00680bb07601.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_97ee05be-a680-4ddd-a457-9f18b7452b6a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_1e4bf7af-5c24-4425-9705-fede4b3ef1d5.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_01152c76-e91b-443f-9582-ecd1ddbeb7e7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_c3678b33-152a-4e86-aad9-232481fd7960.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_6dab3106-9e2b-4085-ae78-fbb10d3203e8.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_a81cc2b7-ee40-4f09-8029-ff20826c2414.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_a82b8e68-75a1-467c-918f-e503894d7150.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_cd32992c-8f88-4b86-a41c-036261841f66.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_5698ff2c-a1c7-4f53-af78-e5c45fb817b6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_25edd501-d3c9-4c70-a563-4124b6330335.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_ff554358-a253-44fd-ba9f-4fdce8a42873.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_e881fbbb-a57b-4f76-adeb-b07aba60e99d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_2872515b-6d88-49e9-9cba-94c0a07f9784.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_ca8b5078-3160-4ed8-a024-7b5aa45414c6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/09fba873-de56-49ae-a24f-6be535b4265f_b06326a2-fe08-4b14-90fd-ee55b86c38b9.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
     "price": {
-      "priceFormatted": "€ 2,249"
+      "priceFormatted": "€ 1,100",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1100,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/opel-corsa-1-4-16v-sport-1e-eigenaar-airco-gasoline-grey-edbbcd14-ecd0-4f29-aded-db080f838744",
+    "url": "/offers/opel-corsa-1-2-16v-business-5-drs-airco-navi-bj-2007-nap-gasoline-grey-cat_ma54mo1918-09fba873-de56-49ae-a24f-6be535b4265f",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
       "make": "Opel",
       "model": "Corsa",
       "modelGroup": "Corsa",
-      "variant": null,
+      "variant": "Corsa",
+      "motorTypeName": "1.2",
       "modelId": 1918,
-      "modelVersionInput": "1.4-16V Sport - 1e Eigenaar - Airco",
+      "modelVersionInput": "1.2-16V Business 5-Drs Airco Navi! Bj:2007 NAP!",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "248,331 km"
+      "mileageInKm": "218,012 km",
+      "engineDisplacementInCCM": "1,229 cc"
     },
     "location": {
       "countryCode": "NL",
-      "zip": "5038 GP",
-      "city": "TILBURG",
-      "street": "Boomstraat 117a"
+      "zip": "8304 AW",
+      "city": "EMMELOORD",
+      "street": "Techniekweg 9"
     },
     "seller": {
-      "dealer": {},
-      "id": "51036003",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/51036003-original-4eb7d248-ab67-481e-b3d3-41f247eb2482.png/resize/100x50%3E/quality/90"
-        }
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "nl-NL"
       },
-      "companyName": "Euromax Auto's",
-      "contactName": "Euromax Autos",
+      "id": "36671533",
+      "type": "Dealer",
+      "companyName": "Autobedrijf Duran",
+      "contactName": "Afdeling Verkoop",
       "links": {
-        "infoPage": "/lst?atype=C&cid=51036003",
-        "imprint": "https://www.autoscout24.com/dealerinfo/euromax-auto-s/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/autobedrijf-duran?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/autobedrijf-duran/imprint"
       },
       "phones": [
         {
+          "phoneType": "Office",
+          "formattedNumber": "+31 (0)527 - 728201",
+          "callTo": "+31527728201"
+        },
+        {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 25370431",
-          "callTo": "+31625370431"
+          "formattedNumber": "+31 (0)6 - 24778052",
+          "callTo": "+31624778052"
         },
         {
           "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 25370431",
+          "formattedNumber": "+31 (0)6 - 24778052",
           "callTo": null
         }
       ]
@@ -7811,21 +9818,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "01-2007",
+      "firstRegistration": "03-2007",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.1506075986805332",
+      "imageContent": "no-placeholder|0.1282343659978924",
       "isSmyleEligible": "false",
-      "mileage": "248331",
-      "priceLabel": "somewhat-expensive",
-      "price": "2249",
+      "mileage": "218012",
+      "priceLabel": "top-price",
+      "price": "1100",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:, generation_id:264, motortype_id:627, trim_id:7128];"
+      "modelTaxonomy": "[make_id:54, model_group_id:1918, variant_id:3184, generation_id:264, motortype_id:625, trim_id:480616];"
     },
-    "coverImageAttractiveness": 0.1506075986805332,
+    "coverImageAttractiveness": 0.1282343659978924,
     "vehicleDetails": [
       {
-        "data": "248,331 km",
-        "iconName": "mileage_road",
+        "data": "218,012 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -7834,7 +9841,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "01/2007",
+        "data": "03/2007",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -7844,14 +9851,14 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "66 kW (90 hp)",
+        "data": "59 kW (80 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [
       "- (l/100 km)",
-      "142 g/km (comb.)"
+      "139 g/km (comb.)"
     ],
     "trackingParameters": [
       {
@@ -7873,906 +9880,107 @@
     ]
   },
   {
-    "id": "a7b6d902-6615-4677-8567-20e967cb8d0c",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325240508"
-    },
-    "crossReferenceId": "325240508",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_4205f531-59c5-4222-8f6d-d6f58a07efa2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_0c5391ed-54e4-4afe-a189-e18320c921fb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_e121f86d-c35c-4c72-9ed3-d30dd0f2c402.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_3bff59be-16ba-4080-9e08-e6a8b7990959.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_9e393118-ddc6-46a4-953f-ff7eba8a26df.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_a5ed4b96-0dde-4839-a20c-35b41f7353ac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_61fa437c-fa57-4aad-82b7-2f0597ceb889.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_6bf76557-08c6-497e-8da8-e1d1a032e65a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_4ff58f20-683b-4f34-b6a2-b5b240f5dcb8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_2c2898da-a8fa-4428-b22d-c7166fda3d10.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_5de5624f-5954-4277-b02c-9a5c90407722.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_e5b1e43e-9c66-481e-a4ba-6148842d724f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_66ee449a-dda3-4d71-ad43-d24e82ede71b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_1c0ea9e8-489d-4c0a-a3fa-35e6ed8da336.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_2b3eb951-d796-4e1e-9a44-611c3851264a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_fab6c03b-6915-48c9-93d9-9513763ba88b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_9c348a48-b4ed-4553-8f67-d54c7b436d24.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_75138f02-a79d-4c79-bdf2-ecb1996d1b9b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_531021a0-9961-459e-85e4-34e9bda3927b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_8531d759-d16a-402d-b027-944445993bc7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_b46f96c4-88cd-4918-9580-314311cb9d9d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_b68e34ce-d4d5-4c62-beb5-d121bad0a993.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_35a5fb3a-0c02-4c95-ae6c-35b405988441.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_9b4a6da6-0715-4ca7-b2cd-113d1379f97d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_9e14167b-6570-46c4-88e2-152d7ef90e48.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_fe959835-c0cb-4e20-a518-3e6a1fc4d62d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_cd0f8d3b-a221-4fe9-924d-03d785014cdc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/a7b6d902-6615-4677-8567-20e967cb8d0c_6c75d591-f6ee-41b3-ae64-baab107b0720.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 6,995"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/mini-one-d-mini-1-5-business-cruisecontrol-parkeersensore-diesel-grey-a7b6d902-6615-4677-8567-20e967cb8d0c",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "MINI",
-      "model": "One D",
-      "modelGroup": "Mini",
-      "variant": "One 5-Türer",
-      "modelId": 19746,
-      "modelVersionInput": "Mini 1.5 Business - Cruisecontrol - Parkeersensore",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "202,550 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "4131 NR",
-      "city": "VIANEN",
-      "street": "De Limiet 26"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "34954813",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/34954813-original-207864e9-b58e-4b3c-b0d4-ac62f62127a4.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Haak & Jansen Occasions",
-      "contactName": "Max Haak",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=34954813",
-        "imprint": "https://www.autoscout24.com/dealerinfo/haak-en-jansen-occasions/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 57336242",
-          "callTo": "+31657336242"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 57336242",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2016",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.24298006281141127",
-      "isSmyleEligible": "false",
-      "mileage": "202550",
-      "priceLabel": "unknown",
-      "price": "6995",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:16338, model_group_id:100141, variant_id:2685, generation_id:373, motortype_id:734, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.24298006281141127,
-    "vehicleDetails": [
-      {
-        "data": "202,550 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "09/2016",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "70 kW (95 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "92 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "338f7cd8-4234-4b95-bc19-508cebc9ea94",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "BR844742"
-    },
-    "crossReferenceId": "BR844742",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_2fc5b6be-9f1a-4e17-87b1-84ca6e3c4df2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_70d52aec-e158-443a-92ae-ab2ea9076069.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_2ab41c81-6986-4871-ac41-62167d4dd861.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_9a45864c-c7f0-4a9e-b662-ffcb7524ed85.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_9a0c8488-9a70-4b78-85b7-c8a34c1d7d06.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_c8eb7473-d677-4244-8073-56abb5de80cd.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_d1b0cafb-7010-4b7a-a195-b3727ee01281.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_6a5c5f76-406e-47e4-8eb5-a50f4b4b1336.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_c4d1cc73-fe85-4f99-a5fb-f61865a90810.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_7864e509-2e79-421f-959b-ca4cab19aa61.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_f27e94bd-3d26-46c5-b31e-84fbeb225591.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_b9cfc1e3-ea7b-4ee2-a07f-f46885bb8b36.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_76d57168-cd63-4049-b575-fe2a65b6bd9c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_d5d5a8a3-d657-4c85-8aec-e4cdd86a3fdc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/338f7cd8-4234-4b95-bc19-508cebc9ea94_af63254d-58bf-464b-82ad-a2ccb1194a90.png/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "isOfferNew": true,
-    "price": {
-      "priceFormatted": "€ 6,590",
-      "priceSuperscriptString": "1"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/citroen-c3-feel-1-5-diesel-102cv-diesel-red-338f7cd8-4234-4b95-bc19-508cebc9ea94",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Citroen",
-      "model": "C3",
-      "modelGroup": "C3",
-      "variant": null,
-      "modelId": 18264,
-      "modelVersionInput": "Feel 1.5 Diesel 102CV",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "125,469 km"
-    },
-    "location": {
-      "countryCode": "IT",
-      "zip": "42122",
-      "city": "Reggio Emilia RE",
-      "street": "Via Enzo Lazzaretti, 8"
-    },
-    "ratings": {
-      "ratingsCount": 115,
-      "ratingsStars": 4,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {},
-      "id": "25631076",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/21784695-original-21c7e076-0ab5-4fa0-860b-0e03d78e3bf7.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "brumbrum - Reggio Emilia",
-      "contactName": "Servizio Clienti",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=25631076",
-        "imprint": "https://www.autoscout24.com/dealerinfo/brumbrum-reggio-emilia/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+39 02 - 80029807",
-          "callTo": "+390280029807"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+39 389 - 2607371",
-          "callTo": "+393892607371"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+39 389 - 2607371",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "08-2021",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.26041737661345343",
-      "isSmyleEligible": "false",
-      "mileage": "125469",
-      "priceLabel": "good-price",
-      "price": "6590",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:21, model_group_id:200303, variant_id:, generation_id:2127, motortype_id:3659, trim_id:3640];"
-    },
-    "coverImageAttractiveness": 0.26041737661345343,
-    "vehicleDetails": [
-      {
-        "data": "125,469 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "08/2021",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Diesel",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "75 kW (102 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "92c3150e-ba5c-40eb-910b-28b09b7768cd",
+    "id": "35c3fd42-27dc-4e4b-84c7-5841341f48a8",
     "identifier": {
       "legacyId": null,
       "crossReferenceId": null
     },
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_6b0e9c1e-23a5-4e60-a568-5b830f6cd5e1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_9c3cf288-f4c5-418e-991f-43480fcb7488.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_4e694d2f-833f-40d4-bfbf-0d91a2f32e9c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_0436caeb-35bd-4724-9700-5237d1e62830.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_5ba823dc-fa7b-4acb-a16a-bc22f8162863.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_54d57d3d-8f41-476a-aa79-7856cec5507c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_e32e2277-fe4f-4a60-851b-e60a1969dc33.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_6fc919c2-d9b9-4bdc-845f-338469739a81.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_15565eab-d7ed-424a-8cd5-90438d74f440.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_b2e4c03c-6e15-459e-9af3-758d5e4ef95e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_2e78e8ea-575b-48d1-a48d-b663e2e47048.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_955807ed-976d-40f0-b3de-12703e8e6714.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_8a14d069-a639-4adc-9c42-c3a2130c35ea.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_e2c35bb0-0a15-4532-879a-1becf906bd69.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_cb80e51f-dbff-443c-80e9-21f7e89d3749.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_f592b474-522d-429d-8f47-1aa4aa9048e2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_f2689fe1-6171-4e88-b73c-2b4445d51404.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_7ea3ea15-acd9-4429-adf7-10ef480e847b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_b06915ec-e10b-4e72-a8df-f569e90155aa.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_07bb4f9c-964a-4e77-9c0f-521358ad264b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_8409120e-cc98-4c6f-b421-6d710eef4462.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_813fbaf7-5172-44a5-989c-bd184812680e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_0652c464-4af7-40ac-b859-83b336766858.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/92c3150e-ba5c-40eb-910b-28b09b7768cd_df72bb01-cb86-4c81-8393-b3955c10208b.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_04b7382d-58ae-48eb-80f0-7f8d6b514029.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_450263fe-c275-4f79-bee8-511f0ad0c608.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_626a05b6-dd50-4548-a3ab-e9ef04946833.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_2c998ad6-ff31-42c0-be39-532fbc983705.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_64865742-13e5-460a-82e2-d7867bf8ea77.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_974bcf41-9150-48a7-8f94-a81348825f11.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_2a9f9b6c-6685-4366-9d9f-c8020a791ab6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_b1c13efa-6c4b-4777-8418-900269162b74.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_7b694860-c7c8-49a5-9a91-1223173ba945.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_97254800-239a-44e4-965a-5be2c998c317.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_11ed8969-2b4c-423e-b0c7-ee245ef3cd19.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_c97858a8-d04e-47d9-980d-fc4075112bff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_8a8751b8-cdaf-4c84-98b2-3f6975e588e4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_655f265c-40f0-40a4-82b1-6499e724f2f6.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_3c027565-ff68-44a5-81ed-2e568158d665.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_5a37a8d1-c8d9-43ac-aeae-3622b32cfa73.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_5e65d1ed-077c-4c79-acd3-7ef29e9e9866.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_e1399b59-5ec6-4892-95a3-6def339b3aa4.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_1bc69c73-b17c-4ec2-a390-12e3913fb95b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/35c3fd42-27dc-4e4b-84c7-5841341f48a8_3a379604-1ec8-44a6-bac9-61d83f470faf.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
-    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 8,390"
+      "priceFormatted": "€ 5,790",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 5790,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/peugeot-308-peugeot-308-allure-1-hand-zahnriemen-tuev-gasoline-grey-92c3150e-ba5c-40eb-910b-28b09b7768cd",
+    "url": "/offers/mitsubishi-lancer-edition-cleartec-komplett-nur-mitsubishi-scheckheft-gasoline-grey-cat_ma50mo1884-35c3fd42-27dc-4e4b-84c7-5841341f48a8",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Peugeot",
-      "model": "308",
-      "modelGroup": "308",
-      "variant": null,
-      "modelId": 19055,
-      "modelVersionInput": "Peugeot 308 Allure | 1.Hand | Zahnriemen & TÜV",
+      "make": "Mitsubishi",
+      "model": "Lancer",
+      "modelGroup": "Lancer",
+      "variant": "Lancer Sport-Limousine",
+      "motorTypeName": "1.6",
+      "modelId": 1884,
+      "modelVersionInput": "EDITION ClearTec-komplett nur Mitsubishi Scheckheft",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "88,933 km"
+      "mileageInKm": "113,218 km"
     },
     "location": {
       "countryCode": "DE",
-      "zip": "56220",
-      "city": "Urmitz",
-      "street": "Brückenstraße 19"
+      "zip": "14612",
+      "city": "Falkensee",
+      "street": "Friedrich-Engels-Alle 47"
     },
     "ratings": {
-      "ratingsCount": 12,
+      "ratingsCount": 96,
       "ratingsStars": 5,
       "ratingsEnabled": true
     },
     "seller": {
-      "dealer": {},
-      "id": "50855295",
+      "dealer": {
+        "maxImages": 50,
+        "isFreespeeCallTrackingEnabled": true,
+        "culture": "de-DE"
+      },
+      "id": "24516",
       "type": "Dealer",
       "logo": {
         "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/50855295-original-a555f4c6-a7b4-4503-9c9b-f4a68e5821bc.jpg/resize/100x50%3E/quality/90"
+          "href": "https://prod.pictures.autoscout24.net/dealer-info/24516-original-9f644db2-50f8-4b88-bb21-67eda7ef34e0.jpg/resize/100x50%3E/quality/90"
         }
       },
-      "companyName": "Albrecht & Koch Autohandel GbR",
-      "contactName": "Tim Koch",
+      "companyName": "Kaiser Automobile GmbH",
+      "contactName": "K. Kaiser",
       "links": {
-        "infoPage": "/lst?atype=C&cid=50855295",
-        "imprint": "https://www.autoscout24.com/dealerinfo/albrecht-und-koch-autohandel-gbr/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1512 - 1503250",
-          "callTo": "+4915121503250"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)1512 - 1503250",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "10-2016",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.18003473328794295",
-      "isSmyleEligible": "false",
-      "mileage": "88933",
-      "priceLabel": "top-price",
-      "price": "8390",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:55, model_group_id:201149, variant_id:, generation_id:1083, motortype_id:3320, trim_id:1066];"
-    },
-    "coverImageAttractiveness": 0.18003473328794295,
-    "vehicleDetails": [
-      {
-        "data": "88,933 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "10/2016",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "96 kW (131 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "3cda2dc0-e451-42c5-8922-36a40709b5d8",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "324821801"
-    },
-    "crossReferenceId": "324821801",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_793ad8a4-a1f6-4981-8589-c715d1cb3500.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_ed845130-33e4-4a8d-b882-8daf6f3fda7b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_c4d01cc3-1734-40aa-b508-073770dc6db4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_68262ea5-54a9-4c63-b91e-45c0ecaf8b70.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_42404e0f-623c-4e17-8cf4-c53c532a823d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_9bfebfa3-744d-4f29-8e3a-7e0ebd1a4593.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_55aad33e-d308-4a06-9aa9-a0991e39244f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_87eb3833-0896-4ce0-a530-2acbf717d14d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_39fdd41c-8730-4300-9ad1-d9347784b890.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_d70bc43f-773b-4868-9f95-38ec7cb31b6f.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_dda6003b-7e9f-4775-ab5b-e87ed5c71507.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_f9ce4487-3ed5-41bf-b263-4259be6e18d4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_36f4a578-1db1-4d99-a4e3-6f2dd77ac9e4.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_8d4849f3-38b5-4526-941f-e4271749293b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_f4e3bb68-2ef5-4d9f-952e-be0805cf6b20.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_80685d0c-fa5d-449e-a92f-ddf5d78fea47.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_355d27e9-51bf-4d53-897a-6ec207cbe8b0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_c9c4bb41-48fd-459f-b02d-cf8ad49f79d9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_b1006152-787c-4aca-b360-684b60e2efad.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_44814156-c285-46e9-8340-bfe9864597f8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_34f33430-f474-46db-89d3-38e2061f7888.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_720d86fd-3332-4670-9120-389e835c6088.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_50ef324d-6b73-43e0-a172-6d7b29df83ad.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_57d8b6b1-ad02-4b1b-98bd-882f12b73b79.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_e9eaaf85-685d-4d76-af89-f373b3882f91.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_6e9515f1-b1b3-4b06-8814-f9a5a6231726.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_93a73a10-380e-4736-8e79-21f8c8ad70dc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_284de2e2-9b2d-4650-9f59-3d5edf3087b3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_e060a5a2-f8ad-4d75-a677-f4f277b9ae24.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/3cda2dc0-e451-42c5-8922-36a40709b5d8_252183be-4b5b-4a1e-addb-0c99f675cfc4.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 6,750"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-golf-1-6-trendline-airco-pdc-lm-nap-gasoline-grey-3cda2dc0-e451-42c5-8922-36a40709b5d8",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Golf",
-      "modelGroup": "Golf",
-      "variant": "Plus",
-      "modelId": 2084,
-      "modelVersionInput": "1.6 Trendline*Airco*PDC*LM*NAP*",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "108,645 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "7335 GW",
-      "city": "APELDOORN",
-      "street": "Hoenderparkweg 92-2"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "47844472",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/47844472-original-9db7f1db-3233-48fe-91d1-f1d0113a763e.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "KM Autobedrijf",
-      "contactName": "Afdeling Verkoop",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=47844472",
-        "imprint": "https://www.autoscout24.com/dealerinfo/km-autobedrijf/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 57516691",
-          "callTo": "+31657516691"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 57516691",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "07-2009",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.11352772184255311",
-      "isSmyleEligible": "false",
-      "mileage": "108645",
-      "priceLabel": "good-price",
-      "price": "6750",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100101, variant_id:2346, generation_id:6, motortype_id:425, trim_id:626];"
-    },
-    "coverImageAttractiveness": 0.11352772184255311,
-    "vehicleDetails": [
-      {
-        "data": "108,645 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "07/2009",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "75 kW (102 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "166 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "b1e4908d-6665-4598-80a9-b0adbcea0a78",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "424771894"
-    },
-    "crossReferenceId": "424771894",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_5b00d2c0-3077-43ea-a700-88bce34f32e0.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_2238e3f8-fc10-4b9a-b02e-b70e9738af6b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_fb942b2d-2ef9-4714-8e88-7a230a339fcc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_dfbd1b02-7645-4477-b004-c952dbe630a2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_e5e46882-4d5c-415a-9ad4-0fa424868df8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/b1e4908d-6665-4598-80a9-b0adbcea0a78_ad6a5374-f872-4922-824d-de32592206b0.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 1,499"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-polo-1-4-55kw-basis-gasoline-silver-b1e4908d-6665-4598-80a9-b0adbcea0a78",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Polo",
-      "modelGroup": "Polo",
-      "variant": "Classic",
-      "modelId": 2090,
-      "modelVersionInput": "1.4 55kW Basis",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Automatic",
-      "fuel": "Gasoline",
-      "mileageInKm": "78,000 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "12439",
-      "city": "Berlin",
-      "street": "Adlergestell 127"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "48695830",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/48695830-original-782ee761-abd9-4f49-bfb9-295dac033381.png/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Auto Center 24",
-      "contactName": "Fatih Arduc",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=48695830",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto-center-24-berlin-12439-1/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/kaiser-automobile-gmbh-falkensee?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/kaiser-automobile-gmbh-falkensee/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+49 (0)30 - 54807101",
-          "callTo": "+493054807101"
+          "formattedNumber": "+49 (0)332 - 25079704",
+          "callTo": "+4933225079704"
         },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)163 - 1580051",
-          "callTo": "+491631580051"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "03-2001",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.2581909150731463",
-      "isSmyleEligible": "false",
-      "mileage": "78000",
-      "priceLabel": "toolow-price ",
-      "price": "1499",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100099, variant_id:160, generation_id:173, motortype_id:, trim_id:260];"
-    },
-    "coverImageAttractiveness": 0.2581909150731463,
-    "vehicleDetails": [
-      {
-        "data": "78,000 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Automatic",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "03/2001",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "55 kW (75 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "6.3 l/100 km (comb.)",
-      "- (g/km)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "bd8aa67c-b54f-4834-8439-59011dbfa95e",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "324027711"
-    },
-    "crossReferenceId": "324027711",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_9d502804-b212-474e-8e25-a326f0b76d73.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_fdd26d85-bc33-4519-bc0c-1b4ba1757589.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_ed449b16-e5b3-4cb2-9601-b99bce643cf5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_5a1217db-bf3a-4996-8ce9-1f3a30227ae6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_1cdd03b3-a39e-4d95-b2e2-f6e75ef44182.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_4345ab90-9f97-4e25-a2ae-3d23aae6ac91.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_214bead3-130f-40d2-9933-a126e5d8da6a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_f89e69bf-f674-473b-9124-9ab3622173b8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_65d9cf79-c9dd-4700-8e70-add0da0beec3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_0b6b1e0e-3af9-49ba-868e-fbe0663eb55e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_3de09bd5-189d-4114-a3b3-737b1971e9bb.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_92e66198-c063-44d3-ba15-416c1f0f3f53.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_ada55b9b-7597-4cce-88a6-4c11a949f3a9.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_a684919a-608e-4428-9ac2-6230eb0b2275.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_7b424ff8-2935-4813-b23d-eaf412e023b7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_5388d530-638a-4498-bf52-6059a1a93e06.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_14a798e5-bb7a-4550-8213-f86a30d7e3f1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_0a191b8b-6cb1-4fe4-9c2e-e5505b70d1ce.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_9383c672-cf2d-407f-9172-e3bcfd0507df.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_59a597a0-c987-438f-918e-165e548430d3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_be9a598a-cf8f-4d9f-866d-9abfc4092a81.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_e4e2f735-9c4a-4dba-8008-00925504d810.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/bd8aa67c-b54f-4834-8439-59011dbfa95e_8325675e-363a-4aa1-b7e7-81a2381ad5ab.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 7,999"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/bmw-116-1-116i-lci-5-deurs-clima-airco-carplay-cruise-cont-gasoline-black-bd8aa67c-b54f-4834-8439-59011dbfa95e",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "BMW",
-      "model": "116",
-      "modelGroup": "1 Series",
-      "variant": "Sedan",
-      "modelId": 18480,
-      "modelVersionInput": "1 116i LCI 5-Deurs Clima Airco CarPlay Cruise Cont",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "139,743 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "7317 AZ",
-      "city": "APELDOORN",
-      "street": "Stadhoudersmolenweg 190a"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "48688987",
-      "type": "Dealer",
-      "companyName": "AUTO SPA",
-      "contactName": "S. v/d Pol",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=48688987",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto-spa/imprint"
-      },
-      "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)55 - 2085100",
-          "callTo": "+31552085100"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 14754562",
-          "callTo": "+31614754562"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 14754562",
-          "callTo": null
+          "formattedNumber": "+49 (0)3322 - 4258580",
+          "callTo": "+4933224258580"
         }
       ]
     },
@@ -8786,336 +9994,21 @@
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "06-2011",
+      "firstRegistration": "08-2011",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.19393462276554374",
+      "imageContent": "no-placeholder|0.20067622773107185",
       "isSmyleEligible": "false",
-      "mileage": "139743",
-      "priceLabel": "fair-price",
-      "price": "7999",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:13, model_group_id:100037, variant_id:194, generation_id:191, motortype_id:519, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.19393462276554374,
-    "vehicleDetails": [
-      {
-        "data": "139,743 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "06/2011",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "90 kW (122 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "4c95c52a-972f-40ee-936b-1d8beddfb3e3",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "325442495"
-    },
-    "crossReferenceId": "325442495",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_9cd31002-ddb7-4484-9ef1-a4e56ea4517c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_1cacda35-b6bc-46fb-9984-2e222cfb9182.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_849522db-145f-495e-8087-9196aeb724ce.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_81cbe1fe-fcd5-438c-94ab-fd4fefe736e8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_672cb5f6-5498-46af-86e0-83b6b4cd3df2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_962df4f1-737e-44b4-b479-af110d9ad458.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_2d41b983-7931-443b-b57b-38fdb0071d21.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_cfc87a48-af46-476f-855e-6819ea6a2924.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_b6592723-8391-4002-b08a-162147f10930.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_703c063b-5c28-4414-8ad9-c78a2c52fba6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_9f19501c-5276-4e0a-8ec3-8e2b4558a457.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_9f6245ed-26c7-4456-b184-cbadccec7e9d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_37e94f89-749c-48c4-bcd0-252c492c83a6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_cf3cf785-a48b-4006-a00b-1a11cd44ef57.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_e88ec00e-62c2-49df-9566-dc2ca5c81f76.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_bc1f41ac-69a7-4021-b270-78612c967463.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_2e387f41-b126-482b-bd80-2b30b1316ca6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_34b1eaa1-0848-4276-ab0d-3b93bbc3cc68.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_deaf35fc-45d8-451a-866b-a02179593fc6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_e90263ad-71c6-4aa1-a41f-da1bb95d0ed3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_eb79bdd3-6bba-48c7-b270-4502b25d0abe.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_832b898d-ada1-405c-8a18-8bec57815f5c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_5f4edf13-ee7d-4df1-b781-7a81bfd98190.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_928d85c2-3f19-4875-88bf-f80eac0faf5a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/4c95c52a-972f-40ee-936b-1d8beddfb3e3_82e43341-171d-41b6-b936-f28ac612f1b8.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 3,249"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/renault-megane-1-6-dynamique-5-drs-ecc-audio-cd-navigatie-lmv-17-gasoline-blue-4c95c52a-972f-40ee-936b-1d8beddfb3e3",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Renault",
-      "model": "Megane",
-      "modelGroup": "Megane",
-      "variant": null,
-      "modelId": 1965,
-      "modelVersionInput": "1.6 Dynamique 5-Drs ECC Audio-CD/Navigatie LMV 17\"",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "205,902 km"
-    },
-    "location": {
-      "countryCode": "NL",
-      "zip": "1746 CM",
-      "city": "DIRKSHORN",
-      "street": "Cornelis de Vriesweg 51c"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "41939492",
-      "type": "Dealer",
-      "companyName": "AVO auto's",
-      "contactName": "Stephan Rutten",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=41939492",
-        "imprint": "https://www.autoscout24.com/dealerinfo/avo-auto-s/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 11344594",
-          "callTo": "+31611344594"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+31 (0)6 - 11344594",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "07-2009",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.12625527941433534",
-      "isSmyleEligible": "false",
-      "mileage": "205902",
-      "priceLabel": "fair-price",
-      "price": "3249",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:60, model_group_id:201267, variant_id:, generation_id:1151, motortype_id:4412, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.12625527941433534,
-    "vehicleDetails": [
-      {
-        "data": "205,902 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "07/2009",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "81 kW (110 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "162 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "39fdd38c-4252-4de8-9106-e10ff10378e5",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": "1146847"
-    },
-    "crossReferenceId": "1146847",
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_979bae12-9946-4cd6-a97b-878cf842bcc8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_c1bfe3da-d57c-4473-a77b-1869a9fd577e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_4719b5b9-3f54-4d70-bf86-c481e27310c7.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_401d9705-05b5-49dd-a095-87b30709b202.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_31cdcb24-d190-4d74-a0e3-11791cd9cab8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_fc599dfe-94c2-4061-83b0-f89428987e3e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_bcef58ba-cd2a-4eed-927a-8876fbcf9f19.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_c8b91336-9cab-4bab-9ed2-4278ce22bc2e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_5f7aabe8-8c0b-4548-a55a-ea7744a047c5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_55b4c5ab-7e75-4cee-9cb4-1623b2e8c53b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_5f455056-cd8a-460c-a3f1-b3f4efd90fde.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_d7ba418f-05a1-4522-9ba4-717b783177ad.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_e345dd09-9c01-4110-a896-47c6642534ab.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_a821f747-9f5d-4788-8697-4dc3238f6248.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_6f44e86a-cfe2-463a-844f-d96caade832a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_1cb6748d-e8ac-4959-ae43-e55751cb1073.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_8691be87-5600-4fe7-9b4b-1301da92390a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/39fdd38c-4252-4de8-9106-e10ff10378e5_b740c1be-3702-48b2-b8d6-a2b99b896f60.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 800"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-fox-diesel-silver-39fdd38c-4252-4de8-9106-e10ff10378e5",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Fox",
-      "modelGroup": "Fox",
-      "variant": null,
-      "modelId": 18599,
-      "modelVersionInput": null,
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Diesel",
-      "mileageInKm": "316,755 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "38444",
-      "city": "Wolfsburg Heiligendorf",
-      "street": "Neue Straße 53"
-    },
-    "ratings": {
-      "ratingsCount": 551,
-      "ratingsStars": 4.5,
-      "ratingsEnabled": true
-    },
-    "seller": {
-      "dealer": {},
-      "id": "17031",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/17031-original-ffece146-0426-4c14-9746-e1746801af45.jpg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Hoffmann Automobile",
-      "contactName": "Team Verkauf",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=17031",
-        "imprint": "https://www.autoscout24.com/dealerinfo/hoffmann-automobile/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)5365 - 96062",
-          "callTo": "+49536596062"
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "09-2006",
-      "fuelType": "d",
-      "imageContent": "no-placeholder|0.24065242732211511",
-      "isSmyleEligible": "false",
-      "mileage": "316755",
+      "mileage": "113218",
       "priceLabel": "unknown",
-      "price": "800",
+      "price": "5790",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:18599, variant_id:, generation_id:1294, motortype_id:4077, trim_id:];"
+      "modelTaxonomy": "[make_id:50, model_group_id:201023, variant_id:1563, generation_id:1701, motortype_id:8307, trim_id:480549];"
     },
-    "coverImageAttractiveness": 0.24065242732211511,
+    "coverImageAttractiveness": 0.20067622773107185,
     "vehicleDetails": [
       {
-        "data": "316,755 km",
-        "iconName": "mileage_road",
+        "data": "113,218 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -9124,23 +10017,22 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "09/2006",
+        "data": "08/2011",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
       {
-        "data": "Diesel",
+        "data": "Gasoline",
         "iconName": "gas_pump",
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "51 kW (69 hp)",
+        "data": "86 kW (117 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",
@@ -9161,95 +10053,103 @@
     ]
   },
   {
-    "id": "78bae634-4d97-4987-9af0-af91a0f836da",
+    "id": "d5e9ec67-df61-43f3-aede-610a01eb4a99",
     "identifier": {
       "legacyId": null,
-      "crossReferenceId": "321503823"
+      "crossReferenceId": "3211050"
     },
-    "crossReferenceId": "321503823",
+    "crossReferenceId": "3211050",
     "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_861624c7-d320-4b8f-b925-2a29e224b15b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_c27a5063-aabb-4c28-97a9-bbac99b1619e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_154d6b60-59c1-4d43-8ce6-3e0e9cd60150.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_e7be4733-6f37-4dee-93ef-4d49a337839d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_c5050c0e-4d3b-4288-9478-83da1c474fb2.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_5920de4b-3cac-4d01-b14c-3365b659c790.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_6d167ff5-ae85-4e49-b5a7-0e1b263ac0cc.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_3defb923-1545-400b-907c-0e1acad7bd13.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_9e9f576f-91bf-4872-bcec-8c43ed930b20.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_e305d215-3379-45ef-a2e8-76155ec96d1e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_bf50817e-7f13-4eca-80e0-9f0d10d72e58.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_60450cf2-5588-4326-9a78-4b2d557aa2d3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_fe44604d-c21d-443b-bee8-d1442a7be2e5.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_f9f90c11-c988-46ea-a95a-df97995cf80c.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_cfdceabd-e6a8-42c6-9734-549470d6791e.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_72686079-a49f-41a3-afae-4458f8171ae1.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_6e515e39-465e-47f4-b2d5-3c4bba589462.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_2138a05c-c767-4d83-a2ac-38711aa1f61d.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_3d59826a-ddf9-46c3-bada-cdd6c8978b6a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_bca4b366-4c4e-4baa-9854-049a20bcf6e6.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_dd477cfe-f554-4647-b245-b78358d17a56.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_dafbc6e5-dad7-48d2-9410-46377ef5e352.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_13cca826-f1c4-42cf-8580-5d6871755e4a.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_bf0de63d-581e-400e-92bf-0b15973167fe.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/78bae634-4d97-4987-9af0-af91a0f836da_b5da0f37-fb87-4225-ad62-b2d39436f999.jpg/250x188.webp"
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_6b7f48ff-17e6-45d5-ac81-8fe9dc50d98b.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_c6fb5ef9-9ff2-42a2-af52-f9c63517045e.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_783d660d-fcd4-4525-9f12-5429e8fdaa22.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_a639948d-0456-4205-b932-34e030911f5a.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_63941e59-bd55-4b58-af06-4d9bf595949f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_dc094ca9-1048-4db9-9b66-3c558505d983.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_9e52e4dc-f88d-40f9-bf39-666964ae44fa.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_2c63ba3a-a990-4977-ba75-d767d6960219.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_cad1cca2-ea4b-4e29-be1a-1dfbf4dbce72.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_f3ef19db-4561-4805-b0de-32bb3872697d.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_53b28f2a-9e51-4ef4-91f9-309a624a0ad7.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_263451ec-1f5b-43de-ab35-39679b8b15d1.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_b5d4df79-7b59-4ed4-b226-bcd5e28466ab.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_a90c5d8d-2dc3-4437-aac2-56bacb722aff.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_7af31ff1-f8eb-4301-b138-04bcb0422ed2.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_4e9b64fd-2a84-40ab-bc79-96313dea3934.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_7344de11-b717-4c90-af53-6f3212e44a5f.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_4443e2d5-700c-437e-a30f-3e7dc7814671.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_03c24cfa-17db-4f43-b573-61f1855e1256.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_0cf1c41d-74ee-450c-8845-8cff0c656add.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_c46a0995-ded0-4ea3-b37d-fe896ba71718.jpg/250x188.webp",
+      "https://prod.pictures.autoscout24.net/listing-images/d5e9ec67-df61-43f3-aede-610a01eb4a99_9c81913b-51f2-4fcf-98a3-da192b00141f.jpg/250x188.webp"
     ],
     "ocsImagesA": [],
+    "isOfferNew": true,
     "price": {
-      "priceFormatted": "€ 19,999"
+      "priceFormatted": "€ 1,250",
+      "isVatLabelLegallyRequired": false,
+      "priceRaw": 1250,
+      "isConditionalPrice": false
     },
     "availableNow": true,
+    "availability": {
+      "fromDate": null,
+      "inDays": null
+    },
     "superDeal": {
       "oldPriceFormatted": "",
       "isEligible": false
     },
-    "url": "/offers/ford-focus-2-0-st-rs-look-251-pk-apple-carplay-pdc-v-a-recard-gasoline-blue-78bae634-4d97-4987-9af0-af91a0f836da",
+    "url": "/offers/seat-ibiza-1-6-16v-sportsyle-uitv-3-deurs-airco-gasoline-black-cat_ma64mo2006-d5e9ec67-df61-43f3-aede-610a01eb4a99",
     "vehicle": {
       "articleType": "Car",
       "type": "Car",
-      "make": "Ford",
-      "model": "Focus",
-      "modelGroup": "Focus",
-      "variant": null,
-      "modelId": 15537,
-      "modelVersionInput": "2.0 ST RS Look 251 pk apple carplay pdc v/a Recard",
+      "make": "SEAT",
+      "model": "Ibiza",
+      "modelGroup": "Ibiza",
+      "variant": "Ibiza",
+      "motorTypeName": "1.6",
+      "modelId": 2006,
+      "modelVersionInput": "1.6-16v Sportsyle Uitv. 3-Deurs AIRCO",
+      "modelVersionCustom": null,
       "subtitle": null,
       "offerType": "U",
       "transmission": "Manual",
       "fuel": "Gasoline",
-      "mileageInKm": "41,546 km"
+      "mileageInKm": "286,660 km",
+      "engineDisplacementInCCM": "1,598 cc",
+      "isCurrentlyDamaged": false
     },
     "location": {
       "countryCode": "NL",
-      "zip": "8171 NT",
-      "city": "VAASSEN",
-      "street": "Spinfondsweg 21"
+      "zip": "7482 DB",
+      "city": "HAAKSBERGEN",
+      "street": "Tolstraat 8b"
     },
     "seller": {
-      "dealer": {},
-      "id": "16502511",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/16502511-original-c0052157-5f65-43bf-94cd-0c0a662bc74a/resize/100x50%3E/quality/90"
-        }
+      "dealer": {
+        "maxImages": 50,
+        "hasDealerInformationOnResultList": true,
+        "culture": "nl-NL"
       },
-      "companyName": "City Cars Vaassen",
-      "contactName": "R. Hendriks",
+      "id": "16338194",
+      "type": "Dealer",
+      "companyName": "Paul Wijlens Automobielen",
+      "contactName": "P. Wijlens",
       "links": {
-        "infoPage": "/lst?atype=C&cid=16502511",
-        "imprint": "https://www.autoscout24.com/dealerinfo/city-cars-vaassen/imprint"
+        "infoPage": "https://www.autoscout24.com/dealerinfo/paul-wijlens-automobielen?atype=C",
+        "imprint": "https://www.autoscout24.com/dealerinfo/paul-wijlens-automobielen/imprint"
       },
       "phones": [
         {
           "phoneType": "Office",
-          "formattedNumber": "+31 (0)578 - 561012",
-          "callTo": "+31578561012"
+          "formattedNumber": "+31 (0)53 - 5722615",
+          "callTo": "+31535722615"
         },
         {
           "phoneType": "Mobile",
-          "formattedNumber": "+31 (0)6 - 17835177",
-          "callTo": "+31617835177"
+          "formattedNumber": "+31 (0)6 - 54311322",
+          "callTo": "+31654311322"
         }
       ]
     },
@@ -9258,26 +10158,26 @@
     "isOcs": false,
     "specialConditions": [],
     "statistics": {
-      "leadsRange": "Some"
+      "leadsRange": "Zero"
     },
     "searchResultType": "Organic",
     "searchResultSection": "Main",
     "tracking": {
-      "firstRegistration": "01-2018",
+      "firstRegistration": "03-2007",
       "fuelType": "b",
-      "imageContent": "no-placeholder|0.20506500559167473",
+      "imageContent": "no-placeholder|0.17227490759090192",
       "isSmyleEligible": "false",
-      "mileage": "41546",
-      "priceLabel": "top-price",
-      "price": "19999",
+      "mileage": "286660",
+      "priceLabel": "fair-price",
+      "price": "1250",
       "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:29, model_group_id:15537, variant_id:, generation_id:273, motortype_id:637, trim_id:];"
+      "modelTaxonomy": "[make_id:64, model_group_id:2006, variant_id:3199, generation_id:1192, motortype_id:4138, trim_id:7197];"
     },
-    "coverImageAttractiveness": 0.20506500559167473,
+    "coverImageAttractiveness": 0.17227490759090192,
     "vehicleDetails": [
       {
-        "data": "41,546 km",
-        "iconName": "mileage_road",
+        "data": "286,660 km",
+        "iconName": "mileage_odometer",
         "ariaLabel": "Mileage"
       },
       {
@@ -9286,7 +10186,7 @@
         "ariaLabel": "Gear"
       },
       {
-        "data": "01/2018",
+        "data": "03/2007",
         "iconName": "calendar",
         "ariaLabel": "First registration"
       },
@@ -9296,168 +10196,12 @@
         "ariaLabel": "Fuel type"
       },
       {
-        "data": "185 kW (252 hp)",
-        "iconName": "speedometer",
-        "ariaLabel": "Power"
-      }
-    ],
-    "wltpValues": [
-      "- (l/100 km)",
-      "0 g/km (comb.)"
-    ],
-    "isListingBoost": false,
-    "trackingParameters": [
-      {
-        "key": "boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "applied_boost_level",
-        "value": "t50"
-      },
-      {
-        "key": "relevance_adjustment",
-        "value": "boost"
-      },
-      {
-        "key": "boosting_product",
-        "value": "mia"
-      }
-    ]
-  },
-  {
-    "id": "2395144e-220c-4602-8683-cd83e7c7f62f",
-    "identifier": {
-      "legacyId": null,
-      "crossReferenceId": null
-    },
-    "images": [
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_fe576aa8-33d6-4f51-ad27-87af4eca2c26.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_ef6e8e5c-6005-43f8-be1c-92a99bf752ac.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_ca7441bf-e345-4c18-910d-a6ee61669a54.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_52496552-61fa-4d04-a2eb-c5c499f2d12b.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_51fa36de-0970-49c2-b522-36c40bb72613.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_fbee5607-5113-47bb-8e5c-b9d66703bff3.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_05d8d9de-9dc5-4901-b79c-dcb019a70ce8.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_29877464-d94c-45b9-a255-76fad40b8b57.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_b75d0cd1-b5ba-4613-ac96-10f62b9fe272.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_af69c953-8ecb-4fd9-9e5f-3df9d185cdef.jpg/250x188.webp",
-      "https://prod.pictures.autoscout24.net/listing-images/2395144e-220c-4602-8683-cd83e7c7f62f_0fbf6321-5e84-4fcd-9412-a1ce9f62a766.jpg/250x188.webp"
-    ],
-    "ocsImagesA": [],
-    "price": {
-      "priceFormatted": "€ 990"
-    },
-    "availableNow": true,
-    "superDeal": {
-      "oldPriceFormatted": "",
-      "isEligible": false
-    },
-    "url": "/offers/volkswagen-golf-trendline-gasoline-blue-2395144e-220c-4602-8683-cd83e7c7f62f",
-    "vehicle": {
-      "articleType": "Car",
-      "type": "Car",
-      "make": "Volkswagen",
-      "model": "Golf",
-      "modelGroup": "Golf",
-      "variant": null,
-      "modelId": 2084,
-      "modelVersionInput": "Trendline",
-      "subtitle": null,
-      "offerType": "U",
-      "transmission": "Manual",
-      "fuel": "Gasoline",
-      "mileageInKm": "241,500 km"
-    },
-    "location": {
-      "countryCode": "DE",
-      "zip": "85521",
-      "city": "Riemerling",
-      "street": "Rosenheimer Landstraße 133"
-    },
-    "seller": {
-      "dealer": {},
-      "id": "18032948",
-      "type": "Dealer",
-      "logo": {
-        "small": {
-          "href": "https://prod.pictures.autoscout24.net/dealer-info/18032948-original-cbad53ed-aae4-43ee-9356-c27d901472e0.jpeg/resize/100x50%3E/quality/90"
-        }
-      },
-      "companyName": "Auto Peter",
-      "contactName": "Ihr Verkaufsteam",
-      "links": {
-        "infoPage": "/lst?atype=C&cid=18032948",
-        "imprint": "https://www.autoscout24.com/dealerinfo/auto-peter-riemerling/imprint"
-      },
-      "phones": [
-        {
-          "phoneType": "Office",
-          "formattedNumber": "+49 (0)89 - 99248513",
-          "callTo": "+498999248513"
-        },
-        {
-          "phoneType": "Mobile",
-          "formattedNumber": "+49 (0)1556 - 0012282",
-          "callTo": "+4915560012282"
-        },
-        {
-          "phoneType": "Whatsapp",
-          "formattedNumber": "+49 (0)1556 - 0012282",
-          "callTo": null
-        }
-      ]
-    },
-    "appliedAdTier": "T50",
-    "adTier": "T50",
-    "isOcs": false,
-    "specialConditions": [],
-    "statistics": {
-      "leadsRange": "Some"
-    },
-    "searchResultType": "Organic",
-    "searchResultSection": "Main",
-    "tracking": {
-      "firstRegistration": "08-2005",
-      "fuelType": "b",
-      "imageContent": "no-placeholder|0.18006061996320444",
-      "isSmyleEligible": "false",
-      "mileage": "241500",
-      "priceLabel": "top-price",
-      "price": "990",
-      "orderBucket": "unknown",
-      "modelTaxonomy": "[make_id:74, model_group_id:100101, variant_id:, generation_id:4, motortype_id:425, trim_id:];"
-    },
-    "coverImageAttractiveness": 0.18006061996320444,
-    "vehicleDetails": [
-      {
-        "data": "241,500 km",
-        "iconName": "mileage_road",
-        "ariaLabel": "Mileage"
-      },
-      {
-        "data": "Manual",
-        "iconName": "gearbox",
-        "ariaLabel": "Gear"
-      },
-      {
-        "data": "08/2005",
-        "iconName": "calendar",
-        "ariaLabel": "First registration"
-      },
-      {
-        "data": "Gasoline",
-        "iconName": "gas_pump",
-        "ariaLabel": "Fuel type"
-      },
-      {
-        "data": "75 kW (102 hp)",
+        "data": "77 kW (105 hp)",
         "iconName": "speedometer",
         "ariaLabel": "Power"
       }
     ],
     "wltpValues": [],
-    "isListingBoost": false,
     "trackingParameters": [
       {
         "key": "boost_level",

--- a/autoscout24-scraper/run.py
+++ b/autoscout24-scraper/run.py
@@ -25,12 +25,12 @@ async def run():
     listings = await autoscout24.scrape_listings(url, max_pages=3)
     output.joinpath("listings.json").write_text(json.dumps(listings, indent=2, ensure_ascii=False), encoding="utf-8")
     
-    # car detail pages
+    # car detail pages, taken from the listings above because offers expire
     urls = [
-        "https://www.autoscout24.com/offers/bmw-116-116d-euro-6-diesel-white-7bc1efe2-6741-46d9-9af1-9c1e525bdd86",
-        "https://www.autoscout24.com/offers/fiat-500-1-0-hybrid-dolcevita-electric-gasoline-white-2fc80bb0-03e3-4d12-bee0-08b5c4dc4bbc",
-        "https://www.autoscout24.com/offers/fiat-500-lim-dolcevita-1-0-pdch-dab-klima-uvm-electric-gasoline-white-117b7cf9-f7e8-449c-bfdd-cfd449484f99"
-    ]
+        "https://www.autoscout24.com" + listing["url"]
+        for listing in listings
+        if listing.get("url")
+    ][:3]
     
     car_details = await autoscout24.scrape_car_details(urls)
     output.joinpath("car_details.json").write_text(json.dumps(car_details, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/autoscout24-scraper/test.py
+++ b/autoscout24-scraper/test.py
@@ -1,3 +1,5 @@
+import os
+
 from cerberus import Validator as _Validator
 import autoscout24
 import pytest
@@ -5,8 +7,8 @@ import pprint
 
 pp = pprint.PrettyPrinter(indent=4)
 
-# enable scrapfly cache
-autoscout24.BASE_CONFIG["cache"] = False
+# enable cache?
+autoscout24.BASE_CONFIG["cache"] = os.getenv("SCRAPFLY_CACHE") == "true"
 
 
 class Validator(_Validator):
@@ -16,7 +18,6 @@ class Validator(_Validator):
 
 def validate_or_fail(item, validator):
     if not validator.validate(item):
-        pp.pformat(item)
         pytest.fail(f"Validation failed for item: {pp.pformat(item)}\nErrors: {validator.errors}")
 
 
@@ -29,8 +30,9 @@ def require_min_presence(items, key, min_perc=0.1):
         )
 
 listing_schema = {
-    "price": {"type": "dict", "schema": {"priceFormatted": {"type": "string"}}},
-    "url": {"type": "string"},
+    # without required the schema also validates an empty dict, so a page of junk passes
+    "price": {"type": "dict", "required": True, "schema": {"priceFormatted": {"type": "string"}}},
+    "url": {"type": "string", "required": True},
     "location": {
         "type": "dict",
         "schema": {
@@ -62,17 +64,39 @@ listing_schema = {
     "vehicleDetails": {"type": "list", "min_presence": 0.1},
 }
 car_details_schema = {
-    "price": {"type": "dict", "schema": {"priceFormatted": {"type": "string"}}},
+    "price": {"type": "dict", "required": True, "schema": {"priceFormatted": {"type": "string"}}},
     "vehicle": {"type": "dict", "min_presence": 0.1},
     "seller": {"type": "dict", "min_presence": 0.1},
     "location": {"type": "dict", "min_presence": 0.1},
 }
 
+def test_page_url():
+    base = "https://www.autoscout24.com/lst/c/compact"
+    assert autoscout24.change_page(base, 2) == base + "?page=2"
+    # a page number already in the url is replaced instead of appended a second time
+    assert autoscout24.change_page(base + "?page=2", 3) == base + "?page=3"
+    # existing filters survive
+    assert autoscout24.change_page(base + "?desc=0", 4) == base + "?desc=0&page=4"
+    # a multi select filter repeats its key, and collapsing it would change the result set
+    assert autoscout24.change_page(base + "?eq=1&eq=15&atype=C", 2) == base + "?eq=1&eq=15&atype=C&page=2"
+    # AutoScout24 emits blank filters of its own, so they are kept as sent
+    assert autoscout24.change_page(base + "?fregfrom=&desc=0", 2) == base + "?fregfrom=&desc=0&page=2"
+
+
 @pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 async def test_listings_scraping():
     url = "https://www.autoscout24.com/lst/c/compact"
+    first_page = await autoscout24.scrape_listings(url, max_pages=1)
+    assert first_page, "the first listings page returned no listings"
     results = await autoscout24.scrape_listings(url, max_pages=3)
-    assert len(results) >= 30
+    # a failed page 2 or 3 used to be swallowed and left one page of results behind, so the
+    # expectation is relative to what one page actually holds instead of a fixed count that
+    # duplicates across pages could satisfy on their own. the comparison is strict because two
+    # healthy pages minus their overlap lands exactly on 2x page one when the third page dies
+    assert len(results) > 2 * len(first_page)
+    urls = [item["url"] for item in results if item.get("url")]
+    assert len(set(urls)) == len(urls), "the same listing was returned by more than one page"
     validator = Validator(listing_schema, allow_unknown=True)
     for result in results:
         validate_or_fail(result, validator)
@@ -82,6 +106,7 @@ async def test_listings_scraping():
 
 
 @pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
 async def test_car_details_scraping():
     listings = await autoscout24.scrape_listings(
         "https://www.autoscout24.com/lst/c/compact", max_pages=1
@@ -94,6 +119,8 @@ async def test_car_details_scraping():
     assert urls, "scrape_listings returned no usable URLs to feed into scrape_car_details"
     results = await autoscout24.scrape_car_details(urls)
     assert len(results) >= 1
+    # an unparsed page used to be appended as None, which cerberus reports as a DocumentError
+    assert all(isinstance(result, dict) for result in results)
     validator = Validator(car_details_schema, allow_unknown=True)
     for result in results:
         validate_or_fail(result, validator)


### PR DESCRIPTION
Closes #182

`concurrent_scrape` yields errors instead of raising them, so a failed page used to land in the results as a page of zero listings. Guarding it positively is the core of this PR.

**What changed in `autoscout24.py`:**

1. Guard on the success type - `isinstance(response, ScrapeApiResponse)` - not on an error class. The error classes are siblings, and an `asp: True` target most likely yields `ScrapflyAspError`, which a `ScrapflyScrapeError` check misses and then crashes on `.selector`. Same idiom as `zoominfo.py:74`.
2. New `change_page()` replaces the string concat. It keeps repeated query keys, which AutoScout24 uses for multi-select filters (`eq=1&eq=15`) - `dict(parse_qsl(...))` would drop all but the last one.
3. Page cap is `min(max_pages, numberOfPages)`. Listings are deduped by url. An empty payload logs a warning instead of passing as zero results.
4. One sequential retry per page that came back empty. Under concurrency AutoScout24 intermittently bounces a page to the homepage; the same page fetched sequentially succeeds every time.
5. `render_js` dropped. Identical `__NEXT_DATA__` payload, 1 credit instead of 6.

**Tests:** offline `test_page_url`, flaky markers on both live tests plus `pytest-rerunfailures` in the dev group (the marker was a silent no-op without it), `required: True` on `price` and `url`, and `>= 30` replaced by `> 2 * len(first_page)` with a unique-url assertion. The old count passed on 20 real listings plus 10 duplicates.

`run.py` takes detail urls from the listings it just scraped instead of three expired offers.

The workflow gets the new offline test folded into an existing runner rather than a new one, and `-k` is now quoted so a multi-name expression survives the shell.

**Live validation:** suite `3 passed in 49.26s`. `run.py` -> 57 listings, 57 unique urls, 3/3 car details. The homepage bounce hit page 3 and one offer page during separate runs and the retry recovered both.